### PR TITLE
Add validation to Registrations to ensure regIdentifier is unique

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -2,8 +2,11 @@ class Registration
   include Mongoid::Document
   include CanHaveRegistrationAttributes
 
-  validates :regIdentifier,
+  validates :reg_identifier,
             :addresses,
             :metaData,
             presence: true
+
+  validates :reg_identifier,
+            uniqueness: true
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -9,6 +9,17 @@ RSpec.describe Registration, type: :model do
         expect(registration).to_not be_valid
       end
     end
+
+    context "when a registration has the same reg_identifier as another registration" do
+      let(:registration_a) { create(:registration, :has_required_data) }
+      let(:registration_b) { create(:registration, :has_required_data) }
+
+      before(:each) { registration_b.reg_identifier = registration_a.reg_identifier }
+
+      it "is not valid" do
+        expect(registration_b).to_not be_valid
+      end
+    end
   end
 
   describe "#address" do

--- a/spec/views/registrations/index.html.erb_spec.rb
+++ b/spec/views/registrations/index.html.erb_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe "registrations/index", type: :view do
              create(
                :registration,
                :has_required_data,
-               reg_identifier: "Reg Identifier",
+               reg_identifier: "Reg Identifier 1",
                company_name: "Company Name Index"
              ),
              create(
                :registration,
                :has_required_data,
-               reg_identifier: "Reg Identifier",
+               reg_identifier: "Reg Identifier 2",
                company_name: "Company Name Index"
              )
            ])
@@ -20,7 +20,8 @@ RSpec.describe "registrations/index", type: :view do
 
   it "renders a list of registrations" do
     render
-    assert_select "tr>td", text: "Reg Identifier".to_s, count: 2
+    assert_select "tr>td", text: "Reg Identifier 1".to_s, count: 1
+    assert_select "tr>td", text: "Reg Identifier 2".to_s, count: 1
     assert_select "tr>td", text: "Company Name Index".to_s, count: 2
   end
 end

--- a/spec/views/registrations/new.html.erb_spec.rb
+++ b/spec/views/registrations/new.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "registrations/new", type: :view do
   before(:each) do
     assign(:registration, Registration.new(
-                            reg_identifier: "Reg Identifier",
+                            reg_identifier: "Reg Identifier New",
                             company_name: "Company Name New"
     ))
   end

--- a/spec/views/registrations/show.html.erb_spec.rb
+++ b/spec/views/registrations/show.html.erb_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe "registrations/show", type: :view do
     @registration = assign(:registration, create(
                                             :registration,
                                             :has_required_data,
-                                            reg_identifier: "Reg Identifier",
+                                            reg_identifier: "Reg Identifier Show",
                                             company_name: "Company Name Show"
     ))
   end
 
   it "renders attributes in <p>" do
     render
-    expect(rendered).to match(/Reg Identifier/)
+    expect(rendered).to match(/Reg Identifier Show/)
     expect(rendered).to match(/Company Name Show/)
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-169

The registration number (known as the regIdentifier in the model) is expected to be unique. Validation is in place for TransientRegistrations. This change adds validation for the Registration model as well.