### PR TITLE
 Generate relative dates for seed files

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,10 +5,17 @@
 # remains in that state without having to manually update the dates.
 
 def registered_date(flag)
+  # Resetting variables here so it's easier to read calculations below
+  expires_after = Rails.configuration.expires_after
+  renewal_window = Rails.configuration.renewal_window
+
   dates = {
-    expired: 37.months.ago,
-    in_renewal_window: 35.months.ago,
-    outside_renewal_window: 12.months.ago
+    # Registration should have expired 1 month ago
+    expired: expires_after.years.ago - 1.month,
+    # Registration should be halfway through the renewal window
+    in_renewal_window: expires_after.years.ago + (renewal_window / 2).months,
+    # Registration is not yet in the renewal window
+    outside_renewal_window: expires_after.years.ago + (renewal_window * 2).months
   }
 
   dates[flag.to_sym] || Date.today

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,29 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+# This file adds seeds by parsing the JSON files in the db/seeds/ folder.
+
+# If a "date_flag" is set for a seed, we generate the dates dynamically.
+# This ensures a seed which is always intended to be in a time-sensitive state
+# remains in that state without having to manually update the dates.
+
+def registered_date(flag)
+  dates = {
+    expired: 37.months.ago,
+    in_renewal_window: 35.months.ago,
+    outside_renewal_window: 12.months.ago
+  }
+
+  dates[flag.to_sym] || Date.today
+end
+
+def parse_dates(seed, date)
+  seed["metaData"]["dateRegistered"] = date
+  seed["metaData"]["lastModified"] = date
+  seed["metaData"]["dateActivated"] = date
+  seed["convictionSearchResult"]["searchedAt"] = date
+  seed["expires_on"] = date + 3.years
+  seed["keyPeople"].each do |key_person|
+    key_person["convictionSearchResult"]["searchedAt"] = date
+  end
+end
 
 # Only seed if not running in production or we specifically require it, eg. for Heroku
 if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
@@ -16,6 +35,12 @@ if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
   seeds = []
   Dir.glob("#{Rails.root}/db/seeds/*.json").each do |file|
     seeds << JSON.parse(File.read(file))
+  end
+
+  seeds.each do |seed|
+    next unless seed["date_flag"].present?
+    parse_dates(seed, registered_date(seed["date_flag"]))
+    seed.delete("date_flag")
   end
 
   # Sort seeds to list ones with regIdentifiers first

--- a/db/seeds/CBDU1.json
+++ b/db/seeds/CBDU1.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "limitedCompany",
@@ -44,7 +45,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -52,19 +52,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU1",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU10.json
+++ b/db/seeds/CBDU10.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "partnership",
@@ -43,7 +44,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     },
@@ -55,7 +55,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     }
@@ -64,19 +63,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU10",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU11.json
+++ b/db/seeds/CBDU11.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "overseas",
@@ -46,7 +47,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     }
@@ -55,19 +55,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU11",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU12.json
+++ b/db/seeds/CBDU12.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "overseas",
@@ -46,7 +47,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     }
@@ -55,19 +55,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU12",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU13.json
+++ b/db/seeds/CBDU13.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "soleTrader",
@@ -43,7 +44,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -51,19 +51,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU13",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU14.json
+++ b/db/seeds/CBDU14.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "partnership",
@@ -43,7 +44,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     },
@@ -55,7 +55,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     }
@@ -64,19 +63,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU14",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU15.json
+++ b/db/seeds/CBDU15.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "limitedCompany",
@@ -44,7 +45,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -52,19 +52,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU15",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU16.json
+++ b/db/seeds/CBDU16.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "limitedCompany",
@@ -44,7 +45,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -52,19 +52,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU16",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU2.json
+++ b/db/seeds/CBDU2.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "limitedCompany",
@@ -44,7 +45,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -54,17 +54,13 @@
   "regIdentifier": "CBDU2",
   "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU3.json
+++ b/db/seeds/CBDU3.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "soleTrader",
@@ -43,7 +44,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -51,19 +51,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU3",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU4.json
+++ b/db/seeds/CBDU4.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "broker_dealer",
   "businessType": "partnership",
@@ -43,7 +44,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     },
@@ -55,7 +55,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     }
@@ -64,19 +63,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU4",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU5.json
+++ b/db/seeds/CBDU5.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "soleTrader",
@@ -43,7 +44,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -51,19 +51,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU5",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU6.json
+++ b/db/seeds/CBDU6.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "soleTrader",
@@ -43,7 +44,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -51,19 +51,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU6",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU7.json
+++ b/db/seeds/CBDU7.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "localAuthority",
@@ -43,7 +44,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -51,19 +51,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU7",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU8.json
+++ b/db/seeds/CBDU8.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "limitedLiabilityPartnership",
@@ -44,7 +45,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     },
@@ -56,7 +56,6 @@
       "personType": "KEY",
       "convictionSearchResult": {
         "matchResult": "NO",
-        "searchedAt": "2015-07-16 00:00:00Z",
         "confirmed": "no"
       }
     }
@@ -65,19 +64,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU8",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }

--- a/db/seeds/CBDU9.json
+++ b/db/seeds/CBDU9.json
@@ -1,4 +1,5 @@
 {
+  "date_flag": "in_renewal_window",
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
   "businessType": "charity",
@@ -43,7 +44,6 @@
     "personType": "KEY",
     "convictionSearchResult": {
       "matchResult": "NO",
-      "searchedAt": "2015-07-16 00:00:00Z",
       "confirmed": "no"
     }
   }],
@@ -51,19 +51,14 @@
   "declaredConvictions": "no",
   "declaration": 1,
   "regIdentifier": "CBDU9",
-  "expires_on": "2018-07-15 00:00:00Z",
   "metaData": {
-    "dateRegistered": "2015-07-15 00:00:00Z",
     "anotherString": "userDetailAddedAtRegistration",
-    "lastModified": "2015-07-16 00:00:00Z",
-    "dateActivated": "2015-07-16 00:00:00Z",
     "status": "ACTIVE",
     "route": "DIGITAL",
     "distance": "n/a"
   },
   "convictionSearchResult": {
     "matchResult": "NO",
-    "searchedAt": "2015-07-16 00:00:00Z",
     "confirmed": "no"
   }
 }


### PR DESCRIPTION
When seeding registrations, we sometimes want their dates to be relative to the current date (eg 3 months ago) as opposed to a specific date (eg 26 February 2018). This change lets us specify relative dates in seed data and parse the seed data appropriately.

When we parse each JSON seed, check to see if the JSON's `date_flag` is set and then generate all time-sensitive dates based on the flag. Options are expired, in the renewal window or outside the renewal window.

If no `date_flag` is set, the script will load whichever dates are provided in the seed data.