### PR TITLE
Add missing validation messages, update max country length

### DIFF
--- a/app/forms/company_address_manual_form.rb
+++ b/app/forms/company_address_manual_form.rb
@@ -41,7 +41,7 @@ class CompanyAddressManualForm < BaseForm
   validates :town_city, presence: true, length: { maximum: 30 }
   validates :postcode, length: { maximum: 30 }
   validates :country, presence: true, if: :overseas?
-  validates :country, length: { maximum: 255 }
+  validates :country, length: { maximum: 50 }
 
   def overseas?
     business_type == "overseas"

--- a/config/locales/forms/company_address_manual_forms/en.yml
+++ b/config/locales/forms/company_address_manual_forms/en.yml
@@ -36,8 +36,11 @@ en:
             town_city:
               blank: "Enter a town or city"
               too_long: "The town or city must be no longer than 30 characters"
+            postcode:
+              too_long: "The postcode must be no longer than 30 characters"
             country:
               blank: "Enter a country"
+              too_long: "The country must be no longer than 50 characters"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/spec/forms/company_address_manual_forms_spec.rb
+++ b/spec/forms/company_address_manual_forms_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe CompanyAddressManualForm, type: :model do
 
       context "when the country is too long" do
         before(:each) do
-          company_address_manual_form.country = "GTR9I5VBRXUA0YW081EV9Q3EKUT08L5MQAUJ6TAR0GXHS4DPGCS83S0J8NHJM4ZLWSPULG24707RAIB1A68UHNHKMB6GTC5O7QNGRB97RI2DD61G6TKU4YY8013HTDVILLM87QJXPJZNN3UWU7M9H3AI1CHVU4166K0UDNL1PF8FYNMVJHWXGK79RPIBRREKNJJOHTW3E6ZA2DA77PRQYFXWHOL2KXCO6QLBW9K8KC4LJNHZAJZT81CRM4IJKFY2"
+          company_address_manual_form.country = "f8x4jhjdq46425oqers8r0b0xejkl19bapc4jhjdq46425oqers"
         end
 
         it "is not valid" do


### PR DESCRIPTION
- Add missing messages for too-long postcodes and country names
- Change max length of country to 50 characters after consulting with content designer