### PR TITLE
Handle JSON parsing errors for OS Places response

### DIFF
--- a/app/services/address_finder_service.rb
+++ b/app/services/address_finder_service.rb
@@ -14,7 +14,13 @@ class AddressFinderService
         url: @url
       )
 
-      JSON.parse(response)
+      begin
+        JSON.parse(response)
+      rescue JSON::ParserError => e
+        Airbrake.notify(e)
+        Rails.logger.error "OS Places JSON error: " + e.to_s
+        :error
+      end
     rescue RestClient::BadRequest
       Rails.logger.debug "OS Places: resource not found"
       :not_found

--- a/spec/cassettes/company_postcode_form_modified_postcode.yml
+++ b/spec/cassettes/company_postcode_form_modified_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 09 Feb 2018 14:57:25 GMT
+      - Fri, 23 Feb 2018 15:48:24 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAN2Y0W6bMBSGX8XimkoQgoHdkcRtkChEQFpFVS+cxG3QCI4IbKumvftMIS4QNu3CROkuIvEfw7H9n08Hk6ef0p6m8VeSSV8kTTHNsSrJUnHI0qZO4pQcpS9PEgqn9gKB0HZ9j8UfnGnkB44NwihAKJKeZSmn38tHJ4ETRr7L7jnQY76hW1IGQxVAe86CBB/zOH0t59CtkW6wUEqzfFfFVGMEjTK2oUWaZ28sxMSWHEi6JWnu0g1O4rwbjnYZLV53Lzgj1Qje7uM0PuYZzuNvxM4Ibi0sKdPYRb6jGUu2PGxxTmbsVz2c0Tec3OM46Q4ccJbHOGGiaYYMlp4TAV0GUWB7oX8P5v4yRDLoWCSDegHsgrtxLNaTIk62bPce3pfzVMnY0LodbyVnw+XiT5uub+nWRJZo9oqZD8wFmtY3derIZyn263cS6rr5Ly/xhkzoj+YAM5xZsGeO18nKGC3WCZn1VeiX3ERspENo6h+Icc0RW8wdd+FHoTi8NHiGl6FoV4/XyYgaLetGVUTSVeYbDrBGFS8Il6IqOmzAddIcrnA5ebRX4tAaa+edy9KvHq3KhhosUyRV5nBI8dpdDijV0g3V+ACKaw5UNEdgZjvuCkycCIGpfYvE0QWtc7p08+rp6vGkRk0ViZo6HGr9Vb3oW9KEjYMY15y7dwe0m7Hc3bKoI1kPesbo6tHjtgjkjKUbjrRLYzXWtBZWlW5jBYeCatwDlQk/B1RQJFLwPwFKVUzNGjfejyfdBOoBBaETrYB/C8q++ojCqLxG3p1rezOBLavnLGZ+ipb1d4cEgTcccv9S48s2OctsN7l3zZnkm5oFKzB1ke2x1Qvscuefm9C0rp7DXlfqc5shsvkZw5H4p8pelj6l/f9GpRv0BXeOB+59D63Awp0K/FzQz8GD198Au4bUzI1EMjcakrmzeg6K2/NvwFnliLMVAAA=
     http_version: 
-  recorded_at: Fri, 09 Feb 2018 15:04:53 GMT
+  recorded_at: Fri, 23 Feb 2018 15:48:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_postcode_form_no_matches_postcode.yml
+++ b/spec/cassettes/company_postcode_form_no_matches_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Fri, 09 Feb 2018 15:02:31 GMT
+      - Fri, 23 Feb 2018 15:48:24 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -30,5 +30,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":{"message":"Parameters are not valid","statuscode":400}}'
     http_version: 
-  recorded_at: Fri, 09 Feb 2018 15:09:59 GMT
+  recorded_at: Fri, 23 Feb 2018 15:48:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_postcode_form_valid_postcode.yml
+++ b/spec/cassettes/company_postcode_form_valid_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 09 Feb 2018 14:45:03 GMT
+      - Fri, 23 Feb 2018 14:54:15 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAOWUUW+bMBDHv4rlZx6gaULWN1NQE42aypBNXdUHJziJNbCRMduqad+9x8JSIN1LlU2T9oDA/7PvfP/7iYfvuNRKfhYGX2HPdd95/sydXbrYwU1l1IlYSCVqfPWAF4TdphFFNyxZ3UEgjAiN2D1iCQnxo4Ot/tqeDtgyzZIYNlS6thudi1ZMPTQlCxAFr61UO9Am07k3aSsobez+oHn+xWzug7bRjbLmCSRY5KISKhfKxnrDC2nHcrY3utntt9yIQ4TnpVSytoZb+UUQI/jgYkWbhjR2rw0kW1U5tyKE53DY6Cde3HJZjAMVN1byAhYDKxyUsWUSJikKCH3voL4vDuqqwsfRgrpZB40scmiZ8rJLvh4q/ZQQba/6q8Vux8B+B2uz49AyNKxVt2M8sGOJplz/nH43o2S7lRsR6G/9AJgL7Zbg7ssdc92sCxG+No0fTh+ryaXrebMXoo7rI0yUZCtGYhTRm5jQ8Dw4XbjTE5x8d/7P4zQyw0GLhC0/JRTeqzQ6E1GDnG9F6nRsfxkqfwSV34cqW7DlhwixiEYfSRBHKbqLr//vP9WrlpyJqLdC9Lsx/VGUHp8B5v82jvgGAAA=
     http_version: 
-  recorded_at: Fri, 09 Feb 2018 14:52:32 GMT
+  recorded_at: Fri, 23 Feb 2018 14:54:15 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/address_finder_service_spec.rb
+++ b/spec/services/address_finder_service_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe AddressFinderService do
+  let(:address_finder_service) { AddressFinderService.new("BS1 5AH") }
+
+  context "when the response can be parsed as JSON" do
+    it "returns the parsed JSON" do
+      VCR.use_cassette("company_postcode_form_valid_postcode") do
+        expect(address_finder_service.search_by_postcode.first["postcode"]).to include("BS1 5AH")
+      end
+    end
+  end
+
+  context "when the response cannot be parsed as JSON" do
+    before do
+      allow_any_instance_of(RestClient::Request).to receive(:execute).and_return("foo")
+    end
+
+    it "returns :error" do
+      expect(address_finder_service.search_by_postcode).to eq(:error)
+    end
+  end
+
+  context "When OS Places returns a bad request error" do
+    let(:address_finder_service) { AddressFinderService.new("AA1 1AA") }
+
+    it "returns :not_found" do
+      VCR.use_cassette("company_postcode_form_no_matches_postcode") do
+        expect(address_finder_service.search_by_postcode).to eq(:not_found)
+      end
+    end
+  end
+
+  context "When OS Places returns an exception with response" do
+    before do
+      allow_any_instance_of(Rails.configuration).to receive(:execute).and_return(RestClient::ExceptionWithResponse)
+    end
+
+    skip "returns :error" do
+      expect(address_finder_service.search_by_postcode).to eq(:error)
+    end
+  end
+
+  context "When OS Places returns a socket error" do
+    before do
+      allow_any_instance_of(RestClient::Request).to receive(:execute).and_return(SocketError)
+    end
+
+    skip "returns :error" do
+      expect(address_finder_service.search_by_postcode).to eq(:error)
+    end
+  end
+end

--- a/spec/services/address_finder_service_spec.rb
+++ b/spec/services/address_finder_service_spec.rb
@@ -30,24 +30,4 @@ RSpec.describe AddressFinderService do
       end
     end
   end
-
-  context "When OS Places returns an exception with response" do
-    before do
-      allow_any_instance_of(Rails.configuration).to receive(:execute).and_return(RestClient::ExceptionWithResponse)
-    end
-
-    skip "returns :error" do
-      expect(address_finder_service.search_by_postcode).to eq(:error)
-    end
-  end
-
-  context "When OS Places returns a socket error" do
-    before do
-      allow_any_instance_of(RestClient::Request).to receive(:execute).and_return(SocketError)
-    end
-
-    skip "returns :error" do
-      expect(address_finder_service.search_by_postcode).to eq(:error)
-    end
-  end
 end


### PR DESCRIPTION
If we get a valid response from OS Places but the JSON is not parseable, rescue the error and return an :error response from the AddressFinderService.