### PR TITLE
Changing from upper to lower tier exits renewals process

### DIFF
--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -56,7 +56,7 @@ module CanChangeWorkflowStatus
 
         transitions from: :business_type_form,
                     to: :cannot_renew_lower_tier_form,
-                    if: :switch_to_lower_tier?
+                    if: :switch_to_lower_tier_based_on_business_type?
 
         transitions from: :business_type_form,
                     to: :other_businesses_form,
@@ -82,7 +82,15 @@ module CanChangeWorkflowStatus
                     to: :construction_demolition_form
 
         transitions from: :waste_types_form,
+                    to: :cannot_renew_lower_tier_form,
+                    if: :switch_to_lower_tier_based_on_smart_answers?
+
+        transitions from: :waste_types_form,
                     to: :cbd_type_form
+
+        transitions from: :construction_demolition_form,
+                    to: :cannot_renew_lower_tier_form,
+                    if: :switch_to_lower_tier_based_on_smart_answers?
 
         transitions from: :construction_demolition_form,
                     to: :cbd_type_form
@@ -262,8 +270,24 @@ module CanChangeWorkflowStatus
   end
 
   # Charity registrations should be lower tier
-  def switch_to_lower_tier?
+  def switch_to_lower_tier_based_on_business_type?
     business_type == "other"
+  end
+
+  def switch_to_lower_tier_based_on_smart_answers?
+    if other_businesses == false && construction_waste == false
+      true
+    elsif other_businesses == false && construction_waste == true
+      false
+    elsif other_businesses == true && is_main_service == false && construction_waste == false
+      true
+    elsif other_businesses == true && is_main_service == false && construction_waste == true
+      false
+    elsif other_businesses == true && is_main_service == true && only_amf == false
+      false
+    elsif other_businesses == true && is_main_service == true && only_amf == true
+      true
+    end
   end
 
   def only_carries_own_waste?

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -254,11 +254,25 @@ module CanChangeWorkflowStatus
         transitions from: :worldpay_form,
                     to: :payment_summary_form
 
-        transitions from: :cannot_renew_lower_tier_form,
-                    to: :business_type_form
+        # Exit routes from renewals process
 
         transitions from: :cannot_renew_type_change_form,
                     to: :business_type_form
+
+        transitions from: :cannot_renew_lower_tier_form,
+                    to: :business_type_form,
+                    if: :switch_to_lower_tier_based_on_business_type?
+
+        transitions from: :cannot_renew_lower_tier_form,
+                    to: :construction_demolition_form,
+                    if: :only_carries_own_waste?
+
+        transitions from: :cannot_renew_lower_tier_form,
+                    to: :waste_types_form,
+                    if: :waste_is_main_service?
+
+        transitions from: :cannot_renew_lower_tier_form,
+                    to: :construction_demolition_form
       end
     end
   end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -289,19 +289,10 @@ module CanChangeWorkflowStatus
   end
 
   def switch_to_lower_tier_based_on_smart_answers?
-    if other_businesses == false && construction_waste == false
-      true
-    elsif other_businesses == false && construction_waste == true
-      false
-    elsif other_businesses == true && is_main_service == false && construction_waste == false
-      true
-    elsif other_businesses == true && is_main_service == false && construction_waste == true
-      false
-    elsif other_businesses == true && is_main_service == true && only_amf == false
-      false
-    elsif other_businesses == true && is_main_service == true && only_amf == true
-      true
-    end
+    return true if other_businesses == false && construction_waste == false
+    return true if other_businesses == true && is_main_service == false && construction_waste == false
+    return true if other_businesses == true && is_main_service == true && only_amf == true
+    false
   end
 
   def only_carries_own_waste?

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -251,8 +251,6 @@ RSpec.describe TransientRegistration, type: :model do
       end
     end
 
-    # TODO: TESTS
-
     context "when a TransientRegistration's state is :other_businesses_form" do
       let(:transient_registration) do
         create(:transient_registration,
@@ -332,8 +330,28 @@ RSpec.describe TransientRegistration, type: :model do
         end
       end
 
-      it "transitions to :cbd_type_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:construction_demolition_form).to(:cbd_type_form).on_event(:next)
+      context "when the registration should change to lower tier" do
+        before(:each) do
+          transient_registration.other_businesses = true
+          transient_registration.is_main_service = true
+          transient_registration.only_amf = true
+        end
+
+        it "transitions to :cannot_renew_lower_tier_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:construction_demolition_form).to(:cannot_renew_lower_tier_form).on_event(:next)
+        end
+      end
+
+      context "when the registration should stay upper tier" do
+        before(:each) do
+          transient_registration.other_businesses = true
+          transient_registration.is_main_service = true
+          transient_registration.only_amf = false
+        end
+
+        it "transitions to :cbd_type_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:construction_demolition_form).to(:cbd_type_form).on_event(:next)
+        end
       end
     end
 

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -809,5 +809,64 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to_not allow_event :next
       end
     end
+
+    context "when a TransientRegistration's state is :cannot_renew_type_change_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "cannot_renew_type_change_form")
+      end
+
+      it "changes to :business_type_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:cannot_renew_type_change_form).to(:business_type_form).on_event(:back)
+      end
+
+      it "does not respond to the 'next' event" do
+        expect(transient_registration).to_not allow_event :next
+      end
+    end
+
+    context "when a TransientRegistration's state is :cannot_renew_lower_tier_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "cannot_renew_lower_tier_form")
+      end
+
+      context "when the tier change is due to the business type" do
+        before(:each) { transient_registration.business_type = "other" }
+
+        it "changes to :business_type_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:cannot_renew_lower_tier_form).to(:business_type_form).on_event(:back)
+        end
+      end
+
+      context "when the tier change is because the business only deals with certain waste types" do
+        before(:each) do
+          transient_registration.other_businesses = true
+          transient_registration.is_main_service = true
+          transient_registration.only_amf = true
+        end
+
+        it "changes to :waste_types_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:cannot_renew_lower_tier_form).to(:waste_types_form).on_event(:back)
+        end
+      end
+
+      context "when the tier change is because the business doesn't deal with construction waste" do
+        before(:each) do
+          transient_registration.other_businesses = false
+          transient_registration.construction_waste = false
+        end
+
+        it "changes to :construction_demolition_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:cannot_renew_lower_tier_form).to(:construction_demolition_form).on_event(:back)
+        end
+      end
+
+      it "does not respond to the 'next' event" do
+        expect(transient_registration).to_not allow_event :next
+      end
+    end
   end
 end

--- a/spec/requests/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/requests/cannot_renew_lower_tier_forms_spec.rb
@@ -59,9 +59,38 @@ RSpec.describe "CannotRenewLowerTierForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the business_type form" do
-            get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
-            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          context "when the tier change is due to the business type" do
+            before(:each) { transient_registration.update_attributes(business_type: "other") }
+
+            it "redirects to the business_type form" do
+              get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+              expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
+          context "when the tier change is because the business only deals with certain waste types" do
+            before(:each) do
+              transient_registration.update_attributes(other_businesses: true,
+                                                       is_main_service: true,
+                                                       only_amf: true)
+            end
+
+            it "redirects to the waste_types form" do
+              get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+              expect(response).to redirect_to(new_waste_types_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
+          context "when the tier change is because the business doesn't deal with construction waste" do
+            before(:each) do
+              transient_registration.update_attributes(other_businesses: false,
+                                                       construction_waste: false)
+            end
+
+            it "redirects to the construction_demolition form" do
+              get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])
+              expect(response).to redirect_to(new_construction_demolition_form_path(transient_registration[:reg_identifier]))
+            end
           end
         end
       end

--- a/spec/requests/construction_demolition_forms_spec.rb
+++ b/spec/requests/construction_demolition_forms_spec.rb
@@ -71,9 +71,30 @@ RSpec.describe "ConstructionDemolitionForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the cbd_type form" do
-            post construction_demolition_forms_path, construction_demolition_form: valid_params
-            expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:reg_identifier]))
+          context "when the registration should change to lower tier" do
+            before(:each) do
+              transient_registration.update_attributes(other_businesses: false)
+
+              valid_params[:construction_waste] = "false"
+            end
+
+            it "redirects to the cannot_renew_lower_tier form" do
+              post construction_demolition_forms_path, construction_demolition_form: valid_params
+              expect(response).to redirect_to(new_cannot_renew_lower_tier_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
+          context "when the registration should stay upper tier" do
+            before(:each) do
+              transient_registration.update_attributes(other_businesses: false)
+
+              valid_params[:construction_waste] = "true"
+            end
+
+            it "redirects to the cbd_type form" do
+              post construction_demolition_forms_path, construction_demolition_form: valid_params
+              expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:reg_identifier]))
+            end
           end
         end
 

--- a/spec/requests/waste_types_forms_spec.rb
+++ b/spec/requests/waste_types_forms_spec.rb
@@ -71,9 +71,32 @@ RSpec.describe "WasteTypesForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the cbd_type form" do
-            post waste_types_forms_path, waste_types_form: valid_params
-            expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:reg_identifier]))
+          context "when the registration should change to lower tier" do
+            before(:each) do
+              transient_registration.update_attributes(other_businesses: true)
+              transient_registration.update_attributes(is_main_service: true)
+
+              valid_params[:only_amf] = "true"
+            end
+
+            it "redirects to the cannot_renew_lower_tier form" do
+              post waste_types_forms_path, waste_types_form: valid_params
+              expect(response).to redirect_to(new_cannot_renew_lower_tier_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
+          context "when the registration should stay upper tier" do
+            before(:each) do
+              transient_registration.update_attributes(other_businesses: true)
+              transient_registration.update_attributes(is_main_service: true)
+
+              valid_params[:only_amf] = "false"
+            end
+
+            it "redirects to the cbd_type form" do
+              post waste_types_forms_path, waste_types_form: valid_params
+              expect(response).to redirect_to(new_cbd_type_form_path(transient_registration[:reg_identifier]))
+            end
           end
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-94

If the user's responses to the 'smart answers' section of the service indicate that they should have a lower tier registration, they should be informed of this and directed to make a new, free, lower tier registration instead of renewing.