### PR TITLE
Set up "skeleton" of happy path for partnerships

### DIFF
--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -190,7 +190,7 @@ module CanChangeWorkflowStatus
   private
 
   def skip_registration_number?
-    %w[localAuthority soleTrader].include?(business_type)
+    %w[localAuthority partnership soleTrader].include?(business_type)
   end
 
   # Charity registrations should be lower tier

--- a/config/locales/forms/company_address_forms/en.yml
+++ b/config/locales/forms/company_address_forms/en.yml
@@ -4,6 +4,7 @@ en:
       heading_localAuthority: What's the address of the local authority or public body? (select)
       heading_limitedCompany: What's the address of the company? (select)
       heading_limitedLiabilityPartnership: What's the address of the limited liability partnership? (select)
+      heading_partnership: What's the address of the partnership? (select)
       heading_soleTrader: What's the address of the individual? (select)
       error_heading: Something is wrong
       next_button: Continue

--- a/config/locales/forms/company_name_forms/en.yml
+++ b/config/locales/forms/company_name_forms/en.yml
@@ -4,6 +4,7 @@ en:
       heading_localAuthority: What's the name of the local authority or public body?
       heading_limitedCompany: What's the name of the company?
       heading_limitedLiabilityPartnership: What's the name of the limited liability partnership?
+      heading_partnership: What's the name of the partnership?
       heading_soleTrader: What's the name of the individual?
       error_heading: Something is wrong
       next_button: Continue

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -4,6 +4,7 @@ en:
       heading_localAuthority: What's the address of the local authority or public body? (postcode)
       heading_limitedCompany: What's the address of the company? (postcode)
       heading_limitedLiabilityPartnership: What's the address of the limited liability partnership? (postcode)
+      heading_partnership: What's the address of the partnership? (postcode)
       heading_soleTrader: What's the address of the individual? (postcode)
       error_heading: Something is wrong
       next_button: Continue

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -4,6 +4,7 @@ en:
       heading_localAuthority: Chief executive details
       heading_limitedCompany: Director details
       heading_limitedLiabilityPartnership: Partner details
+      heading_partnership: Partner details
       heading_soleTrader: Individual details
       error_heading: Something is wrong
       next_button: Continue

--- a/config/locales/forms/registration_number_forms/en.yml
+++ b/config/locales/forms/registration_number_forms/en.yml
@@ -3,7 +3,6 @@ en:
     new:
       heading_limitedCompany: What's the registration number of the company?
       heading_limitedLiabilityPartnership: What's the registration number of the limited liability partnership?
-      heading_soleTrader: What's the registration number of the individual?
       error_heading: Something is wrong
       next_button: Continue
   activemodel:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -163,80 +163,80 @@ if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
     }
   )
 
-    # Local authority or public body
-    Registration.find_or_create_by(
-      tier: "UPPER",
-      registrationType: "carrier_broker_dealer",
-      businessType: "localAuthority",
-      otherBusinesses: "yes",
-      isMainService: "yes",
-      onlyAMF: "no",
-      companyName: "LocalAuthority Seed",
-      companyNo: 1_234_567,
-      firstName: "Test",
-      lastName: "User",
-      phoneNumber: "01234 567890",
-      contactEmail: "user@waste-exemplar.gov.uk",
-      addresses: [
-        {
-          addressType: "REGISTERED",
-          addressMode: "manual-uk",
-          houseNumber: "Unit 5",
-          addressLine1: "Horizon House",
-          addressLine2: "Deanery Road",
-          townCity: "Bristol",
-          postcode: "BS1 5AH",
-          location: {
-            lat: 0,
-            lon: 0
-          }
-        },
-        {
-          addressType: "POSTAL",
-          houseNumber: "Richard Fairclough House",
-          addressLine1: "Knutsford Road",
-          addressLine2: "Latchford",
-          addressLine3: "",
-          addressLine4: "",
-          townCity: "Warrington",
-          postcode: "WA4 1HT",
-          country: ""
+  # Local authority or public body
+  Registration.find_or_create_by(
+    tier: "UPPER",
+    registrationType: "carrier_broker_dealer",
+    businessType: "localAuthority",
+    otherBusinesses: "yes",
+    isMainService: "yes",
+    onlyAMF: "no",
+    companyName: "LocalAuthority Seed",
+    companyNo: 1_234_567,
+    firstName: "Test",
+    lastName: "User",
+    phoneNumber: "01234 567890",
+    contactEmail: "user@waste-exemplar.gov.uk",
+    addresses: [
+      {
+        addressType: "REGISTERED",
+        addressMode: "manual-uk",
+        houseNumber: "Unit 5",
+        addressLine1: "Horizon House",
+        addressLine2: "Deanery Road",
+        townCity: "Bristol",
+        postcode: "BS1 5AH",
+        location: {
+          lat: 0,
+          lon: 0
         }
-      ],
-      keyPeople: [
-        {
-          firstName: "Test",
-          lastName: "Employee",
-          dateOfBirth: 40.years.ago,
-          position: "Director",
-          personType: "KEY",
-          convictionSearchResult: {
-            matchResult: "NO",
-            searchedAt: DateTime.new,
-            confirmed: "no"
-          }
-        }
-      ],
-      accountEmail: "user@waste-exemplar.gov.uk",
-      declaredConvictions: "no",
-      declaration: 1,
-      regIdentifier: "CBDU3",
-      expires_on: 6.months.from_now,
-      metaData: {
-        dateRegistered: 30.months.ago,
-        anotherString: "userDetailAddedAtRegistration",
-        lastModified: 29.months.ago,
-        dateActivated: 29.months.ago,
-        status: "ACTIVE",
-        route: "DIGITAL",
-        distance: "n/a"
       },
-      convictionSearchResult: {
-        matchResult: "NO",
-        searchedAt: 29.months.ago,
-        confirmed: "no"
+      {
+        addressType: "POSTAL",
+        houseNumber: "Richard Fairclough House",
+        addressLine1: "Knutsford Road",
+        addressLine2: "Latchford",
+        addressLine3: "",
+        addressLine4: "",
+        townCity: "Warrington",
+        postcode: "WA4 1HT",
+        country: ""
       }
-    )
+    ],
+    keyPeople: [
+      {
+        firstName: "Test",
+        lastName: "Employee",
+        dateOfBirth: 40.years.ago,
+        position: "Director",
+        personType: "KEY",
+        convictionSearchResult: {
+          matchResult: "NO",
+          searchedAt: DateTime.new,
+          confirmed: "no"
+        }
+      }
+    ],
+    accountEmail: "user@waste-exemplar.gov.uk",
+    declaredConvictions: "no",
+    declaration: 1,
+    regIdentifier: "CBDU3",
+    expires_on: 6.months.from_now,
+    metaData: {
+      dateRegistered: 30.months.ago,
+      anotherString: "userDetailAddedAtRegistration",
+      lastModified: 29.months.ago,
+      dateActivated: 29.months.ago,
+      status: "ACTIVE",
+      route: "DIGITAL",
+      distance: "n/a"
+    },
+    convictionSearchResult: {
+      matchResult: "NO",
+      searchedAt: 29.months.ago,
+      confirmed: "no"
+    }
+  )
 
   # Limited liability partnership
   Registration.find_or_create_by(
@@ -383,6 +383,93 @@ if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
     declaredConvictions: "no",
     declaration: 1,
     regIdentifier: "CBDU5",
+    expires_on: 6.months.from_now,
+    metaData: {
+      dateRegistered: 30.months.ago,
+      anotherString: "userDetailAddedAtRegistration",
+      lastModified: 29.months.ago,
+      dateActivated: 29.months.ago,
+      status: "ACTIVE",
+      route: "DIGITAL",
+      distance: "n/a"
+    },
+    convictionSearchResult: {
+      matchResult: "NO",
+      searchedAt: 29.months.ago,
+      confirmed: "no"
+    }
+  )
+
+  # Partnership
+  Registration.find_or_create_by(
+    tier: "UPPER",
+    registrationType: "carrier_broker_dealer",
+    businessType: "partnership",
+    otherBusinesses: "yes",
+    isMainService: "yes",
+    onlyAMF: "no",
+    companyName: "Partnership Seed",
+    companyNo: 1_234_567,
+    firstName: "Test",
+    lastName: "User",
+    phoneNumber: "01234 567890",
+    contactEmail: "user@waste-exemplar.gov.uk",
+    addresses: [
+      {
+        addressType: "REGISTERED",
+        addressMode: "manual-uk",
+        houseNumber: "Unit 5",
+        addressLine1: "Horizon House",
+        addressLine2: "Deanery Road",
+        townCity: "Bristol",
+        postcode: "BS1 5AH",
+        location: {
+          lat: 0,
+          lon: 0
+        }
+      },
+      {
+        addressType: "POSTAL",
+        houseNumber: "Richard Fairclough House",
+        addressLine1: "Knutsford Road",
+        addressLine2: "Latchford",
+        addressLine3: "",
+        addressLine4: "",
+        townCity: "Warrington",
+        postcode: "WA4 1HT",
+        country: ""
+      }
+    ],
+    keyPeople: [
+      {
+        firstName: "Test",
+        lastName: "Employee",
+        dateOfBirth: 40.years.ago,
+        position: "Partner",
+        personType: "KEY",
+        convictionSearchResult: {
+          matchResult: "NO",
+          searchedAt: DateTime.new,
+          confirmed: "no"
+        }
+      },
+      {
+        firstName: "Another",
+        lastName: "Employee",
+        dateOfBirth: 50.years.ago,
+        position: "Partner",
+        personType: "KEY",
+        convictionSearchResult: {
+          matchResult: "NO",
+          searchedAt: DateTime.new,
+          confirmed: "no"
+        }
+      }
+    ],
+    accountEmail: "user@waste-exemplar.gov.uk",
+    declaredConvictions: "no",
+    declaration: 1,
+    regIdentifier: "CBDU6",
     expires_on: 6.months.from_now,
     metaData: {
       dateRegistered: 30.months.ago,

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -318,6 +318,14 @@ RSpec.describe TransientRegistration, type: :model do
         end
       end
 
+      context "when the business type is partnership" do
+        before(:each) { transient_registration.business_type = "partnership" }
+
+        it "changes to :company_name_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:renewal_information_form).to(:company_name_form).on_event(:next)
+        end
+      end
+
       context "when the business type is soleTrader" do
         before(:each) { transient_registration.business_type = "soleTrader" }
 
@@ -371,6 +379,14 @@ RSpec.describe TransientRegistration, type: :model do
 
         it "changes to :registration_number_form after the 'back' event" do
           expect(transient_registration).to transition_from(:company_name_form).to(:registration_number_form).on_event(:back)
+        end
+      end
+
+      context "when the business type is partnership" do
+        before(:each) { transient_registration.business_type = "partnership" }
+
+        it "changes to :renewal_infromation_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
         end
       end
 

--- a/spec/requests/company_name_forms_spec.rb
+++ b/spec/requests/company_name_forms_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe "CompanyNameForms", type: :request do
             end
           end
 
+          context "when the business type is partnership" do
+            before(:each) { transient_registration.update_attributes(business_type: "partnership") }
+
+            it "redirects to the renewal_information form" do
+              get back_company_name_forms_path(transient_registration[:reg_identifier])
+              expect(response).to redirect_to(new_renewal_information_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
           context "when the business type is soleTrader" do
             before(:each) { transient_registration.update_attributes(business_type: "soleTrader") }
 

--- a/spec/requests/renewal_information_forms_spec.rb
+++ b/spec/requests/renewal_information_forms_spec.rb
@@ -96,6 +96,15 @@ RSpec.describe "RenewalInformationForms", type: :request do
             end
           end
 
+          context "when the business type is partnership" do
+            before(:each) { transient_registration.update_attributes(business_type: "partnership") }
+
+            it "redirects to the company_name form" do
+              post renewal_information_forms_path, renewal_information_form: valid_params
+              expect(response).to redirect_to(new_company_name_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
           context "when the business type is soleTrader" do
             before(:each) { transient_registration.update_attributes(business_type: "soleTrader") }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-149

This story covers setting up a "skeleton" of the happy path for those who would select Partnership on the select org type page. Pages in the skeleton will mostly be blank – just a title and continue button.

This is so we can set up how users move between the pages, and also so we can start testing the process as a whole.

As we continue to work on the stories, these pages will be fleshed out with the proper forms.