### PR TITLE
Change 'other' business type to 'charity or trust'

### DIFF
--- a/app/forms/business_type_form.rb
+++ b/app/forms/business_type_form.rb
@@ -14,10 +14,10 @@ class BusinessTypeForm < BaseForm
     super(attributes, params[:reg_identifier])
   end
 
-  validates :business_type, inclusion: { in: %w[limitedCompany
+  validates :business_type, inclusion: { in: %w[charity
+                                                limitedCompany
                                                 limitedLiabilityPartnership
                                                 localAuthority
-                                                other
                                                 overseas
                                                 partnership
                                                 soleTrader] }

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -320,7 +320,7 @@ module CanChangeWorkflowStatus
 
   # Charity registrations should be lower tier
   def switch_to_lower_tier_based_on_business_type?
-    business_type == "other"
+    business_type == "charity"
   end
 
   def switch_to_lower_tier_based_on_smart_answers?

--- a/app/models/concerns/can_check_business_type_changes.rb
+++ b/app/models/concerns/can_check_business_type_changes.rb
@@ -14,7 +14,7 @@ module CanCheckBusinessTypeChanges
       when "authority"
         matches_allowed_types?(["localAuthority"])
       when "charity"
-        matches_allowed_types?(["other", "overseas"])
+        matches_allowed_types?(["overseas"])
       when "limitedCompany"
         matches_allowed_types?(["limitedLiabilityPartnership", "overseas"])
       when "partnership"

--- a/app/views/business_type_forms/new.html.erb
+++ b/app/views/business_type_forms/new.html.erb
@@ -41,8 +41,8 @@
           <%= f.label :business_type, t(".option_partnership"), value: 'partnership' %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'other' %>
-          <%= f.label :business_type, t(".option_other"), value: 'other' %>
+          <%= f.radio_button :business_type, 'charity' %>
+          <%= f.label :business_type, t(".option_charity"), value: 'charity' %>
         </div>
         <div class="multiple-choice">
           <%= f.radio_button :business_type, 'overseas' %>

--- a/config/locales/forms/business_type_forms/en.yml
+++ b/config/locales/forms/business_type_forms/en.yml
@@ -7,7 +7,7 @@ en:
       option_limited_liability_partnership: Limited liability partnership
       option_individual: Individual (eg a sole trader)
       option_partnership: Partnership
-      option_other: Other organisation (eg a trust, charity or club)
+      option_charity: Charity or trust
       option_overseas: Based overseas
       help: Not sure? Call our helpline on 03708 506 506.
       error_heading: Something is wrong

--- a/db/seeds/CBDU9.json
+++ b/db/seeds/CBDU9.json
@@ -1,11 +1,11 @@
 {
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
-  "businessType": "other",
+  "businessType": "charity",
   "otherBusinesses": "yes",
   "isMainService": "yes",
   "onlyAMF": "no",
-  "companyName": "Other Seed",
+  "companyName": "Charity or Trust Seed",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",

--- a/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe TransientRegistration, type: :model do
           # Permutation table of old business_type, new business_type and the state that should result
           # Example where the business_type doesn't change:
           %w[limitedCompany limitedCompany] => :other_businesses_form,
+          %w[charity charity]               => :cannot_renew_lower_tier_form,
           # Examples where the business_type change is allowed and not allowed:
           %w[authority localAuthority]      => :other_businesses_form,
           %w[authority limitedCompany]      => :cannot_renew_type_change_form,
-          %w[charity other]                 => :cannot_renew_lower_tier_form,
           %w[charity limitedCompany]        => :cannot_renew_type_change_form,
           %w[limitedCompany overseas]       => :other_businesses_form,
           %w[limitedCompany soleTrader]     => :cannot_renew_type_change_form,
@@ -45,6 +45,8 @@ RSpec.describe TransientRegistration, type: :model do
           %w[partnership soleTrader]        => :cannot_renew_type_change_form,
           %w[publicBody localAuthority]     => :other_businesses_form,
           %w[publicBody soleTrader]         => :cannot_renew_type_change_form,
+          %w[soleTrader overseas]           => :other_businesses_form,
+          %w[soleTrader limitedCompany]     => :cannot_renew_type_change_form,
           # Example where the business_type was invalid to begin with:
           %w[foo limitedCompany]            => :cannot_renew_type_change_form
         }.each do |business_types, next_form|

--- a/spec/models/workflow_states/transient_registration_cannot_renew_lower_tier_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_cannot_renew_lower_tier_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TransientRegistration, type: :model do
       end
 
       context "when the tier change is due to the business type" do
-        before(:each) { transient_registration.business_type = "other" }
+        before(:each) { transient_registration.business_type = "charity" }
 
         it "changes to :business_type_form after the 'back' event" do
           expect(transient_registration).to transition_from(:cannot_renew_lower_tier_form).to(:business_type_form).on_event(:back)

--- a/spec/requests/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/requests/cannot_renew_lower_tier_forms_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "CannotRenewLowerTierForms", type: :request do
           end
 
           context "when the tier change is due to the business type" do
-            before(:each) { transient_registration.update_attributes(business_type: "other") }
+            before(:each) { transient_registration.update_attributes(business_type: "charity") }
 
             it "redirects to the business_type form" do
               get back_cannot_renew_lower_tier_forms_path(transient_registration[:reg_identifier])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-202

Charities and trusts are the only ones who should select this option. We should rename this business type so it's clear who this option applies to, rather than it being a catchall.