### PR TITLE
Clarify postcode is optional for overseas users

### DIFF
--- a/app/forms/company_address_manual_form.rb
+++ b/app/forms/company_address_manual_form.rb
@@ -39,6 +39,7 @@ class CompanyAddressManualForm < BaseForm
   validates :address_line_1, presence: true, length: { maximum: 160 }
   validates :address_line_2, length: { maximum: 70 }
   validates :town_city, presence: true, length: { maximum: 30 }
+  validates :postcode, length: { maximum: 30 }
   validates :country, presence: true, if: :overseas?
 
   def overseas?

--- a/app/views/company_address_manual_forms/new.html.erb
+++ b/app/views/company_address_manual_forms/new.html.erb
@@ -15,7 +15,7 @@
 
     <% unless @company_address_manual_form.overseas? %>
       <div class="form-group">
-        <label class="form-label"><%= t(".postcode_label") %></label>
+        <label class="form-label"><%= t(".preset_postcode_label") %></label>
         <span class="postcode"><%= @company_address_manual_form.postcode %></span>
         <%= link_to(t(".postcode_change_link"), back_company_address_manual_forms_path(@company_address_manual_form.reg_identifier)) %>
       </div>

--- a/config/locales/forms/company_address_manual_forms/en.yml
+++ b/config/locales/forms/company_address_manual_forms/en.yml
@@ -14,7 +14,8 @@ en:
       address_line_1_label: Address line 1
       address_line_2_label: Address line 2 (optional)
       town_city_label: Town or city
-      postcode_label: Postcode
+      postcode_label: Postcode (optional)
+      preset_postcode_label: Postcode
       postcode_change_link: Change
       country_label: Country
       error_heading: Something is wrong

--- a/spec/forms/company_address_manual_forms_spec.rb
+++ b/spec/forms/company_address_manual_forms_spec.rb
@@ -186,6 +186,18 @@ RSpec.describe CompanyAddressManualForm, type: :model do
       end
     end
 
+    describe "#postcode" do
+      context "when the postcode is too long" do
+        before(:each) do
+          company_address_manual_form.postcode = "4jhjdq46425oqers8r0b0xejkl19bapc"
+        end
+
+        it "is not valid" do
+          expect(company_address_manual_form).to_not be_valid
+        end
+      end
+    end
+
     describe "#country" do
       context "when the country is blank" do
         before(:each) do


### PR DESCRIPTION
Just add some "optional" text to the label. Also add some validations on postcode length as we had none.