### PR TITLE
Add character limit for country names

### DIFF
--- a/app/forms/company_address_manual_form.rb
+++ b/app/forms/company_address_manual_form.rb
@@ -41,6 +41,7 @@ class CompanyAddressManualForm < BaseForm
   validates :town_city, presence: true, length: { maximum: 30 }
   validates :postcode, length: { maximum: 30 }
   validates :country, presence: true, if: :overseas?
+  validates :country, length: { maximum: 255 }
 
   def overseas?
     business_type == "overseas"

--- a/spec/forms/company_address_manual_forms_spec.rb
+++ b/spec/forms/company_address_manual_forms_spec.rb
@@ -224,6 +224,16 @@ RSpec.describe CompanyAddressManualForm, type: :model do
           end
         end
       end
+
+      context "when the country is too long" do
+        before(:each) do
+          company_address_manual_form.country = "GTR9I5VBRXUA0YW081EV9Q3EKUT08L5MQAUJ6TAR0GXHS4DPGCS83S0J8NHJM4ZLWSPULG24707RAIB1A68UHNHKMB6GTC5O7QNGRB97RI2DD61G6TKU4YY8013HTDVILLM87QJXPJZNN3UWU7M9H3AI1CHVU4166K0UDNL1PF8FYNMVJHWXGK79RPIBRREKNJJOHTW3E6ZA2DA77PRQYFXWHOL2KXCO6QLBW9K8KC4LJNHZAJZT81CRM4IJKFY2"
+        end
+
+        it "is not valid" do
+          expect(company_address_manual_form).to_not be_valid
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This is capped at 255 for now, but may be changed after consulting with a content designer.