### PR TITLE
Set up "skeleton" of happy path for "other" organisations

### DIFF
--- a/app/controllers/cannot_renew_lower_tier_forms_controller.rb
+++ b/app/controllers/cannot_renew_lower_tier_forms_controller.rb
@@ -1,0 +1,8 @@
+class CannotRenewLowerTierFormsController < FormsController
+  def new
+    super(CannotRenewLowerTierForm, "cannot_renew_lower_tier_form")
+  end
+
+  # Override this method as user shouldn't be able to "submit" this page
+  def create; end
+end

--- a/app/forms/cannot_renew_lower_tier_form.rb
+++ b/app/forms/cannot_renew_lower_tier_form.rb
@@ -1,0 +1,9 @@
+class CannotRenewLowerTierForm < BaseForm
+  attr_accessor :reg_identifier
+
+  def initialize(transient_registration)
+    @transient_registration = transient_registration
+    # Get values from transient registration so form will be pre-filled
+    self.reg_identifier = @transient_registration.reg_identifier
+  end
+end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -37,14 +37,18 @@ module CanChangeWorkflowStatus
 
       state :renewal_complete_form
 
+      state :cannot_renew_lower_tier_form
       state :cannot_renew_type_change_form
-      state :cannot_renew_should_be_lower_form
       state :cannot_renew_reg_number_change_form
 
       # Transitions
       event :next do
         transitions from: :renewal_start_form,
                     to: :business_type_form
+
+        transitions from: :business_type_form,
+                    to: :cannot_renew_lower_tier_form,
+                    if: :switch_to_lower_tier?
 
         transitions from: :business_type_form,
                     to: :smart_answers_form,
@@ -174,6 +178,9 @@ module CanChangeWorkflowStatus
         transitions from: :worldpay_form,
                     to: :payment_summary_form
 
+        transitions from: :cannot_renew_lower_tier_form,
+                    to: :business_type_form
+
         transitions from: :cannot_renew_type_change_form,
                     to: :business_type_form
       end
@@ -184,5 +191,10 @@ module CanChangeWorkflowStatus
 
   def skip_registration_number?
     %w[localAuthority soleTrader].include?(business_type)
+  end
+
+  # Charity registrations should be lower tier
+  def switch_to_lower_tier?
+    business_type == "other"
   end
 end

--- a/app/views/cannot_renew_lower_tier_forms/new.html.erb
+++ b/app/views/cannot_renew_lower_tier_forms/new.html.erb
@@ -1,0 +1,9 @@
+<%= render("shared/back", back_path: back_cannot_renew_lower_tier_forms_path(@cannot_renew_lower_tier_form.reg_identifier)) %>
+
+<div class="text">
+  <h1 class="heading-large"><%= t(".heading", reg_identifier: @cannot_renew_lower_tier_form.reg_identifier) %></h1>
+  <p><%= t(".paragraph_1") %></p>
+  <p><%= t(".paragraph_2") %></p>
+  <p><%= t(".paragraph_3") %></p>
+  <a href="<%= Rails.configuration.wcrs_frontend_url %>/registrations/start" class="button"><%= t(".next_button") %></a>
+</div>

--- a/config/locales/forms/cannot_renew_lower_tier_forms/en.yml
+++ b/config/locales/forms/cannot_renew_lower_tier_forms/en.yml
@@ -1,15 +1,15 @@
 en:
-  cannot_renew_type_change_forms:
+  cannot_renew_lower_tier_forms:
     new:
-      heading: You cannot renew %{reg_identifier}
-      paragraph_1: You've told us that your business type should be lower tier.
-      paragraph_2: Because of this change, you cannot renew %{reg_identifier} and instead must make a new registration.
+      heading: You should not renew %{reg_identifier}
+      paragraph_1: Based on the answers to our questions, you are eligible to register as a lower tier waste carrier.
+      paragraph_2: There is no charge to register as a lower tier waste carrier, but you will need to create a new registration.
       paragraph_3: If you have any questions about this, please contact our helpline on 03708 506 506
       next_button: Start a new registration
   activemodel:
     errors:
       models:
-        cannot_renew_type_change_form:
+        cannot_renew_lower_tier_form:
           attributes:
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"

--- a/config/locales/forms/cannot_renew_lower_tier_forms/en.yml
+++ b/config/locales/forms/cannot_renew_lower_tier_forms/en.yml
@@ -1,15 +1,15 @@
 en:
-  cannot_renew_lower_tier_forms:
+  cannot_renew_type_change_forms:
     new:
-      heading: You should not renew %{reg_identifier}
-      paragraph_1: Based on the answers to our questions, you are eligible to register as a lower tier waste carrier.
-      paragraph_2: There is no charge to registered as a lower tier waste carrier, but you will need to create a new registration.
+      heading: You cannot renew %{reg_identifier}
+      paragraph_1: You've told us that your business type should be lower tier.
+      paragraph_2: Because of this change, you cannot renew %{reg_identifier} and instead must make a new registration.
       paragraph_3: If you have any questions about this, please contact our helpline on 03708 506 506
       next_button: Start a new registration
   activemodel:
     errors:
       models:
-        cannot_renew_lower_tier_form:
+        cannot_renew_type_change_form:
           attributes:
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"

--- a/config/locales/forms/cannot_renew_type_change_forms/en.yml
+++ b/config/locales/forms/cannot_renew_type_change_forms/en.yml
@@ -1,15 +1,15 @@
 en:
-  cannot_renew_lower_tier_forms:
+  cannot_renew_type_change_forms:
     new:
-      heading: You should not renew %{reg_identifier}
-      paragraph_1: Based on the answers to our questions, you are eligible to register as a lower tier waste carrier.
-      paragraph_2: There is no charge to registered as a lower tier waste carrier, but you will need to create a new registration.
+      heading: You cannot renew %{reg_identifier}
+      paragraph_1: You've told us that your business type should be lower tier.
+      paragraph_2: Because of this change, you cannot renew %{reg_identifier} and instead must make a new registration.
       paragraph_3: If you have any questions about this, please contact our helpline on 03708 506 506
       next_button: Start a new registration
   activemodel:
     errors:
       models:
-        cannot_renew_lower_tier_form:
+        cannot_renew_type_change_form:
           attributes:
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,16 @@ Rails.application.routes.draw do
               on: :collection
             end
 
+  resources :cannot_renew_lower_tier_forms,
+            only: [:new, :create],
+            path: "cannot-renew-lower-tier",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "cannot_renew_lower_tier_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :cannot_renew_type_change_forms,
             only: [:new, :create],
             path: "cannot-renew-type-change",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -324,4 +324,79 @@ if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
       confirmed: "no"
     }
   )
+
+  # 'Other' business type (eg charity)
+  Registration.find_or_create_by(
+    tier: "UPPER",
+    registrationType: "carrier_broker_dealer",
+    businessType: "other",
+    otherBusinesses: "yes",
+    isMainService: "yes",
+    onlyAMF: "no",
+    companyName: "Other Seed",
+    companyNo: 1_234_567,
+    firstName: "Test",
+    lastName: "User",
+    phoneNumber: "01234 567890",
+    contactEmail: "user@waste-exemplar.gov.uk",
+    addresses: [
+      {
+        addressType: "REGISTERED",
+        addressMode: "manual-uk",
+        houseNumber: "Unit 5",
+        addressLine1: "Horizon House",
+        addressLine2: "Deanery Road",
+        townCity: "Bristol",
+        postcode: "BS1 5AH",
+        location: {
+          lat: 0,
+          lon: 0
+        }
+      },
+      {
+        addressType: "POSTAL",
+        houseNumber: "Richard Fairclough House",
+        addressLine1: "Knutsford Road",
+        addressLine2: "Latchford",
+        addressLine3: "",
+        addressLine4: "",
+        townCity: "Warrington",
+        postcode: "WA4 1HT",
+        country: ""
+      }
+    ],
+    keyPeople: [
+      {
+        firstName: "Test",
+        lastName: "Employee",
+        dateOfBirth: 40.years.ago,
+        position: "Partner",
+        personType: "KEY",
+        convictionSearchResult: {
+          matchResult: "NO",
+          searchedAt: DateTime.new,
+          confirmed: "no"
+        }
+      }
+    ],
+    accountEmail: "user@waste-exemplar.gov.uk",
+    declaredConvictions: "no",
+    declaration: 1,
+    regIdentifier: "CBDU5",
+    expires_on: 6.months.from_now,
+    metaData: {
+      dateRegistered: 30.months.ago,
+      anotherString: "userDetailAddedAtRegistration",
+      lastModified: 29.months.ago,
+      dateActivated: 29.months.ago,
+      status: "ACTIVE",
+      route: "DIGITAL",
+      distance: "n/a"
+    },
+    convictionSearchResult: {
+      matchResult: "NO",
+      searchedAt: 29.months.ago,
+      confirmed: "no"
+    }
+  )
 end

--- a/spec/factories/forms/cannot_renew_lower_tier_form.rb
+++ b/spec/factories/forms/cannot_renew_lower_tier_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :cannot_renew_lower_tier_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "cannot_renew_lower_tier_form")) }
+    end
+  end
+end

--- a/spec/forms/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/forms/cannot_renew_lower_tier_forms_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe CannotRenewLowerTierForm, type: :model do
+  describe "#reg_identifier" do
+    context "when a valid transient registration exists" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "cannot_renew_lower_tier_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:cannot_renew_lower_tier_form) { CannotRenewLowerTierForm.new(transient_registration) }
+
+      context "when a reg_identifier meets the requirements" do
+        before(:each) do
+          cannot_renew_lower_tier_form.reg_identifier = transient_registration.reg_identifier
+        end
+
+        it "is valid" do
+          expect(cannot_renew_lower_tier_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          cannot_renew_lower_tier_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(cannot_renew_lower_tier_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "cannot_renew_lower_tier_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:cannot_renew_lower_tier_form) { CannotRenewLowerTierForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        cannot_renew_lower_tier_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(cannot_renew_lower_tier_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        cannot_renew_lower_tier_form.valid?
+        expect(cannot_renew_lower_tier_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe TransientRegistration, type: :model do
             transient_registration.business_type = "other"
           end
 
-          it "changes to :smart_answers_form after the 'next' event" do
-            expect(transient_registration).to transition_from(:business_type_form).to(:smart_answers_form).on_event(:next)
+          it "changes to :cannot_renew_lower_tier_form after the 'next' event" do
+            expect(transient_registration).to transition_from(:business_type_form).to(:cannot_renew_lower_tier_form).on_event(:next)
           end
         end
 

--- a/spec/requests/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/requests/cannot_renew_lower_tier_forms_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "CannotRenewLowerTierForms", type: :request do
+  describe "GET new_cannot_renew_lower_tier_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "cannot_renew_lower_tier_form")
+        end
+
+        it "returns a success response" do
+          get new_cannot_renew_lower_tier_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_cannot_renew_lower_tier_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_cannot_renew_lower_tier_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "cannot_renew_lower_tier_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-150

This story covers setting up a "skeleton" of the happy path for those who would select Other organisations on the select org type page. The "other" type covers charities, trusts, clubs and other organisations which should be lower tier registrations. For this reason, selecting "other" as your business type shoud tell you to start a new lower tier registration instead of renewing.