### PR TITLE
Lock the mongo driver version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 ruby "2.4.2"
 
 gem "rails", "4.2.10"
-# Use MongoDB as the database
+# Use MongoDB as the database - we need to support 2.4
+gem "mongo", "2.4.3"
 gem "mongoid", "~> 5.2"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ DEPENDENCIES
   high_voltage (~> 3.0)
   jbuilder (~> 2.0)
   jquery-rails
+  mongo (= 2.4.3)
   mongoid (~> 5.2)
   rails (= 4.2.10)
   rails_12factor
@@ -257,7 +258,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
 
 RUBY VERSION
    ruby 2.4.2p198


### PR DESCRIPTION
Version 2.5.0 of the MongoDB Ruby driver has now been released. This adds support for 3.6 but drops support for 2.4, which we still need to have until our database upgrade is complete.