### PR TITLE
Deal with blank `company_no`s correctly.

### DIFF
--- a/app/forms/registration_number_form.rb
+++ b/app/forms/registration_number_form.rb
@@ -12,7 +12,7 @@ class RegistrationNumberForm < BaseForm
     # Assign the params for validation and pass them to the BaseForm method for updating
     # If param isn't set, use a blank string instead to avoid errors with the validator
     self.company_no = params[:company_no] || ""
-    self.company_no = process_company_no(company_no)
+    self.company_no = process_company_no(company_no) if company_no.present?
     attributes = { company_no: company_no }
 
     super(attributes, params[:reg_identifier])

--- a/config/locales/forms/registration_number_forms/en.yml
+++ b/config/locales/forms/registration_number_forms/en.yml
@@ -18,6 +18,7 @@ en:
               inactive: "Your company must be registered as an active company"
               not_found: "Companies House couldn't find a company with this number"
               error: "There was an error with Companies House"
+              blank: "Enter a company registration number"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"


### PR DESCRIPTION
This bug was flagged up in QA. Instead of just asking the user to enter a number, the app was attempting to turn the blank input into a valid number by adding 0s. This resulted in a `company_no` of `00000000`.