### PR TITLE
Specify Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
-
-# Ruby 2.4.2
+ruby "2.4.2"
 
 gem "rails", "4.2.10"
 # Use MongoDB as the database


### PR DESCRIPTION
We weren't specifying the Ruby version in the Gemfile. This led to a bug on Heroku as it was using a different version.