### PR TITLE
Changing company's registration number exits renewals process

### DIFF
--- a/app/controllers/cannot_renew_company_no_change_forms_controller.rb
+++ b/app/controllers/cannot_renew_company_no_change_forms_controller.rb
@@ -1,0 +1,8 @@
+class CannotRenewCompanyNoChangeFormsController < FormsController
+  def new
+    super(CannotRenewCompanyNoChangeForm, "cannot_renew_company_no_change_form")
+  end
+
+  # Override this method as user shouldn't be able to "submit" this page
+  def create; end
+end

--- a/app/forms/cannot_renew_company_no_change_form.rb
+++ b/app/forms/cannot_renew_company_no_change_form.rb
@@ -1,0 +1,8 @@
+class CannotRenewCompanyNoChangeForm < BaseForm
+  def initialize(transient_registration)
+    super
+  end
+
+  # Override BaseForm method as users shouldn't be able to submit this form
+  def submit; end
+end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -304,6 +304,9 @@ module CanChangeWorkflowStatus
 
   def require_new_registration_based_on_company_no?
     old_company_no = Registration.where(reg_identifier: reg_identifier).first.company_no.to_s
+    # It was previously valid to have company_nos with less than 8 digits
+    # The form prepends 0s to make up the length, so we should do this for the old number to match
+    old_company_no = "0#{old_company_no}" while old_company_no.length < 8
     old_company_no != company_no
   end
 

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -108,6 +108,10 @@ module CanChangeWorkflowStatus
                     to: :registration_number_form
 
         transitions from: :registration_number_form,
+                    to: :cannot_renew_company_no_change_form,
+                    if: :require_new_registration_based_on_company_no?
+
+        transitions from: :registration_number_form,
                     to: :company_name_form
 
         transitions from: :company_name_form,
@@ -296,6 +300,11 @@ module CanChangeWorkflowStatus
     return true if other_businesses == true && is_main_service == false && construction_waste == false
     return true if other_businesses == true && is_main_service == true && only_amf == true
     false
+  end
+
+  def require_new_registration_based_on_company_no?
+    old_company_no = Registration.where(reg_identifier: reg_identifier).first.company_no.to_s
+    old_company_no != company_no
   end
 
   def only_carries_own_waste?

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -47,7 +47,7 @@ module CanChangeWorkflowStatus
 
       state :cannot_renew_lower_tier_form
       state :cannot_renew_type_change_form
-      state :cannot_renew_reg_number_change_form
+      state :cannot_renew_company_no_change_form
 
       # Transitions
       event :next do
@@ -200,6 +200,9 @@ module CanChangeWorkflowStatus
 
         transitions from: :registration_number_form,
                     to: :renewal_information_form
+
+        transitions from: :cannot_renew_company_no_change_form,
+                    to: :registration_number_form
 
         transitions from: :company_name_form,
                     to: :renewal_information_form,

--- a/app/views/cannot_renew_company_no_change_forms/new.html.erb
+++ b/app/views/cannot_renew_company_no_change_forms/new.html.erb
@@ -1,0 +1,9 @@
+<%= render("shared/back", back_path: back_cannot_renew_company_no_change_forms_path(@cannot_renew_company_no_change_form.reg_identifier)) %>
+
+<div class="text">
+  <h1 class="heading-large"><%= t(".heading", reg_identifier: @cannot_renew_company_no_change_form.reg_identifier) %></h1>
+  <p><%= t(".paragraph_1") %></p>
+  <p><%= t(".paragraph_2", reg_identifier: @cannot_renew_company_no_change_form.reg_identifier) %></p>
+  <p><%= t(".paragraph_3") %></p>
+  <a href="<%= Rails.configuration.wcrs_frontend_url %>/registrations/start" class="button"><%= t(".next_button") %></a>
+</div>

--- a/config/locales/forms/cannot_renew_company_no_change_forms/en.yml
+++ b/config/locales/forms/cannot_renew_company_no_change_forms/en.yml
@@ -1,0 +1,17 @@
+en:
+  cannot_renew_company_no_change_forms:
+    new:
+      heading: You cannot renew %{reg_identifier}
+      paragraph_1: You've told us that your company number has changed.
+      paragraph_2: Because of this change, you cannot renew %{reg_identifier} and instead must make a new registration.
+      paragraph_3: If you have any questions about this, please contact our helpline on 03708 506 506
+      next_button: Start a new registration
+  activemodel:
+    errors:
+      models:
+        cannot_renew_company_no_change_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/cannot_renew_company_no_change_forms/en.yml
+++ b/config/locales/forms/cannot_renew_company_no_change_forms/en.yml
@@ -2,7 +2,7 @@ en:
   cannot_renew_company_no_change_forms:
     new:
       heading: You cannot renew %{reg_identifier}
-      paragraph_1: You've told us that your company number has changed.
+      paragraph_1: Your Companies House registration number has changed, which means the organisation responsible for this registration has changed.
       paragraph_2: Because of this change, you cannot renew %{reg_identifier} and instead must make a new registration.
       paragraph_3: If you have any questions about this, please contact our helpline on 03708 506 506
       next_button: Start a new registration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,4 +272,14 @@ Rails.application.routes.draw do
               as: "back",
               on: :collection
             end
+
+  resources :cannot_renew_company_no_change_forms,
+            only: [:new, :create],
+            path: "cannot-renew-company-no-change",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "cannot_renew_company_no_change_forms#go_back",
+              as: "back",
+              on: :collection
+            end
 end

--- a/spec/cassettes/registration_number_form_changed_company_no.yml
+++ b/spec/cassettes/registration_number_form_changed_company_no.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/01709418
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      Host:
+      - api.companieshouse.gov.uk
+      Authorization:
+      - Basic <COMPANIES_HOUSE_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jan 2018 15:23:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1414'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '597'
+      X-Ratelimit-Reset:
+      - '1517239636'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"registered_office_address":{"locality":"Folkestone","region":"Kent","address_line_1":"Hemsted
+        House Woodland Road","postal_code":"CT18 8DL","address_line_2":"Lyminge"},"accounts":{"last_accounts":{"period_end_on":"2017-02-28","period_start_on":"2016-03-01","made_up_to":"2017-02-28"},"accounting_reference_date":{"day":"28","month":"02"},"overdue":false,"next_due":"2018-11-30","next_made_up_to":"2018-02-28","next_accounts":{"overdue":false,"due_on":"2018-11-30","period_end_on":"2018-02-28","period_start_on":"2017-03-01"}},"company_name":"JIM
+        GARRAHY''S FUDGE KITCHEN LIMITED","date_of_creation":"1983-03-24","sic_codes":["10822"],"undeliverable_registered_office_address":false,"last_full_members_list_date":"2015-11-20","type":"ltd","has_been_liquidated":false,"company_number":"01709418","jurisdiction":"england-wales","has_insolvency_history":false,"etag":"079ea458cdac90941922af7f7742f1d7cdf14cd1","has_charges":true,"company_status":"active","confirmation_statement":{"next_due":"2018-12-04","next_made_up_to":"2018-11-20","overdue":false,"last_made_up_to":"2017-11-20"},"links":{"self":"/company/01709418","filing_history":"/company/01709418/filing-history","officers":"/company/01709418/officers","charges":"/company/01709418/charges","persons_with_significant_control_statements":"/company/01709418/persons-with-significant-control-statements"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Mon, 29 Jan 2018 15:23:57 GMT
+recorded_with: VCR 4.0.0

--- a/spec/factories/forms/cannot_renew_company_no_change_form.rb
+++ b/spec/factories/forms/cannot_renew_company_no_change_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :cannot_renew_company_no_change_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "cannot_renew_company_no_change_form")) }
+    end
+  end
+end

--- a/spec/forms/cannot_renew_company_no_change_forms_spec.rb
+++ b/spec/forms/cannot_renew_company_no_change_forms_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe CannotRenewCompanyNoChangeForm, type: :model do
+  describe "#reg_identifier" do
+    context "when a valid transient registration exists" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "cannot_renew_company_no_change_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:cannot_renew_company_no_change_form) { CannotRenewCompanyNoChangeForm.new(transient_registration) }
+
+      context "when a reg_identifier meets the requirements" do
+        before(:each) do
+          cannot_renew_company_no_change_form.reg_identifier = transient_registration.reg_identifier
+        end
+
+        it "is valid" do
+          expect(cannot_renew_company_no_change_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          cannot_renew_company_no_change_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(cannot_renew_company_no_change_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "cannot_renew_company_no_change_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:cannot_renew_company_no_change_form) { CannotRenewCompanyNoChangeForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        cannot_renew_company_no_change_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(cannot_renew_company_no_change_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        cannot_renew_company_no_change_form.valid?
+        expect(cannot_renew_company_no_change_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/requests/cannot_renew_company_no_change_forms_spec.rb
+++ b/spec/requests/cannot_renew_company_no_change_forms_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "CannotRenewCompanyNoChangeForms", type: :request do
+  describe "GET new_cannot_renew_company_no_change_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "cannot_renew_company_no_change_form")
+        end
+
+        it "returns a success response" do
+          get new_cannot_renew_company_no_change_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_cannot_renew_company_no_change_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_cannot_renew_company_no_change_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "cannot_renew_company_no_change_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_cannot_renew_company_no_change_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the registration_number form" do
+            get back_cannot_renew_company_no_change_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_registration_number_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_cannot_renew_company_no_change_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_cannot_renew_company_no_change_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/registration_number_forms_spec.rb
+++ b/spec/requests/registration_number_forms_spec.rb
@@ -74,6 +74,27 @@ RSpec.describe "RegistrationNumberForms", type: :request do
               expect(response).to redirect_to(new_company_name_form_path(transient_registration[:reg_identifier]))
             end
           end
+
+          context "when the original registration had a shorter variant of the company_no" do
+            before(:each) do
+              registration = Registration.where(reg_identifier: transient_registration.reg_identifier).first
+              registration.update_attributes(company_no: "9360070")
+            end
+
+            it "returns a 302 response" do
+              VCR.use_cassette("registration_number_form_valid_company_no") do
+                post registration_number_forms_path, registration_number_form: valid_params
+                expect(response).to have_http_status(302)
+              end
+            end
+
+            it "redirects to the company_name form" do
+              VCR.use_cassette("registration_number_form_valid_company_no") do
+                post registration_number_forms_path, registration_number_form: valid_params
+                expect(response).to redirect_to(new_company_name_form_path(transient_registration[:reg_identifier]))
+              end
+            end
+          end
         end
 
         context "when valid params are submitted and the company_no is different to the original registration" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-98

If the company's registration number changes, it is considered a new entity. This means the registration cannot be renewed and they must make a new one instead.