### PR TITLE
Select type of business or organisation

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -3,6 +3,7 @@ class BaseForm
 
   validates_with RegIdentifierValidator
   validate :transient_registration_valid?
+  validates :reg_identifier, presence: true
 
   private
 

--- a/app/forms/business_type_form.rb
+++ b/app/forms/business_type_form.rb
@@ -1,21 +1,31 @@
 class BusinessTypeForm < BaseForm
-  attr_accessor :reg_identifier
+  attr_accessor :reg_identifier, :business_type
 
   def initialize(transient_registration)
     @transient_registration = transient_registration
     # Get values from transient registration so form will be pre-filled
     self.reg_identifier = @transient_registration.reg_identifier
+    self.business_type = @transient_registration.business_type
   end
+
+  validates :business_type, presence: true
+  validates :business_type, inclusion: { in: %w[limitedCompany
+                                                limitedLiabilityPartnership
+                                                localAuthority
+                                                other
+                                                overseas
+                                                partnership
+                                                soleTrader] }
 
   def submit(params)
     # Define the params which are allowed
     self.reg_identifier = params[:reg_identifier]
-    # TODO: Add other params, eg self.field = params[:field]
+    self.business_type = params[:business_type]
 
     # Update the transient registration with params from the registration if valid
     if valid?
       @transient_registration.reg_identifier = reg_identifier
-      # TODO: Add other params, eg @transient_registration.field = field
+      @transient_registration.business_type = business_type
       @transient_registration.save!
       true
     else

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -6,13 +6,15 @@ class TransientRegistration
   validates_with RegIdentifierValidator
   validate :no_renewal_in_progress?, on: :create
 
-  after_initialize :copy_data_from_registration, on: :create
+  after_initialize :copy_data_from_registration
 
   private
 
   def copy_data_from_registration
     # Don't try to get Registration data with an invalid reg_identifier
-    return unless valid?
+    return unless valid? && new_record?
+
+    puts "COPYING!!!"
 
     registration = Registration.where(reg_identifier: reg_identifier).first
 

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -14,8 +14,6 @@ class TransientRegistration
     # Don't try to get Registration data with an invalid reg_identifier
     return unless valid? && new_record?
 
-    puts "COPYING!!!"
-
     registration = Registration.where(reg_identifier: reg_identifier).first
 
     # Don't copy object IDs as Mongo should generate new unique ones

--- a/app/views/business_type_forms/new.html.erb
+++ b/app/views/business_type_forms/new.html.erb
@@ -1,24 +1,51 @@
 <%= render("shared/back", back_path: back_business_type_forms_path(@business_type_form.reg_identifier)) %>
 
-<% if @business_type_form.errors.any? %>
-
-  <h1 class="heading-large"><%= t(".error_heading") %></h1>
-
-  <% @business_type_form.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-
-<% else %>
-
+<div class="text">
   <%= form_for(@business_type_form) do |f| %>
     <%= render("shared/errors", object: @business_type_form) %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+    <div class="form-group">
+      <fieldset>
+        <legend>
+          <h1 class="heading-large"><%= t(".heading") %></h1>
+        </legend>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'localAuthority' %>
+          <%= f.label :business_type, t(".option_local_authority"), value: 'localAuthority' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'limitedCompany' %>
+          <%= f.label :business_type, t(".option_limited_company"), value: 'limitedCompany' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'limitedLiabilityPartnership' %>
+          <%= f.label :business_type, t(".option_limited_liability_partnership"), value: 'limitedLiabilityPartnership' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'soleTrader' %>
+          <%= f.label :business_type, t(".option_individual"), value: 'soleTrader' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'partnership' %>
+          <%= f.label :business_type, t(".option_partnership"), value: 'partnership' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'other' %>
+          <%= f.label :business_type, t(".option_other"), value: 'other' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :business_type, 'overseas' %>
+          <%= f.label :business_type, t(".option_overseas"), value: 'overseas' %>
+        </div>
+      </fieldset>
+    </div>
+
+    <p><%= t(".help") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @business_type_form.reg_identifier %>
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
   <% end %>
-
-<% end %>
+</div>

--- a/config/locales/forms/business_type_forms/en.yml
+++ b/config/locales/forms/business_type_forms/en.yml
@@ -5,7 +5,7 @@ en:
       option_local_authority: Local authority or public body
       option_limited_company: Limited company (eg a registered company or plc)
       option_limited_liability_partnership: Limited liability partnership
-      option_individual: Individual (eg a householder)
+      option_individual: Individual (eg a sole trader)
       option_partnership: Partnership
       option_other: Other organisation (eg a trust, charity or club)
       option_overseas: Based overseas

--- a/config/locales/forms/business_type_forms/en.yml
+++ b/config/locales/forms/business_type_forms/en.yml
@@ -1,7 +1,15 @@
 en:
   business_type_forms:
     new:
-      heading: Business type
+      heading: What type of business or organisation are you?
+      option_local_authority: Local authority or public body
+      option_limited_company: Limited company (eg a registered company or plc)
+      option_limited_liability_partnership: Limited liability partnership
+      option_individual: Individual (eg a householder)
+      option_partnership: Partnership
+      option_other: Other organisation (eg a trust, charity or club)
+      option_overseas: Based overseas
+      help: Not sure? Call our helpline on 03708 506 506.
       error_heading: Something is wrong
       next_button: Continue
   activemodel:

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :transient_registration do
     trait :has_required_data do
-      reg_identifier { create(:registration, :has_required_data, :expires_soon).reg_identifier }
+      # Create a new registration when initializing so we can copy its data
+      initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_soon).reg_identifier) }
     end
   end
 end

--- a/spec/forms/business_type_forms_spec.rb
+++ b/spec/forms/business_type_forms_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BusinessTypeForm, type: :model do
   describe "#submit" do
     context "when the form is valid" do
       let(:business_type_form) { build(:business_type_form, :has_required_data) }
-      let(:valid_params) { { reg_identifier: business_type_form.reg_identifier } }
+      let(:valid_params) { { reg_identifier: business_type_form.reg_identifier, business_type: "limitedCompany" } }
 
       it "should submit" do
         expect(business_type_form.submit(valid_params)).to eq(true)
@@ -13,7 +13,7 @@ RSpec.describe BusinessTypeForm, type: :model do
 
     context "when the form is not valid" do
       let(:business_type_form) { build(:business_type_form, :has_required_data) }
-      let(:invalid_params) { { reg_identifier: "foo" } }
+      let(:invalid_params) { { reg_identifier: "foo", business_type: "foo" } }
 
       it "should not submit" do
         expect(business_type_form.submit(invalid_params)).to eq(false)
@@ -21,19 +21,21 @@ RSpec.describe BusinessTypeForm, type: :model do
     end
   end
 
-  describe "#reg_identifier" do
-    context "when a valid transient registration exists" do
-      let(:transient_registration) do
-        create(:transient_registration,
-               :has_required_data,
-               workflow_state: "business_type_form")
-      end
-      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
-      let(:business_type_form) { BusinessTypeForm.new(transient_registration) }
+  context "when a valid transient registration exists" do
+    let(:transient_registration) do
+      create(:transient_registration,
+             :has_required_data,
+             business_type: "limitedCompany",
+             workflow_state: "business_type_form")
+    end
+    # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+    let(:business_type_form) { BusinessTypeForm.new(transient_registration) }
 
+    describe "#reg_identifier" do
       context "when a reg_identifier meets the requirements" do
         before(:each) do
           business_type_form.reg_identifier = transient_registration.reg_identifier
+          business_type_form.business_type = transient_registration.business_type
         end
 
         it "is valid" do
@@ -44,6 +46,39 @@ RSpec.describe BusinessTypeForm, type: :model do
       context "when a reg_identifier is blank" do
         before(:each) do
           business_type_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(business_type_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#business_type" do
+      context "when a business_type meets the requirements" do
+        before(:each) do
+          business_type_form.reg_identifier = transient_registration.reg_identifier
+          business_type_form.business_type = transient_registration.business_type
+        end
+
+        it "is valid" do
+          expect(business_type_form).to be_valid
+        end
+      end
+
+      context "when a business_type is blank" do
+        before(:each) do
+          business_type_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(business_type_form).to_not be_valid
+        end
+      end
+
+      context "when a business_type is not in the allowed list" do
+        before(:each) do
+          business_type_form.reg_identifier = "foo"
         end
 
         it "is not valid" do

--- a/spec/requests/business_type_forms_spec.rb
+++ b/spec/requests/business_type_forms_spec.rb
@@ -50,18 +50,21 @@ RSpec.describe "BusinessTypeForms", type: :request do
           create(:transient_registration,
                  :has_required_data,
                  account_email: user.email,
+                 business_type: "limitedCompany",
                  workflow_state: "business_type_form")
         end
 
         context "when valid params are submitted" do
           let(:valid_params) {
             {
-              reg_identifier: transient_registration[:reg_identifier]
+              reg_identifier: transient_registration[:reg_identifier],
+              business_type: "partnership"
             }
           }
 
           it "updates the transient registration" do
-            # TODO: Add test once data is submitted through the form
+            post business_type_forms_path, business_type_form: valid_params
+            expect(transient_registration.reload[:reg_identifier]).to eq(valid_params[:reg_identifier])
           end
 
           it "returns a 302 response" do
@@ -78,7 +81,8 @@ RSpec.describe "BusinessTypeForms", type: :request do
         context "when invalid params are submitted" do
           let(:invalid_params) {
             {
-              reg_identifier: "foo"
+              reg_identifier: "foo",
+              business_type: "foo"
             }
           }
 
@@ -99,17 +103,20 @@ RSpec.describe "BusinessTypeForms", type: :request do
           create(:transient_registration,
                  :has_required_data,
                  account_email: user.email,
+                 business_type: "limitedCompany",
                  workflow_state: "renewal_start_form")
         end
 
         let(:valid_params) {
           {
-            reg_identifier: transient_registration[:reg_identifier]
+            reg_identifier: transient_registration[:reg_identifier],
+            business_type: "partnership"
           }
         }
 
         it "does not update the transient registration" do
-          # TODO: Add test once data is submitted through the form
+          post business_type_forms_path, business_type_form: valid_params
+          expect(transient_registration.reload[:business_type]).to_not eq(valid_params[:business_type])
         end
 
         it "returns a 302 response" do

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe "RenewalStartForms", type: :request do
               end
 
               it "returns a success response" do
-                puts Registration.where(reg_identifier: transient_registration[:reg_identifier]).first.to_json
-                puts TransientRegistration.where(reg_identifier: transient_registration[:reg_identifier]).first.to_json
                 get new_renewal_start_form_path(transient_registration[:reg_identifier])
                 expect(response).to have_http_status(200)
               end

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe "RenewalStartForms", type: :request do
               end
 
               it "returns a success response" do
+                puts Registration.where(reg_identifier: transient_registration[:reg_identifier]).first.to_json
+                puts TransientRegistration.where(reg_identifier: transient_registration[:reg_identifier]).first.to_json
                 get new_renewal_start_form_path(transient_registration[:reg_identifier])
                 expect(response).to have_http_status(200)
               end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-90

As part of the renewal, users must state what type of business or organisation the registration belongs to. The form should have their existing choice pre-selected, but they should be able to change it (although changing the type may require making a new registration instead – we'll handle that in a later story).

Some options will not be pre-selected as the available options have changed slightly – for example, public body and local authority have been combined

This doesn't cover any routing that comes from selecting a different type. See [WC-91](https://eaflood.atlassian.net/browse/WC-91) for that.