### PR TITLE
Validate format of UK postcodes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem "rest-client", "~> 2.0"
 
 gem "secure_headers", "~> 5.0"
 
+gem "uk_postcode", require: false
+
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.6)
       execjs (>= 0.3.0, < 3)
+    uk_postcode (2.1.2)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
@@ -285,10 +286,10 @@ DEPENDENCIES
   spring
   turbolinks
   uglifier (>= 1.3.0)
+  uk_postcode
   vcr (~> 4.0)
   web-console (~> 2.0)
   webmock (~> 3.3)
-
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/app/validators/temp_postcode_validator.rb
+++ b/app/validators/temp_postcode_validator.rb
@@ -1,6 +1,8 @@
+require "uk_postcode"
+
 class TempPostcodeValidator < ActiveModel::Validator
   def validate(record)
-    postcode_returns_results?(record) if value_is_present?(record) && value_is_valid_length?(record)
+    postcode_returns_results?(record) if value_is_present?(record) && value_uses_correct_format?(record)
   end
 
   private
@@ -11,9 +13,9 @@ class TempPostcodeValidator < ActiveModel::Validator
     false
   end
 
-  def value_is_valid_length?(record)
-    return true if record.temp_postcode.length < 11
-    record.errors.add(:temp_postcode, :too_long)
+  def value_uses_correct_format?(record)
+    return true if UKPostcode.parse(record.temp_postcode).full_valid?
+    record.errors.add(:temp_postcode, :wrong_format)
     false
   end
 

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -17,7 +17,7 @@ en:
           attributes:
             temp_postcode:
               blank: "Enter a postcode"
-              too_long: "Enter a valid UK postcode"
+              wrong_format: "Enter a valid UK postcode"
               no_results: "We couldn't find any addresses for that postcode. Check the postcode or enter the address manually."
               os_places_error: "Our address finder isn't working."
             reg_identifier:

--- a/spec/forms/company_postcode_forms_spec.rb
+++ b/spec/forms/company_postcode_forms_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe CompanyPostcodeForm, type: :model do
         end
       end
 
-      context "when a company_postcode is too long" do
+      context "when a company_postcode is in the wrong format" do
         before(:each) do
-          company_postcode_form.temp_postcode = "ABC123DEF567"
+          company_postcode_form.temp_postcode = "foo"
         end
 
         it "is not valid" do


### PR DESCRIPTION
Validate the format of UK postcodes before saving them or sending them to OS Places.

Postcodes must be complete (so BS1 5AH, not just BS1).