### PR TITLE
Renewal start page and user permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "sdoc", "~> 0.4.0", group: :doc
 # Use AASM to manage states and transitions
 gem "aasm", "~> 4.12"
 
+# Use CanCanCan for user roles and permissions
+gem "cancancan", "~> 2.0"
+
 # Use Devise for user authentication
 gem "devise", "~> 4.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ gem "sdoc", "~> 0.4.0", group: :doc
 gem "aasm", "~> 4.12"
 
 # Use CanCanCan for user roles and permissions
-gem "cancancan", "~> 2.0"
+# Version 2.0 doesn't support Mongoid, so we're locked to an earlier one
+gem "cancancan", "~> 1.10"
 
 # Use Devise for user authentication
 gem "devise", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     bson (4.2.2)
     builder (3.2.3)
     byebug (9.1.0)
-    cancancan (2.1.2)
+    cancancan (1.17.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -226,7 +226,7 @@ PLATFORMS
 DEPENDENCIES
   aasm (~> 4.12)
   byebug
-  cancancan (~> 2.0)
+  cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise (~> 4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     bson (4.2.2)
     builder (3.2.3)
     byebug (9.1.0)
+    cancancan (2.1.2)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -225,6 +226,7 @@ PLATFORMS
 DEPENDENCIES
   aasm (~> 4.12)
   byebug
+  cancancan (~> 2.0)
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise (~> 4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.4.2p198
 
 BUNDLED WITH
    1.16.0.pre.3

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://travis-ci.org/DEFRA/waste-carriers-renewals.svg?branch=master)](https://travis-ci.org/DEFRA/waste-carriers-renewals) [![Maintainability](https://api.codeclimate.com/v1/badges/414c0f88f3f030452da8/maintainability)](https://codeclimate.com/github/DEFRA/waste-carriers-renewals/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/414c0f88f3f030452da8/test_coverage)](https://codeclimate.com/github/DEFRA/waste-carriers-renewals/test_coverage) [![security](https://hakiri.io/github/DEFRA/waste-carriers-renewals/master.svg)](https://hakiri.io/github/DEFRA/waste-carriers-renewals/master) [![Dependency Status](https://dependencyci.com/github/DEFRA/waste-carriers-renewals/badge)](https://dependencyci.com/github/DEFRA/waste-carriers-renewals)
 
-The Waste Carrier Registrations Service allows businesses, who deal with waste and thus have to register according to the regulations, to register online. Once registered, businesses can sign in again to edit their registrations if needed.
+The 'Register as a waste carrier' service allows businesses, who deal with waste and have to register according to the regulations, to register online. Once registered, businesses can sign in again to edit their registrations if needed.
 
-The service also allows authorised agency users and NCCC contact centre staff to create and manage registrations on other users behalf, e.g. to support 'Assisted Digital' registrations. The service provides an internal user account management facility which allows authorised administrators to create and manage other agency user accounts.
+The service also allows authorised agency users and NCCC staff to create and manage registrations on other users' behalf, e.g. to support 'Assisted Digital' registrations. The service provides an internal user account management facility which allows authorised administrators to create and manage other agency user accounts.
 
-The renewals application allows users who registered using the Waste Carrier Registrations Service to renew their registrations.
+The waste-carriers-renewals application allows users who registered using the 'Register as a waste carrier' service to renew their registrations.
 
 ## Prerequisites
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -30,6 +30,16 @@ class FormsController < ApplicationController
   def set_up_form(form_class, form, reg_identifier)
     set_transient_registration(reg_identifier)
 
+    unless @transient_registration.valid?
+      redirect_to page_path("errors/invalid")
+      return false
+    end
+
+    unless user_has_permission?
+      redirect_to page_path("errors/permission")
+      return false
+    end
+
     unless form_matches_state?
       redirect_to_correct_form
       return false
@@ -40,6 +50,10 @@ class FormsController < ApplicationController
   end
 
   private
+
+  def user_has_permission?
+    can? :update, @transient_registration
+  end
 
   def set_transient_registration(reg_identifier)
     @transient_registration = TransientRegistration.where(reg_identifier: reg_identifier).first ||

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -23,7 +23,7 @@ class FormsController < ApplicationController
     redirect_to_correct_form
   end
 
-  protected
+  private
 
   # Expects a form class name (eg BusinessTypeForm), a snake_case name for the form (eg business_type_form),
   # and the reg_identifier param
@@ -48,8 +48,6 @@ class FormsController < ApplicationController
     # Set an instance variable for the form (eg. @business_type_form) using the provided class (eg. BusinessTypeForm)
     instance_variable_set("@#{form}", form_class.new(@transient_registration))
   end
-
-  private
 
   def user_has_permission?
     can? :update, @transient_registration

--- a/app/controllers/renewal_start_forms_controller.rb
+++ b/app/controllers/renewal_start_forms_controller.rb
@@ -1,9 +1,6 @@
 class RenewalStartFormsController < FormsController
-
-  # Unlike other forms, we don't use 'super' for this action because we need to run different validations
   def new
-    return unless set_up_form(RenewalStartForm, "renewal_start_form", params[:reg_identifier])
-    @renewal_start_form.validate
+    super(RenewalStartForm, "renewal_start_form")
   end
 
   def create

--- a/app/forms/renewal_start_form.rb
+++ b/app/forms/renewal_start_form.rb
@@ -1,4 +1,6 @@
 class RenewalStartForm < BaseForm
+  include CanCalculateRenewalDates
+
   attr_accessor :reg_identifier
 
   def initialize(transient_registration)
@@ -26,6 +28,6 @@ class RenewalStartForm < BaseForm
   end
 
   def projected_renewal_end_date
-    @transient_registration.renewal_attributes["expires_on"].to_date + 3.years
+    expiry_date_after_renewal(@transient_registration.renewal_attributes["expires_on"].to_date)
   end
 end

--- a/app/forms/renewal_start_form.rb
+++ b/app/forms/renewal_start_form.rb
@@ -13,13 +13,9 @@ class RenewalStartForm < BaseForm
     # Define the params which are allowed
     self.reg_identifier = params[:reg_identifier]
 
-    @transient_registration.reg_identifier = reg_identifier
-
     # Update the transient registration with params from the registration if valid
     if valid?
-      attributes = @transient_registration.renewal_attributes
-      @transient_registration.assign_attributes(attributes)
-
+      @transient_registration.reg_identifier = reg_identifier
       @transient_registration.save!
       true
     else
@@ -28,6 +24,6 @@ class RenewalStartForm < BaseForm
   end
 
   def projected_renewal_end_date
-    expiry_date_after_renewal(@transient_registration.renewal_attributes["expires_on"].to_date)
+    expiry_date_after_renewal(@transient_registration.expires_on.to_date)
   end
 end

--- a/app/forms/renewal_start_form.rb
+++ b/app/forms/renewal_start_form.rb
@@ -24,4 +24,8 @@ class RenewalStartForm < BaseForm
       false
     end
   end
+
+  def projected_renewal_end_date
+    @transient_registration.renewal_attributes["expires_on"].to_date + 3.years
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,32 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,31 +2,6 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the passed in user here. For example:
-    #
-    #   user ||= User.new # guest user (not logged in)
-    #   if user.admin?
-    #     can :manage, :all
-    #   else
-    #     can :read, :all
-    #   end
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    can :manage, TransientRegistration, account_email: user.email
   end
 end

--- a/app/models/concerns/can_calculate_renewal_dates.rb
+++ b/app/models/concerns/can_calculate_renewal_dates.rb
@@ -1,0 +1,7 @@
+module CanCalculateRenewalDates
+  extend ActiveSupport::Concern
+
+  def expiry_date_after_renewal(current_expiry_date)
+    current_expiry_date + 3.years
+  end
+end

--- a/app/models/concerns/can_change_registration_status.rb
+++ b/app/models/concerns/can_change_registration_status.rb
@@ -1,6 +1,7 @@
 module CanChangeRegistrationStatus
   extend ActiveSupport::Concern
   include Mongoid::Document
+  include CanCalculateRenewalDates
 
   included do
     include AASM
@@ -61,7 +62,7 @@ module CanChangeRegistrationStatus
     end
 
     def extend_expiry_date
-      new_expiry_date = registration.expires_on + 3.years
+      new_expiry_date = expiry_date_after_renewal(registration.expires_on)
       registration.set(expires_on: new_expiry_date)
     end
 

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -6,13 +6,19 @@ class TransientRegistration
   validates_with RegIdentifierValidator
   validate :no_renewal_in_progress?, on: :create
 
-  def renewal_attributes
-    registration = Registration.where(reg_identifier: reg_identifier).first
-    # Don't return object IDs as Mongo should generate new unique ones
-    registration.attributes.except("_id")
-  end
+  after_initialize :copy_data_from_registration
 
   private
+
+  def copy_data_from_registration
+    # Don't try to get Registration data with an invalid reg_identifier
+    return unless valid?
+
+    registration = Registration.where(reg_identifier: reg_identifier).first
+
+    # Don't copy object IDs as Mongo should generate new unique ones
+    assign_attributes(registration.attributes.except("_id"))
+  end
 
   # Check if a transient renewal already exists for this registration so we don't have
   # multiple renewals in progress at once

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -6,7 +6,7 @@ class TransientRegistration
   validates_with RegIdentifierValidator
   validate :no_renewal_in_progress?, on: :create
 
-  after_initialize :copy_data_from_registration
+  after_initialize :copy_data_from_registration, on: :create
 
   private
 

--- a/app/views/pages/errors/invalid.html.erb
+++ b/app/views/pages/errors/invalid.html.erb
@@ -1,0 +1,4 @@
+<div class="text">
+  <h1 class="heading-large"><%= I18n.t(".invalid_reg_identifier_heading") %></h1>
+  <p><%= I18n.t(".invalid_reg_identifier_text") %></p>
+</div>

--- a/app/views/pages/errors/permission.html.erb
+++ b/app/views/pages/errors/permission.html.erb
@@ -1,0 +1,4 @@
+<div class="text">
+  <h1 class="heading-large"><%= I18n.t(".no_permissions_heading") %></h1>
+  <p><%= I18n.t(".no_permissions_text") %></p>
+</div>

--- a/app/views/renewal_start_forms/new.html.erb
+++ b/app/views/renewal_start_forms/new.html.erb
@@ -1,3 +1,4 @@
+<div class="text">
 <% if @renewal_start_form.errors.any? %>
 
   <h1 class="heading-large"><%= t(".error_heading") %></h1>
@@ -11,7 +12,11 @@
   <%= form_for(@renewal_start_form) do |f| %>
     <%= render("shared/errors", object: @renewal_start_form) %>
 
-    <h1 class="heading-large"><%= t(".confirmation_text", reg_identifier: @renewal_start_form.reg_identifier) %></h1>
+    <h1 class="heading-large"><%= t(".heading", reg_identifier: @renewal_start_form.reg_identifier) %></h1>
+
+    <p><%= t(".paragraph_1", date: "TODO", renewal_charge: "TODO", type_change_charge: "TODO") %></p>
+    <p><%= t(".paragraph_2") %></p>
+    <p><%= t(".paragraph_3") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_start_form.reg_identifier %>
     <div class="form-group">
@@ -20,3 +25,4 @@
   <% end %>
 
 <% end %>
+</div>

--- a/app/views/renewal_start_forms/new.html.erb
+++ b/app/views/renewal_start_forms/new.html.erb
@@ -14,7 +14,7 @@
 
     <h1 class="heading-large"><%= t(".heading", reg_identifier: @renewal_start_form.reg_identifier) %></h1>
 
-    <p><%= t(".paragraph_1", date: "TODO", renewal_charge: "TODO", type_change_charge: "TODO") %></p>
+    <p><%= t(".paragraph_1", date: @renewal_start_form.projected_renewal_end_date, renewal_charge: Rails.configuration.renewal_charge, type_change_charge: Rails.configuration.type_change_charge) %></p>
     <p><%= t(".paragraph_2") %></p>
     <p><%= t(".paragraph_3") %></p>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module WasteCarriersRenewals
       application.css
       print.css
     )
+
+    # Fees
+    config.renewal_charge = 105
+    config.type_change_charge = 40
   end
 end

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,1 @@
+Date::DATE_FORMATS[:default] = '%e %B %Y'

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,0 +1,3 @@
+HighVoltage.configure do |config|
+  config.route_drawer = HighVoltage::RouteDrawers::Root
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,3 +14,10 @@ en:
   shared:
     footer:
       support_text: 'Environment Agency (England) helpline: 03708 506506'
+
+  # Custom error pages
+  invalid_reg_identifier_heading: The registration number you entered is not valid
+  invalid_reg_identifier_text: Maybe you should try searching again.
+
+  no_permissions_heading: You don't have permission to access that registration
+  no_permissions_text: Maybe you should try searching again.

--- a/config/locales/forms/renewal_start_forms/en.yml
+++ b/config/locales/forms/renewal_start_forms/en.yml
@@ -1,9 +1,12 @@
 en:
   renewal_start_forms:
     new:
-      confirmation_text: You are about to renew %{reg_identifier}.
+      heading: You are about to renew %{reg_identifier}
+      paragraph_1: Renewing this registration will extend its expiry date to %{date}. There is a charge of £%{renewal_charge} to do this, plus a £%{type_change_charge} charge if you change the registration type.
+      paragraph_2: If your business type has changed, for example from sole trader to limited company, you cannot renew and instead must create a new registration.
+      paragraph_3: We’ll also check the type of activities you are doing to confirm you still require an upper tier registration. If you don’t you cannot renew and again must create a new lower tier registration.
       error_heading: You cannot renew this registration
-      next_button: Begin renewal
+      next_button: Continue
   activemodel:
     errors:
       models:

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -7,7 +7,11 @@ FactoryBot.define do
       addresses { [build(:address)] }
     end
 
-    trait :has_expires_on do
+    trait :expires_soon do
+      expires_on 2.months.from_now
+    end
+
+    trait :expires_later do
       expires_on 2.years.from_now
     end
 

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     trait :has_required_data do
       # Create a registration and use the reg_identifier so validations pass
       after(:build) do |transient_registration|
-        registration = create(:registration, :has_required_data)
+        registration = create(:registration, :has_required_data, :expires_soon)
         transient_registration.reg_identifier = registration.reg_identifier
       end
     end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -1,11 +1,7 @@
 FactoryBot.define do
   factory :transient_registration do
     trait :has_required_data do
-      # Create a registration and use the reg_identifier so validations pass
-      after(:build) do |transient_registration|
-        registration = create(:registration, :has_required_data, :expires_soon)
-        transient_registration.reg_identifier = registration.reg_identifier
-      end
+      reg_identifier { create(:registration, :has_required_data, :expires_soon).reg_identifier }
     end
   end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Registration, type: :model do
       end
 
       context "when a registration is active" do
-        let(:registration) { build(:registration, :has_expires_on, :is_active) }
+        let(:registration) { build(:registration, :expires_later, :is_active) }
 
         it "has 'active' status" do
           expect(registration.metaData).to have_state(:active)

--- a/spec/requests/business_type_forms_spec.rb
+++ b/spec/requests/business_type_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "BusinessTypeForms", type: :request do
   describe "GET new_business_type_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "business_type_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "BusinessTypeForms", type: :request do
   end
 
   describe "POST business_type_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "business_type_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "BusinessTypeForms", type: :request do
   end
 
   describe "GET back_business_type_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "business_type_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "smart_answers_form")
         end
 

--- a/spec/requests/cbd_type_forms_spec.rb
+++ b/spec/requests/cbd_type_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "CbdTypeForms", type: :request do
   describe "GET new_cbd_type_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "CbdTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "cbd_type_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "CbdTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "CbdTypeForms", type: :request do
   end
 
   describe "POST cbd_type_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "CbdTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "cbd_type_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "CbdTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "CbdTypeForms", type: :request do
   end
 
   describe "GET back_cbd_type_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "CbdTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "cbd_type_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "CbdTypeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/check_your_answers_forms_spec.rb
+++ b/spec/requests/check_your_answers_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "CheckYourAnswersForms", type: :request do
   describe "GET new_check_your_answers_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "check_your_answers_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
   end
 
   describe "POST check_your_answers_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "check_your_answers_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
   end
 
   describe "GET back_check_your_answers_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "check_your_answers_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "CheckYourAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/company_address_forms_spec.rb
+++ b/spec/requests/company_address_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "CompanyAddressForms", type: :request do
   describe "GET new_company_address_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "CompanyAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_address_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "CompanyAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "CompanyAddressForms", type: :request do
   end
 
   describe "POST company_address_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "CompanyAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_address_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "CompanyAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "CompanyAddressForms", type: :request do
   end
 
   describe "GET back_company_address_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "CompanyAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_address_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "CompanyAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/company_name_forms_spec.rb
+++ b/spec/requests/company_name_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "CompanyNameForms", type: :request do
   describe "GET new_company_name_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "CompanyNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_name_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "CompanyNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "CompanyNameForms", type: :request do
   end
 
   describe "POST company_name_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "CompanyNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_name_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "CompanyNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "CompanyNameForms", type: :request do
   end
 
   describe "GET back_company_name_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "CompanyNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_name_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "CompanyNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/company_postcode_forms_spec.rb
+++ b/spec/requests/company_postcode_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "CompanyPostcodeForms", type: :request do
   describe "GET new_company_postcode_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_postcode_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
   end
 
   describe "POST company_postcode_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_postcode_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
   end
 
   describe "GET back_company_postcode_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "company_postcode_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/contact_address_forms_spec.rb
+++ b/spec/requests/contact_address_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "ContactAddressForms", type: :request do
   describe "GET new_contact_address_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "ContactAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_address_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "ContactAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "ContactAddressForms", type: :request do
   end
 
   describe "POST contact_address_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "ContactAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_address_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "ContactAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "ContactAddressForms", type: :request do
   end
 
   describe "GET back_contact_address_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "ContactAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_address_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "ContactAddressForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/contact_email_forms_spec.rb
+++ b/spec/requests/contact_email_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "ContactEmailForms", type: :request do
   describe "GET new_contact_email_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_email_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "ContactEmailForms", type: :request do
   end
 
   describe "POST contact_email_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_email_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "ContactEmailForms", type: :request do
   end
 
   describe "GET back_contact_email_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_email_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/contact_name_forms_spec.rb
+++ b/spec/requests/contact_name_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "ContactNameForms", type: :request do
   describe "GET new_contact_name_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "ContactNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_name_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "ContactNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "ContactNameForms", type: :request do
   end
 
   describe "POST contact_name_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "ContactNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_name_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "ContactNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "ContactNameForms", type: :request do
   end
 
   describe "GET back_contact_name_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "ContactNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_name_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "ContactNameForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/contact_phone_forms_spec.rb
+++ b/spec/requests/contact_phone_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "ContactPhoneForms", type: :request do
   describe "GET new_contact_phone_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "ContactPhoneForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_phone_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "ContactPhoneForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "ContactPhoneForms", type: :request do
   end
 
   describe "POST contact_phone_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "ContactPhoneForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_phone_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "ContactPhoneForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "ContactPhoneForms", type: :request do
   end
 
   describe "GET back_contact_phone_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "ContactPhoneForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "contact_phone_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "ContactPhoneForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/conviction_details_forms_spec.rb
+++ b/spec/requests/conviction_details_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "ConvictionDetailsForms", type: :request do
   describe "GET new_conviction_details_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "conviction_details_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
   end
 
   describe "POST conviction_details_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "conviction_details_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
   end
 
   describe "GET back_conviction_details_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "conviction_details_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/declaration_forms_spec.rb
+++ b/spec/requests/declaration_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "DeclarationForms", type: :request do
   describe "GET new_declaration_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "DeclarationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "declaration_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "DeclarationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "DeclarationForms", type: :request do
   end
 
   describe "POST declaration_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "DeclarationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "declaration_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "DeclarationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "DeclarationForms", type: :request do
   end
 
   describe "GET back_declaration_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "DeclarationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "declaration_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "DeclarationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/declare_convictions_forms_spec.rb
+++ b/spec/requests/declare_convictions_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "DeclareConvictionsForms", type: :request do
   describe "GET new_declare_convictions_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "declare_convictions_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
   end
 
   describe "POST declare_convictions_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "declare_convictions_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
   end
 
   describe "GET back_declare_convictions_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "declare_convictions_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "DeclareConvictionsForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/key_people_director_forms_spec.rb
+++ b/spec/requests/key_people_director_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "KeyPeopleDirectorForms", type: :request do
   describe "GET new_key_people_director_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "key_people_director_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
   end
 
   describe "POST key_people_director_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "key_people_director_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
   end
 
   describe "GET back_key_people_director_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "key_people_director_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "KeyPeopleDirectorForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/payment_summary_forms_spec.rb
+++ b/spec/requests/payment_summary_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "PaymentSummaryForms", type: :request do
   describe "GET new_payment_summary_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "PaymentSummaryForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "payment_summary_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "PaymentSummaryForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "PaymentSummaryForms", type: :request do
   end
 
   describe "POST payment_summary_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "PaymentSummaryForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "payment_summary_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "PaymentSummaryForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "PaymentSummaryForms", type: :request do
   end
 
   describe "GET back_payment_summary_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "PaymentSummaryForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "payment_summary_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "PaymentSummaryForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/registration_number_forms_spec.rb
+++ b/spec/requests/registration_number_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "RegistrationNumberForms", type: :request do
   describe "GET new_registration_number_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "RegistrationNumberForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "registration_number_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "RegistrationNumberForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "RegistrationNumberForms", type: :request do
   end
 
   describe "POST registration_number_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "RegistrationNumberForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "registration_number_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "RegistrationNumberForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "RegistrationNumberForms", type: :request do
   end
 
   describe "GET back_registration_number_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "RegistrationNumberForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "registration_number_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "RegistrationNumberForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/renewal_complete_forms_spec.rb
+++ b/spec/requests/renewal_complete_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "RenewalCompleteForms", type: :request do
   describe "GET new_renewal_complete_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "RenewalCompleteForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_complete_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "RenewalCompleteForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/renewal_information_forms_spec.rb
+++ b/spec/requests/renewal_information_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "RenewalInformationForms", type: :request do
   describe "GET new_renewal_information_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "RenewalInformationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_information_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "RenewalInformationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "RenewalInformationForms", type: :request do
   end
 
   describe "POST renewal_information_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "RenewalInformationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_information_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "RenewalInformationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "RenewalInformationForms", type: :request do
   end
 
   describe "GET back_renewal_information_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "RenewalInformationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_information_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "RenewalInformationForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "RenewalStartForms", type: :request do
 
       context "when no renewal is in progress" do
         context "when a matching registration exists" do
-          let(:registration) { create(:registration, :has_required_data) }
+          let(:registration) { create(:registration, :has_required_data, :expires_soon) }
 
           it "returns a success response" do
             get new_renewal_start_form_path(registration[:reg_identifier])

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe "RenewalStartForms", type: :request do
       end
 
       context "when no matching registration exists" do
-        it "shows an error message" do
+        it "redirects to the invalid reg_identifier error page" do
           get new_renewal_start_form_path("CBDU999999999")
-          expect(response.body).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.no_registration"))
+          expect(response).to redirect_to(page_path("errors/invalid"))
         end
       end
 
       context "when the reg_identifier doesn't match the format" do
-        it "shows an error message" do
-          get new_renewal_start_form_path("asdf")
-          expect(response.body).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+        it "redirects to the invalid reg_identifier error page" do
+          get new_renewal_start_form_path("foo")
+          expect(response).to redirect_to(page_path("errors/invalid"))
         end
       end
 
@@ -74,9 +74,9 @@ RSpec.describe "RenewalStartForms", type: :request do
                      account_email: "not-#{user.email}")
             end
 
-            it "prevents access" do
+            it "redirects to the permissions error page" do
               get new_renewal_start_form_path(registration[:reg_identifier])
-              skip("don't know what this should do yet")
+              expect(response).to redirect_to(page_path("errors/permission"))
             end
           end
 
@@ -88,9 +88,9 @@ RSpec.describe "RenewalStartForms", type: :request do
                      workflow_state: "renewal_start_form")
             end
 
-            it "prevents access" do
+            it "redirects to the permissions error page" do
               get new_renewal_start_form_path(transient_registration[:reg_identifier])
-              skip("don't know what this should do yet")
+              expect(response).to redirect_to(page_path("errors/permission"))
             end
           end
         end
@@ -126,9 +126,9 @@ RSpec.describe "RenewalStartForms", type: :request do
       context "when no matching registration exists" do
         let(:invalid_params) { { reg_identifier: "CBDU99999" } }
 
-        it "shows an error message" do
+        it "redirects to the invalid reg_identifier error page" do
           post renewal_start_forms_path, renewal_start_form: invalid_params
-          expect(response.body).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.no_registration"))
+          expect(response).to redirect_to(page_path("errors/invalid"))
         end
 
         it "does not create a new transient registration" do
@@ -143,9 +143,9 @@ RSpec.describe "RenewalStartForms", type: :request do
       context "when the reg_identifier doesn't match the format" do
         let(:invalid_params) { { reg_identifier: "foo" } }
 
-        it "shows an error message" do
+        it "redirects to the invalid reg_identifier error page" do
           post renewal_start_forms_path, renewal_start_form: invalid_params
-          expect(response.body).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+          expect(response).to redirect_to(page_path("errors/invalid"))
         end
 
         it "does not create a new transient registration" do
@@ -285,9 +285,9 @@ RSpec.describe "RenewalStartForms", type: :request do
           end
           let(:valid_params) { { reg_identifier: registration.reg_identifier } }
 
-          it "prevents access" do
+          it "redirects to the permissions error page" do
             post renewal_start_forms_path, renewal_start_form: valid_params
-            skip("don't know what this should do yet")
+            expect(response).to redirect_to(page_path("errors/permission"))
           end
         end
 
@@ -300,9 +300,9 @@ RSpec.describe "RenewalStartForms", type: :request do
           end
           let(:valid_params) { { reg_identifier: transient_registration.reg_identifier } }
 
-          it "prevents access" do
+          it "redirects to the permissions error page" do
             post renewal_start_forms_path, renewal_start_form: valid_params
-            skip("don't know what this should do yet")
+            expect(response).to redirect_to(page_path("errors/permission"))
           end
         end
       end

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -3,20 +3,10 @@ require "rails_helper"
 RSpec.describe "RenewalStartForms", type: :request do
   describe "GET new_renewal_start_form_path" do
     context "when a user is signed in" do
+      let(:user) { create(:user) }
+
       before(:each) do
-        user = create(:user)
         sign_in(user)
-      end
-
-      context "when no renewal is in progress" do
-        context "when a matching registration exists" do
-          let(:registration) { create(:registration, :has_required_data, :expires_soon) }
-
-          it "returns a success response" do
-            get new_renewal_start_form_path(registration[:reg_identifier])
-            expect(response).to have_http_status(200)
-          end
-        end
       end
 
       context "when no matching registration exists" do
@@ -33,30 +23,75 @@ RSpec.describe "RenewalStartForms", type: :request do
         end
       end
 
-      context "when a renewal is in progress" do
-        context "when a valid transient registration exists" do
-          let(:transient_registration) do
-            create(:transient_registration,
-                   :has_required_data,
-                   workflow_state: "renewal_start_form")
+      context "when a matching registration exists" do
+        context "when the signed-in user owns the registration" do
+          context "when no renewal is in progress" do
+            let(:registration) { create(:registration, :has_required_data, :expires_soon, account_email: user.email) }
+
+            it "returns a success response" do
+              get new_renewal_start_form_path(registration[:reg_identifier])
+              expect(response).to have_http_status(200)
+            end
           end
 
-          it "returns a success response" do
-            get new_renewal_start_form_path(transient_registration[:reg_identifier])
-            expect(response).to have_http_status(200)
+          context "when a renewal is in progress" do
+            context "when a valid transient registration exists" do
+              let(:transient_registration) do
+                create(:transient_registration,
+                       :has_required_data,
+                       account_email: user.email,
+                       workflow_state: "renewal_start_form")
+              end
+
+              it "returns a success response" do
+                get new_renewal_start_form_path(transient_registration[:reg_identifier])
+                expect(response).to have_http_status(200)
+              end
+            end
+
+            context "when the transient registration is in a different state" do
+              let(:transient_registration) do
+                create(:transient_registration,
+                       :has_required_data,
+                       account_email: user.email,
+                       workflow_state: "business_type_form")
+              end
+
+              it "redirects to the form for the current state" do
+                get new_renewal_start_form_path(transient_registration[:reg_identifier])
+                expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+              end
+            end
           end
         end
 
-        context "when the transient registration is in a different state" do
-          let(:transient_registration) do
-            create(:transient_registration,
-                   :has_required_data,
-                   workflow_state: "business_type_form")
+        context "when the signed-in user does not own the registration" do
+          context "when no renewal is in progress" do
+            let(:registration) do
+              create(:registration,
+                     :has_required_data,
+                     :expires_soon,
+                     account_email: "not-#{user.email}")
+            end
+
+            it "prevents access" do
+              get new_renewal_start_form_path(registration[:reg_identifier])
+              skip("don't know what this should do yet")
+            end
           end
 
-          it "redirects to the form for the current state" do
-            get new_renewal_start_form_path(transient_registration[:reg_identifier])
-            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          context "when a renewal is in progress" do
+            let(:transient_registration) do
+              create(:transient_registration,
+                     :has_required_data,
+                     account_email: "not-#{user.email}",
+                     workflow_state: "renewal_start_form")
+            end
+
+            it "prevents access" do
+              get new_renewal_start_form_path(transient_registration[:reg_identifier])
+              skip("don't know what this should do yet")
+            end
           end
         end
       end
@@ -82,56 +117,10 @@ RSpec.describe "RenewalStartForms", type: :request do
 
   describe "POST renewal_start_forms_path" do
     context "when a user is signed in" do
+      let(:user) { create(:user) }
+
       before(:each) do
-        user = create(:user)
         sign_in(user)
-      end
-
-      context "when no renewal is in progress" do
-        context "when a matching registration exists" do
-          let(:registration) { create(:registration, :has_required_data, company_name: "Correct Name") }
-
-          context "when valid params are submitted" do
-            let(:valid_params) { { reg_identifier: registration.reg_identifier } }
-
-            it "creates a new transient registration" do
-              expected_tr_count = TransientRegistration.count + 1
-              post renewal_start_forms_path, renewal_start_form: valid_params
-              updated_tr_count = TransientRegistration.count
-
-              expect(expected_tr_count).to eq(updated_tr_count)
-            end
-
-            it "creates a transient registration with correct data" do
-              post renewal_start_forms_path, renewal_start_form: valid_params
-              transient_registration = TransientRegistration.where(reg_identifier: registration.reg_identifier).first
-
-              expect(transient_registration.reg_identifier).to eq(registration.reg_identifier)
-              expect(transient_registration.company_name).to eq(registration.company_name)
-            end
-
-            it "returns a 302 response" do
-              post renewal_start_forms_path, renewal_start_form: valid_params
-              expect(response).to have_http_status(302)
-            end
-
-            it "redirects to the business type form" do
-              post renewal_start_forms_path, renewal_start_form: valid_params
-              expect(response).to redirect_to(new_business_type_form_path(valid_params[:reg_identifier]))
-            end
-          end
-
-          context "when invalid params are submitted" do
-            let(:invalid_params) { { reg_identifier: "foo" } }
-
-            it "does not create a new transient registration" do
-              original_tr_count = TransientRegistration.count
-              post renewal_start_forms_path, renewal_start_form: invalid_params
-              updated_tr_count = TransientRegistration.count
-              expect(original_tr_count).to eq(updated_tr_count)
-            end
-          end
-        end
       end
 
       context "when no matching registration exists" do
@@ -168,41 +157,65 @@ RSpec.describe "RenewalStartForms", type: :request do
         end
       end
 
-      context "when a renewal is in progress" do
-        let(:transient_registration) do
-          create(:transient_registration,
-                 :has_required_data,
-                 workflow_state: "renewal_start_form")
+      context "when the signed-in user owns the registration" do
+        context "when a matching registration exists" do
+          context "when no renewal is in progress" do
+            let(:registration) do
+              create(:registration,
+                     :has_required_data,
+                     account_email: user.email,
+                     company_name: "Correct Name")
+            end
+
+            context "when valid params are submitted" do
+              let(:valid_params) { { reg_identifier: registration.reg_identifier } }
+
+              it "creates a new transient registration" do
+                expected_tr_count = TransientRegistration.count + 1
+                post renewal_start_forms_path, renewal_start_form: valid_params
+                updated_tr_count = TransientRegistration.count
+
+                expect(expected_tr_count).to eq(updated_tr_count)
+              end
+
+              it "creates a transient registration with correct data" do
+                post renewal_start_forms_path, renewal_start_form: valid_params
+                transient_registration = TransientRegistration.where(reg_identifier: registration.reg_identifier).first
+
+                expect(transient_registration.reg_identifier).to eq(registration.reg_identifier)
+                expect(transient_registration.company_name).to eq(registration.company_name)
+              end
+
+              it "returns a 302 response" do
+                post renewal_start_forms_path, renewal_start_form: valid_params
+                expect(response).to have_http_status(302)
+              end
+
+              it "redirects to the business type form" do
+                post renewal_start_forms_path, renewal_start_form: valid_params
+                expect(response).to redirect_to(new_business_type_form_path(valid_params[:reg_identifier]))
+              end
+            end
+
+            context "when invalid params are submitted" do
+              let(:invalid_params) { { reg_identifier: "foo" } }
+
+              it "does not create a new transient registration" do
+                original_tr_count = TransientRegistration.count
+                post renewal_start_forms_path, renewal_start_form: invalid_params
+                updated_tr_count = TransientRegistration.count
+                expect(original_tr_count).to eq(updated_tr_count)
+              end
+            end
+          end
         end
 
-        let(:valid_params) { { reg_identifier: transient_registration.reg_identifier } }
-
-        it "returns a 302 response" do
-          post renewal_start_forms_path, renewal_start_form: valid_params
-          expect(response).to have_http_status(302)
-        end
-
-        it "redirects to the business type form" do
-          post renewal_start_forms_path, renewal_start_form: valid_params
-          expect(response).to redirect_to(new_business_type_form_path(valid_params[:reg_identifier]))
-        end
-
-        it "does not create a new transient registration" do
-          # Touch the test object so it gets created now and the count is correct
-          transient_registration.touch
-
-          original_tr_count = TransientRegistration.count
-          post renewal_start_forms_path, renewal_start_form: valid_params
-          updated_tr_count = TransientRegistration.count
-
-          expect(original_tr_count).to eq(updated_tr_count)
-        end
-
-        context "when the state is different" do
+        context "when a renewal is in progress" do
           let(:transient_registration) do
             create(:transient_registration,
                    :has_required_data,
-                   workflow_state: "smart_answers_form")
+                   account_email: user.email,
+                   workflow_state: "renewal_start_form")
           end
 
           let(:valid_params) { { reg_identifier: transient_registration.reg_identifier } }
@@ -212,9 +225,9 @@ RSpec.describe "RenewalStartForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the correct form" do
+          it "redirects to the business type form" do
             post renewal_start_forms_path, renewal_start_form: valid_params
-            expect(response).to redirect_to(new_smart_answers_form_path(valid_params[:reg_identifier]))
+            expect(response).to redirect_to(new_business_type_form_path(valid_params[:reg_identifier]))
           end
 
           it "does not create a new transient registration" do
@@ -226,6 +239,70 @@ RSpec.describe "RenewalStartForms", type: :request do
             updated_tr_count = TransientRegistration.count
 
             expect(original_tr_count).to eq(updated_tr_count)
+          end
+
+          context "when the state is different" do
+            let(:transient_registration) do
+              create(:transient_registration,
+                     :has_required_data,
+                     account_email: user.email,
+                     workflow_state: "smart_answers_form")
+            end
+
+            let(:valid_params) { { reg_identifier: transient_registration.reg_identifier } }
+
+            it "returns a 302 response" do
+              post renewal_start_forms_path, renewal_start_form: valid_params
+              expect(response).to have_http_status(302)
+            end
+
+            it "redirects to the correct form" do
+              post renewal_start_forms_path, renewal_start_form: valid_params
+              expect(response).to redirect_to(new_smart_answers_form_path(valid_params[:reg_identifier]))
+            end
+
+            it "does not create a new transient registration" do
+              # Touch the test object so it gets created now and the count is correct
+              transient_registration.touch
+
+              original_tr_count = TransientRegistration.count
+              post renewal_start_forms_path, renewal_start_form: valid_params
+              updated_tr_count = TransientRegistration.count
+
+              expect(original_tr_count).to eq(updated_tr_count)
+            end
+          end
+        end
+      end
+
+      context "when the signed-in user does not own the registration" do
+        context "when no renewal is in progress" do
+          let(:registration) do
+            create(:registration,
+                   :has_required_data,
+                   :expires_soon,
+                   account_email: "not-#{user.email}")
+          end
+          let(:valid_params) { { reg_identifier: registration.reg_identifier } }
+
+          it "prevents access" do
+            post renewal_start_forms_path, renewal_start_form: valid_params
+            skip("don't know what this should do yet")
+          end
+        end
+
+        context "when a renewal is in progress" do
+          let(:transient_registration) do
+            create(:transient_registration,
+                   :has_required_data,
+                   account_email: "not-#{user.email}",
+                   workflow_state: "renewal_start_form")
+          end
+          let(:valid_params) { { reg_identifier: transient_registration.reg_identifier } }
+
+          it "prevents access" do
+            post renewal_start_forms_path, renewal_start_form: valid_params
+            skip("don't know what this should do yet")
           end
         end
       end

--- a/spec/requests/smart_answers_forms_spec.rb
+++ b/spec/requests/smart_answers_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "SmartAnswersForms", type: :request do
   describe "GET new_smart_answers_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "SmartAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "smart_answers_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "SmartAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "SmartAnswersForms", type: :request do
   end
 
   describe "POST smart_answers_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "SmartAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "smart_answers_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "SmartAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -123,9 +127,9 @@ RSpec.describe "SmartAnswersForms", type: :request do
 
 
   describe "GET back_smart_answers_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -133,6 +137,7 @@ RSpec.describe "SmartAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "smart_answers_form")
         end
 
@@ -153,6 +158,7 @@ RSpec.describe "SmartAnswersForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 

--- a/spec/requests/worldpay_forms_spec.rb
+++ b/spec/requests/worldpay_forms_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "WorldpayForms", type: :request do
   describe "GET new_worldpay_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -12,6 +12,7 @@ RSpec.describe "WorldpayForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "worldpay_form")
         end
 
@@ -25,6 +26,7 @@ RSpec.describe "WorldpayForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -37,9 +39,9 @@ RSpec.describe "WorldpayForms", type: :request do
   end
 
   describe "POST worldpay_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "WorldpayForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "worldpay_form")
         end
 
@@ -95,6 +98,7 @@ RSpec.describe "WorldpayForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 
@@ -122,9 +126,9 @@ RSpec.describe "WorldpayForms", type: :request do
   end
 
   describe "GET back_worldpay_forms_path" do
-    context "when a user is signed in" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
       before(:each) do
-        user = create(:user)
         sign_in(user)
       end
 
@@ -132,6 +136,7 @@ RSpec.describe "WorldpayForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "worldpay_form")
         end
 
@@ -152,6 +157,7 @@ RSpec.describe "WorldpayForms", type: :request do
         let(:transient_registration) do
           create(:transient_registration,
                  :has_required_data,
+                 account_email: user.email,
                  workflow_state: "renewal_start_form")
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-89

Before users begin the renewal process, we should set their expectations for how long the renewal lasts and what it will cost.

We should also make sure they actually have permission to renew the registration – users should not be able to modify registrations which don't belong to them. I've implemented CanCanCan to handle this, which might be overkill for now but will come in handy once we have to handle admin users as well.

This PR also adds some custom error pages as there were several instances where it didn't make sense to display the errors on the page (as with validations).