### PR TITLE
 Add terms and conditions for Ordnance Survey

### DIFF
--- a/app/views/pages/os-terms.html.erb
+++ b/app/views/pages/os-terms.html.erb
@@ -1,0 +1,11 @@
+<div class="text">
+  <h1 class="heading-large"><%= t(".heading_h1") %></h1>
+  <p><%= t(".paragraph_1") %></p>
+  <p><%= t(".paragraph_2") %></p>
+  <h2 class="heading-medium"><%= t(".heading_h2") %></h2>
+  <ol class="list list-number">
+    <li><%= t(".list_item_1") %></li>
+    <li><%= t(".list_item_2") %></li>
+    <li><%= t(".list_item_3") %></li>
+  </ol>
+</div>

--- a/config/locales/pages/os-terms/en.yml
+++ b/config/locales/pages/os-terms/en.yml
@@ -1,0 +1,10 @@
+en:
+  pages:
+    os-terms:
+      heading_h1: Ordnance Survey terms and conditions
+      paragraph_1: Addressing information and mapping data from Ordnance Survey (OS) is © Crown copyright and database rights 2018 OS 100024198.
+      paragraph_2: Use of this data is subject to the following conditions by way of exception to the standard Open Government Licence (OGL) referred to at the foot of this page.
+      heading_h2: Terms and conditions
+      list_item_1: You are granted a non-exclusive, royalty free revocable licence solely to view the licensed mapping and addressing data for non-commercial purposes for the period during which we make it available.
+      list_item_2: You are not permitted to copy, sub-license, distribute, sell or otherwise make available such data to third parties in any form.
+      list_item_3: Third party rights to enforce the terms of this licence shall be reserved to OS.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-193

We use the Ordnance Survey's address data to look up and fill in addresses based on a user-provided postcode. This means we need to include certain terms and conditions for its use.