### PR TITLE
Set up "skeleton" of happy path for local authority/public body

### DIFF
--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -183,6 +183,6 @@ module CanChangeWorkflowStatus
   private
 
   def skip_registration_number?
-    business_type == "soleTrader"
+    %w[localAuthority soleTrader].include?(business_type)
   end
 end

--- a/config/locales/forms/company_address_forms/en.yml
+++ b/config/locales/forms/company_address_forms/en.yml
@@ -1,6 +1,7 @@
 en:
   company_address_forms:
     new:
+      heading_localAuthority: What's the address of the local authority or public body? (select)
       heading_limitedCompany: What's the address of the company? (select)
       heading_soleTrader: What's the address of the individual? (select)
       error_heading: Something is wrong

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -1,6 +1,7 @@
 en:
   company_name_forms:
     new:
+      heading_localAuthority: What's the name of the local authority or public body?
       heading_limitedCompany: What's the name of the company?
       heading_soleTrader: What's the name of the individual?
       error_heading: Something is wrong

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -1,6 +1,7 @@
 en:
   company_postcode_forms:
     new:
+      heading_localAuthority: What's the address of the local authority or public body? (postcode)
       heading_limitedCompany: What's the address of the company? (postcode)
       heading_soleTrader: What's the address of the individual? (postcode)
       error_heading: Something is wrong

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -1,6 +1,7 @@
 en:
   key_people_forms:
     new:
+      heading_localAuthority: Chief executive details
       heading_limitedCompany: Director details
       heading_soleTrader: Individual details
       error_heading: Something is wrong

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -162,4 +162,79 @@ if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
       confirmed: "no"
     }
   )
+
+  # Local authority or public body
+  Registration.find_or_create_by(
+    tier: "UPPER",
+    registrationType: "carrier_broker_dealer",
+    businessType: "localAuthority",
+    otherBusinesses: "yes",
+    isMainService: "yes",
+    onlyAMF: "no",
+    companyName: "Local Authority Seed",
+    companyNo: 1_234_567,
+    firstName: "Test",
+    lastName: "User",
+    phoneNumber: "01234 567890",
+    contactEmail: "user@waste-exemplar.gov.uk",
+    addresses: [
+      {
+        addressType: "REGISTERED",
+        addressMode: "manual-uk",
+        houseNumber: "Unit 5",
+        addressLine1: "Horizon House",
+        addressLine2: "Deanery Road",
+        townCity: "Bristol",
+        postcode: "BS1 5AH",
+        location: {
+          lat: 0,
+          lon: 0
+        }
+      },
+      {
+        addressType: "POSTAL",
+        houseNumber: "Richard Fairclough House",
+        addressLine1: "Knutsford Road",
+        addressLine2: "Latchford",
+        addressLine3: "",
+        addressLine4: "",
+        townCity: "Warrington",
+        postcode: "WA4 1HT",
+        country: ""
+      }
+    ],
+    keyPeople: [
+      {
+        firstName: "Test",
+        lastName: "Employee",
+        dateOfBirth: 40.years.ago,
+        position: "Director",
+        personType: "KEY",
+        convictionSearchResult: {
+          matchResult: "NO",
+          searchedAt: DateTime.new,
+          confirmed: "no"
+        }
+      }
+    ],
+    accountEmail: "user@waste-exemplar.gov.uk",
+    declaredConvictions: "no",
+    declaration: 1,
+    regIdentifier: "CBDU3",
+    expires_on: 6.months.from_now,
+    metaData: {
+      dateRegistered: 30.months.ago,
+      anotherString: "userDetailAddedAtRegistration",
+      lastModified: 29.months.ago,
+      dateActivated: 29.months.ago,
+      status: "ACTIVE",
+      route: "DIGITAL",
+      distance: "n/a"
+    },
+    convictionSearchResult: {
+      matchResult: "NO",
+      searchedAt: 29.months.ago,
+      confirmed: "no"
+    }
+  )
 end

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -294,6 +294,14 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:renewal_information_form).to(:cbd_type_form).on_event(:back)
       end
 
+      context "when the business type is localAuthority" do
+        before(:each) { transient_registration.business_type = "localAuthority" }
+
+        it "changes to :company_name_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:renewal_information_form).to(:company_name_form).on_event(:next)
+        end
+      end
+
       context "when the business type is limitedCompany" do
         before(:each) { transient_registration.business_type = "limitedCompany" }
 
@@ -332,6 +340,14 @@ RSpec.describe TransientRegistration, type: :model do
         create(:transient_registration,
                :has_required_data,
                workflow_state: "company_name_form")
+      end
+
+      context "when the business type is localAuthority" do
+        before(:each) { transient_registration.business_type = "localAuthority" }
+
+        it "changes to :renewal_infromation_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
+        end
       end
 
       context "when the business type is limitedCompany" do

--- a/spec/requests/company_name_forms_spec.rb
+++ b/spec/requests/company_name_forms_spec.rb
@@ -146,6 +146,15 @@ RSpec.describe "CompanyNameForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
+          context "when the business type is localAuthority" do
+            before(:each) { transient_registration.update_attributes(business_type: "localAuthority") }
+
+            it "redirects to the renewal_information form" do
+              get back_company_name_forms_path(transient_registration[:reg_identifier])
+              expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
           context "when the business type is limitedCompany" do
             before(:each) { transient_registration.update_attributes(business_type: "limitedCompany") }
 

--- a/spec/requests/renewal_information_forms_spec.rb
+++ b/spec/requests/renewal_information_forms_spec.rb
@@ -69,6 +69,15 @@ RSpec.describe "RenewalInformationForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
+          context "when the business type is localAuthority" do
+            before(:each) { transient_registration.update_attributes(business_type: "localAuthority") }
+
+            it "redirects to the company_name form" do
+              post renewal_information_forms_path, renewal_information_form: valid_params
+              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
           context "when the business type is limitedCompany" do
             before(:each) { transient_registration.update_attributes(business_type: "limitedCompany") }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-146

This story covers setting up a "skeleton" of the happy path for those who would select Local authority or Public body on the select org type page. Pages in the skeleton will mostly be blank – just a title and continue button.

This is so we can set up how users move between the pages, and also so we can start testing the process as a whole.

As we continue to work on the stories, these pages will be fleshed out with the proper forms.