### PR TITLE
Add a key person

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@
 
 // Custom styles
 @import 'partials/addresses';
+@import 'partials/dates';
 @import 'partials/footer';
 
 main {

--- a/app/assets/stylesheets/partials/_dates.scss
+++ b/app/assets/stylesheets/partials/_dates.scss
@@ -1,0 +1,8 @@
+// Inline date fields
+.inline-date {
+  display: inline-block;
+  width: auto;
+}
+.inline-date input {
+  width: 3.5em;
+}

--- a/app/forms/key_people_form.rb
+++ b/app/forms/key_people_form.rb
@@ -41,7 +41,7 @@ class KeyPeopleForm < BaseForm
   end
 
   def old_enough?
-    return unless date_of_birth.present?
+    return false unless date_of_birth.present?
 
     age_limits = {
       limitedCompany: 16.years,
@@ -57,5 +57,6 @@ class KeyPeopleForm < BaseForm
 
     error_message = "age_limit_#{business_type}".to_sym
     errors.add(:date_of_birth, error_message)
+    false
   end
 end

--- a/app/forms/key_people_form.rb
+++ b/app/forms/key_people_form.rb
@@ -27,7 +27,7 @@ class KeyPeopleForm < BaseForm
   validates :first_name, presence: true, length: { maximum: 35 }
   validates :last_name, presence: true, length: { maximum: 35 }
   validate :old_enough?
-  validates_with DobValidator
+  validates_with DateOfBirthValidator
 
   private
 

--- a/app/forms/key_people_form.rb
+++ b/app/forms/key_people_form.rb
@@ -21,6 +21,10 @@ class KeyPeopleForm < BaseForm
     super(attributes, params[:reg_identifier])
   end
 
+  validates :first_name, presence: true, length: { maximum: 35 }
+  validates :last_name, presence: true, length: { maximum: 35 }
+  validates_with DobValidator
+
   private
 
   def add_key_person

--- a/app/forms/key_people_form.rb
+++ b/app/forms/key_people_form.rb
@@ -1,5 +1,6 @@
 class KeyPeopleForm < BaseForm
   attr_accessor :business_type
+  attr_accessor :first_name, :last_name, :dob_day, :dob_month, :dob_year
 
   def initialize(transient_registration)
     super
@@ -9,10 +10,25 @@ class KeyPeopleForm < BaseForm
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    # TODO: Define allowed params, eg self.field = params[:field]
-    # TODO: Include attributes to update in the attributes hash, eg { field: field }
-    attributes = {}
+    self.first_name = params[:first_name]
+    self.last_name = params[:last_name]
+    self.dob_day = params[:dob_day].to_i
+    self.dob_month = params[:dob_month].to_i
+    self.dob_year = params[:dob_year].to_i
+
+    attributes = { keyPeople: add_key_person }
 
     super(attributes, params[:reg_identifier])
+  end
+
+  private
+
+  def add_key_person
+    [KeyPerson.new(first_name: first_name,
+                   last_name: last_name,
+                   dob_day: dob_day,
+                   dob_month: dob_month,
+                   dob_year: dob_year,
+                   person_type: "key")]
   end
 end

--- a/app/forms/key_people_form.rb
+++ b/app/forms/key_people_form.rb
@@ -1,6 +1,6 @@
 class KeyPeopleForm < BaseForm
   attr_accessor :business_type
-  attr_accessor :first_name, :last_name, :dob_day, :dob_month, :dob_year, :date_of_birth
+  attr_accessor :first_name, :last_name, :dob_day, :dob_month, :dob_year, :key_person, :date_of_birth
 
   def initialize(transient_registration)
     super
@@ -16,7 +16,7 @@ class KeyPeopleForm < BaseForm
     self.dob_month = params[:dob_month].to_i
     self.dob_year = params[:dob_year].to_i
 
-    key_person = add_key_person
+    self.key_person = add_key_person
     self.date_of_birth = key_person.date_of_birth
 
     attributes = { keyPeople: [key_person] }

--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -20,9 +20,12 @@ class KeyPerson
   private
 
   def set_date_of_birth
-    return unless dob_year.present? && dob_year.positive?
-    return unless dob_month.present? && dob_month.positive?
-    return unless dob_day.present? && dob_day.positive?
-    self.date_of_birth = Date.new(dob_year, dob_month, dob_day)
+    begin
+      self.date_of_birth = Date.new(dob_year, dob_month, dob_day)
+    rescue NoMethodError
+      errors.add(:date_of_birth, :invalid_date)
+    rescue ArgumentError
+      errors.add(:date_of_birth, :invalid_date)
+    end
   end
 end

--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -6,17 +6,23 @@ class KeyPerson
 
   accepts_nested_attributes_for :convictionSearchResult
 
-  # TODO: Confirm types
+  after_initialize :set_date_of_birth
+
   field :firstName, as: :first_name,       type: String
   field :lastName, as: :last_name,         type: String
   field :position,                         type: String
-  # Do we need all these date fields? TODO: Compare against existing DB
   field :dob_day,                          type: Integer
   field :dob_month,                        type: Integer
   field :dob_year,                         type: Integer
   field :dateOfBirth, as: :date_of_birth,  type: DateTime
-  field :personType, as: :person_type,     type: String # "Key" by default, but why would you add an irrelevant person?
+  field :personType, as: :person_type,     type: String
 
-  validates :first_name, :last_name, :position, :date_of_birth, :person_type,
-            presence: true
+  private
+
+  def set_date_of_birth
+    return unless dob_year.present? && dob_year.positive?
+    return unless dob_month.present? && dob_month.positive?
+    return unless dob_day.present? && dob_day.positive?
+    self.date_of_birth = Date.new(dob_year, dob_month, dob_day)
+  end
 end

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -42,7 +42,8 @@ class TransientRegistration
                                                      "isMainService",
                                                      "constructionWaste",
                                                      "onlyAMF",
-                                                     "addresses"))
+                                                     "addresses",
+                                                     "keyPeople"))
   end
 
   # Check if a transient renewal already exists for this registration so we don't have

--- a/app/validators/date_of_birth_validator.rb
+++ b/app/validators/date_of_birth_validator.rb
@@ -1,4 +1,4 @@
-class DobValidator < ActiveModel::Validator
+class DateOfBirthValidator < ActiveModel::Validator
   def validate(record)
     fields = { day: record.dob_day, month: record.dob_month, year: record.dob_year }
 

--- a/app/validators/date_of_birth_validator.rb
+++ b/app/validators/date_of_birth_validator.rb
@@ -21,12 +21,14 @@ class DateOfBirthValidator < ActiveModel::Validator
     return true unless field.blank?
     error_message = "#{type}_blank".to_sym
     record.errors.add(:date_of_birth, error_message)
+    false
   end
 
   def field_is_integer?(record, type, field)
     return true if field.is_a? Integer
     error_message = "#{type}_integer".to_sym
     record.errors.add(:date_of_birth, error_message)
+    false
   end
 
   def field_is_in_correct_range?(record, type, field)
@@ -39,10 +41,12 @@ class DateOfBirthValidator < ActiveModel::Validator
     return true if ranges[type].include?(field)
     error_message = "#{type}_range".to_sym
     record.errors.add(:date_of_birth, error_message)
+    false
   end
 
   def dob_is_a_date?(record)
     return true if record.date_of_birth.is_a? Date
     record.errors.add(:date_of_birth, :not_a_date)
+    false
   end
 end

--- a/app/validators/dob_validator.rb
+++ b/app/validators/dob_validator.rb
@@ -5,6 +5,8 @@ class DobValidator < ActiveModel::Validator
     fields.each do |type, field|
       validate_field(record, type, field)
     end
+
+    dob_is_a_date?(record)
   end
 
   private
@@ -34,5 +36,10 @@ class DobValidator < ActiveModel::Validator
 
     return true if ranges[type].include?(field)
     record.errors.add(type, :range)
+  end
+
+  def dob_is_a_date?(record)
+    return true if record.date_of_birth.is_a? Date
+    record.errors.add(:date_of_birth, :not_a_date)
   end
 end

--- a/app/validators/dob_validator.rb
+++ b/app/validators/dob_validator.rb
@@ -1,6 +1,6 @@
 class DobValidator < ActiveModel::Validator
   def validate(record)
-    fields = { dob_day: record.dob_day, dob_month: record.dob_month, dob_year: record.dob_year }
+    fields = { day: record.dob_day, month: record.dob_month, year: record.dob_year }
 
     fields.each do |type, field|
       validate_field(record, type, field)
@@ -19,23 +19,26 @@ class DobValidator < ActiveModel::Validator
 
   def field_present?(record, type, field)
     return true unless field.blank?
-    record.errors.add(type, :blank)
+    error_message = "#{type}_blank".to_sym
+    record.errors.add(:date_of_birth, error_message)
   end
 
   def field_is_integer?(record, type, field)
     return true if field.is_a? Integer
-    record.errors.add(type, :integer)
+    error_message = "#{type}_integer".to_sym
+    record.errors.add(:date_of_birth, error_message)
   end
 
   def field_is_in_correct_range?(record, type, field)
     ranges = {
-      dob_day: 1..31,
-      dob_month: 1..12,
-      dob_year: 1900..(Date.today.year.to_i)
+      day: 1..31,
+      month: 1..12,
+      year: 1900..(Date.today.year.to_i)
     }
 
     return true if ranges[type].include?(field)
-    record.errors.add(type, :range)
+    error_message = "#{type}_range".to_sym
+    record.errors.add(:date_of_birth, error_message)
   end
 
   def dob_is_a_date?(record)

--- a/app/validators/dob_validator.rb
+++ b/app/validators/dob_validator.rb
@@ -1,0 +1,38 @@
+class DobValidator < ActiveModel::Validator
+  def validate(record)
+    fields = { dob_day: record.dob_day, dob_month: record.dob_month, dob_year: record.dob_year }
+
+    fields.each do |type, field|
+      validate_field(record, type, field)
+    end
+  end
+
+  private
+
+  def validate_field(record, type, field)
+    return unless field_present?(record, type, field)
+    return unless field_is_integer?(record, type, field)
+    field_is_in_correct_range?(record, type, field)
+  end
+
+  def field_present?(record, type, field)
+    return true unless field.blank?
+    record.errors.add(type, :blank)
+  end
+
+  def field_is_integer?(record, type, field)
+    return true if field.is_a? Integer
+    record.errors.add(type, :integer)
+  end
+
+  def field_is_in_correct_range?(record, type, field)
+    ranges = {
+      dob_day: 1..31,
+      dob_month: 1..12,
+      dob_year: 1900..(Date.today.year.to_i)
+    }
+
+    return true if ranges[type].include?(field)
+    record.errors.add(type, :range)
+  end
+end

--- a/app/views/key_people_forms/new.html.erb
+++ b/app/views/key_people_forms/new.html.erb
@@ -6,6 +6,11 @@
 
     <h1 class="heading-large"><%= t(".heading_#{@key_people_form.business_type}") %></h1>
 
+    <p><%= t(".description_1_#{@key_people_form.business_type}") %></p>
+    <% unless @key_people_form.business_type == "soleTrader" %>
+      <p><%= t(".description_2") %></p>
+    <% end %>
+
     <% if @key_people_form.errors[:first_name].any? %>
     <div class="form-group form-group-error">
     <% else %>
@@ -36,52 +41,47 @@
       </fieldset>
     </div>
 
-    <% if @key_people_form.errors[:dob_year].any? %>
+    <% if @key_people_form.errors[:date_of_birth].any? %>
     <div class="form-group form-group-error">
     <% else %>
     <div class="form-group">
     <% end %>
-      <fieldset id="dob_year">
-        <% if @key_people_form.errors[:dob_year].any? %>
-        <span class="error-message"><%= @key_people_form.errors[:dob_year].join(", ") %></span>
+      <fieldset id="date_of_birth">
+        <% if @key_people_form.errors[:date_of_birth].any? %>
+          <span class="error-message"><%= @key_people_form.errors[:date_of_birth].join(". ") %></span>
         <% end %>
 
-        <%= f.label :dob_year, t(".dob_year"), class: "form-label" %>
-        <%= f.text_field :dob_year, value: @key_people_form.dob_year, class: "form-control" %>
-      </fieldset>
-    </div>
+        <legend>
+          <%= t(".date_of_birth") %>
+          <span class="form-hint"><%= t(".date_of_birth_hint") %></span>
+        </legend>
 
-    <% if @key_people_form.errors[:dob_month].any? %>
-    <div class="form-group form-group-error">
-    <% else %>
-    <div class="form-group">
-    <% end %>
-      <fieldset id="dob_month">
-        <% if @key_people_form.errors[:dob_month].any? %>
-        <span class="error-message"><%= @key_people_form.errors[:dob_month].join(", ") %></span>
-        <% end %>
+        <fieldset id="dob_day" class="inline-date">
+          <%= f.label :dob_day, t(".dob_day"), class: "form-label" %>
+          <%= f.text_field :dob_day, value: @key_people_form.dob_day, class: "form-control" %>
+        </fieldset>
 
-        <%= f.label :dob_month, t(".dob_month"), class: "form-label" %>
-        <%= f.text_field :dob_month, value: @key_people_form.dob_month, class: "form-control" %>
-      </fieldset>
-    </div>
+        <fieldset id="dob_month" class="inline-date">
+          <%= f.label :dob_month, t(".dob_month"), class: "form-label" %>
+          <%= f.text_field :dob_month, value: @key_people_form.dob_month, class: "form-control" %>
+        </fieldset>
 
-    <% if @key_people_form.errors[:dob_day].any? %>
-    <div class="form-group form-group-error">
-    <% else %>
-    <div class="form-group">
-    <% end %>
-      <fieldset id="dob_day">
-        <% if @key_people_form.errors[:dob_day].any? %>
-        <span class="error-message"><%= @key_people_form.errors[:dob_day].join(", ") %></span>
-        <% end %>
+        <fieldset id="dob_year" class="inline-date">
+          <%= f.label :dob_year, t(".dob_year"), class: "form-label" %>
+          <%= f.text_field :dob_year, value: @key_people_form.dob_year, class: "form-control" %>
+        </fieldset>
 
-        <%= f.label :dob_day, t(".dob_day"), class: "form-label" %>
-        <%= f.text_field :dob_day, value: @key_people_form.dob_day, class: "form-control" %>
       </fieldset>
     </div>
 
     <%= f.hidden_field :reg_identifier, value: @key_people_form.reg_identifier %>
+
+    <% unless @key_people_form.business_type == "soleTrader" %>
+      <div class="form-group">
+        <a href="#"><%= t(".add_another") %></a>
+      </div>
+    <% end %>
+
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>
     </div>

--- a/app/views/key_people_forms/new.html.erb
+++ b/app/views/key_people_forms/new.html.erb
@@ -1,24 +1,89 @@
 <%= render("shared/back", back_path: back_key_people_forms_path(@key_people_form.reg_identifier)) %>
 
-<% if @key_people_form.errors.any? %>
-
-  <h1 class="heading-large"><%= t(".error_heading") %></h1>
-
-  <% @key_people_form.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-
-<% else %>
-
+<div class="text">
   <%= form_for(@key_people_form) do |f| %>
     <%= render("shared/errors", object: @key_people_form) %>
 
     <h1 class="heading-large"><%= t(".heading_#{@key_people_form.business_type}") %></h1>
+
+    <% if @key_people_form.errors[:first_name].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="first_name">
+        <% if @key_people_form.errors[:first_name].any? %>
+        <span class="error-message"><%= @key_people_form.errors[:first_name].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :first_name, t(".first_name"), class: "form-label" %>
+        <%= f.text_field :first_name, value: @key_people_form.first_name, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <% if @key_people_form.errors[:last_name].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="last_name">
+        <% if @key_people_form.errors[:last_name].any? %>
+        <span class="error-message"><%= @key_people_form.errors[:last_name].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :last_name, t(".last_name"), class: "form-label" %>
+        <%= f.text_field :last_name, value: @key_people_form.last_name, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <% if @key_people_form.errors[:dob_year].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="dob_year">
+        <% if @key_people_form.errors[:dob_year].any? %>
+        <span class="error-message"><%= @key_people_form.errors[:dob_year].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :dob_year, t(".dob_year"), class: "form-label" %>
+        <%= f.text_field :dob_year, value: @key_people_form.dob_year, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <% if @key_people_form.errors[:dob_month].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="dob_month">
+        <% if @key_people_form.errors[:dob_month].any? %>
+        <span class="error-message"><%= @key_people_form.errors[:dob_month].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :dob_month, t(".dob_month"), class: "form-label" %>
+        <%= f.text_field :dob_month, value: @key_people_form.dob_month, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <% if @key_people_form.errors[:dob_day].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="dob_day">
+        <% if @key_people_form.errors[:dob_day].any? %>
+        <span class="error-message"><%= @key_people_form.errors[:dob_day].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :dob_day, t(".dob_day"), class: "form-label" %>
+        <%= f.text_field :dob_day, value: @key_people_form.dob_day, class: "form-control" %>
+      </fieldset>
+    </div>
 
     <%= f.hidden_field :reg_identifier, value: @key_people_form.reg_identifier %>
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
   <% end %>
-
-<% end %>
+</div>

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -44,6 +44,7 @@ en:
               age_limit_overseas: "Business owners must be 17 or older"
               age_limit_partnership: "Partners must be 17 or older"
               age_limit_soleTrader: "Business owners must be 17 or older"
+              not_a_date: "You must enter a valid date"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -7,12 +7,21 @@ en:
       heading_overseas: Business owner details
       heading_partnership: Partner details
       heading_soleTrader: Business owner details
+      description_1_localAuthority: Provide the name and date of birth for each chief executive of this local authority or public body.
+      description_1_limitedCompany: Provide the name and date of birth for each director of this business.
+      description_1_limitedLiabilityPartnership: Provide the name and date of birth for each partner of this business.
+      description_1_overseas: Provide the name and date of birth for each owner of this business or organisation.
+      description_1_partnership: Provide the name and date of birth for each partner of this business.
+      description_1_soleTrader: Provide the name and date of birth for the owner of this business.
+      description_2: Add their details one person at a time. If you want to add more people, select 'add another person'.
       first_name: First name
       last_name: Last name
+      date_of_birth: Date of birth
+      date_of_birth_hint: For example, 26 5 1976
       dob_year: Year
       dob_month: Month
       dob_day: Day
-      error_heading: Something is wrong
+      add_another: Add another person
       next_button: Continue
   activemodel:
     errors:
@@ -25,18 +34,6 @@ en:
             last_name:
               blank: "You must enter a last name"
               too_long: "The last name must be no longer than 35 characters"
-            dob_day:
-              blank: "You must enter a day"
-              integer: "The day must be a number"
-              range: "The day must be between 1 and 31"
-            dob_month:
-              blank: "You must enter a month"
-              integer: "The month must be a number"
-              range: "The month must be between 1 and 12"
-            dob_year:
-              blank: "You must enter a year"
-              integer: "The year must be a number"
-              range: "The year must be between 1900 and now"
             date_of_birth:
               age_limit_localAuthority: "Chief executives must be 17 or older"
               age_limit_limitedCompany: "Directors must be 16 or older"
@@ -45,6 +42,15 @@ en:
               age_limit_partnership: "Partners must be 17 or older"
               age_limit_soleTrader: "Business owners must be 17 or older"
               not_a_date: "You must enter a valid date"
+              day_blank: "You must enter a day"
+              day_integer: "The day must be a number"
+              day_range: "The day must be between 1 and 31"
+              month_blank: "You must enter a month"
+              month_integer: "The month must be a number"
+              month_range: "The month must be between 1 and 12"
+              year_blank: "You must enter a year"
+              year_integer: "The year must be a number"
+              year_range: "The year must be between 1900 and now"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -36,7 +36,7 @@ en:
               too_long: "The last name must be no longer than 35 characters"
             date_of_birth:
               age_limit_localAuthority: "Chief executives must be 17 or older"
-              age_limit_limitedCompany: "Directors must be 16 or older"
+              age_limit_limitedCompany: "Directors must be 16 or older to be a director of a private limited company in the UK"
               age_limit_limitedLiabilityPartnership: "Partners must be 17 or older"
               age_limit_overseas: "Business owners must be 17 or older"
               age_limit_partnership: "Partners must be 17 or older"

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -13,7 +13,7 @@ en:
       description_1_overseas: Provide the name and date of birth for each owner of this business or organisation.
       description_1_partnership: Provide the name and date of birth for each partner of this business.
       description_1_soleTrader: Provide the name and date of birth for the owner of this business.
-      description_2: Add their details one person at a time. If you want to add more people, select 'add another person'.
+      description_2: Add their details one person at a time. If you need to add more people, select 'add another person'.
       first_name: First name
       last_name: Last name
       date_of_birth: Date of birth

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -6,7 +6,7 @@ en:
       heading_limitedLiabilityPartnership: Partner details
       heading_overseas: Business owner details
       heading_partnership: Partner details
-      heading_soleTrader: Individual details
+      heading_soleTrader: Business owner details
       first_name: First name
       last_name: Last name
       dob_year: Year
@@ -37,6 +37,13 @@ en:
               blank: "You must enter a year"
               integer: "The year must be a number"
               range: "The year must be between 1900 and now"
+            date_of_birth:
+              age_limit_localAuthority: "Chief executives must be 17 or older"
+              age_limit_limitedCompany: "Directors must be 16 or older"
+              age_limit_limitedLiabilityPartnership: "Partners must be 17 or older"
+              age_limit_overseas: "Business owners must be 17 or older"
+              age_limit_partnership: "Partners must be 17 or older"
+              age_limit_soleTrader: "Business owners must be 17 or older"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -7,6 +7,11 @@ en:
       heading_overseas: Business owner details
       heading_partnership: Partner details
       heading_soleTrader: Individual details
+      first_name: First name
+      last_name: Last name
+      dob_year: Year
+      dob_month: Month
+      dob_day: Day
       error_heading: Something is wrong
       next_button: Continue
   activemodel:

--- a/config/locales/forms/key_people_forms/en.yml
+++ b/config/locales/forms/key_people_forms/en.yml
@@ -17,8 +17,26 @@ en:
   activemodel:
     errors:
       models:
-        key_people_director_form:
+        key_people_form:
           attributes:
+            first_name:
+              blank: "You must enter a first name"
+              too_long: "The first name must be no longer than 35 characters"
+            last_name:
+              blank: "You must enter a last name"
+              too_long: "The last name must be no longer than 35 characters"
+            dob_day:
+              blank: "You must enter a day"
+              integer: "The day must be a number"
+              range: "The day must be between 1 and 31"
+            dob_month:
+              blank: "You must enter a month"
+              integer: "The month must be a number"
+              range: "The month must be between 1 and 12"
+            dob_year:
+              blank: "You must enter a year"
+              integer: "The year must be a number"
+              range: "The year must be between 1900 and now"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/spec/cassettes/registration_number_form_changed_company_no.yml
+++ b/spec/cassettes/registration_number_form_changed_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 12 Feb 2018 17:08:17 GMT
+      - Mon, 26 Feb 2018 17:17:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '595'
       X-Ratelimit-Reset:
-      - '1518455578'
+      - '1519665705'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -62,5 +62,5 @@ http_interactions:
         House Woodland Road","postal_code":"CT18 8DL","address_line_2":"Lyminge"},"accounts":{"last_accounts":{"period_end_on":"2017-02-28","period_start_on":"2016-03-01","made_up_to":"2017-02-28"},"accounting_reference_date":{"day":"28","month":"02"},"overdue":false,"next_due":"2018-11-30","next_made_up_to":"2018-02-28","next_accounts":{"overdue":false,"due_on":"2018-11-30","period_end_on":"2018-02-28","period_start_on":"2017-03-01"}},"company_name":"JIM
         GARRAHY''S FUDGE KITCHEN LIMITED","date_of_creation":"1983-03-24","sic_codes":["10822"],"undeliverable_registered_office_address":false,"last_full_members_list_date":"2015-11-20","type":"ltd","has_been_liquidated":false,"company_number":"01709418","jurisdiction":"england-wales","has_insolvency_history":false,"etag":"079ea458cdac90941922af7f7742f1d7cdf14cd1","has_charges":true,"company_status":"active","confirmation_statement":{"next_due":"2018-12-04","next_made_up_to":"2018-11-20","overdue":false,"last_made_up_to":"2017-11-20"},"links":{"self":"/company/01709418","filing_history":"/company/01709418/filing-history","officers":"/company/01709418/officers","charges":"/company/01709418/charges","persons_with_significant_control_statements":"/company/01709418/persons-with-significant-control-statements"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 12 Feb 2018 17:08:17 GMT
+  recorded_at: Mon, 26 Feb 2018 17:17:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_inactive_company_no.yml
+++ b/spec/cassettes/registration_number_form_inactive_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 12 Feb 2018 17:07:58 GMT
+      - Mon, 26 Feb 2018 17:16:46 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '596'
       X-Ratelimit-Reset:
-      - '1518455578'
+      - '1519665705'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Mon, 12 Feb 2018 17:07:59 GMT
+  recorded_at: Mon, 26 Feb 2018 17:16:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_not_found_company_no.yml
+++ b/spec/cassettes/registration_number_form_not_found_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 12 Feb 2018 17:07:58 GMT
+      - Mon, 26 Feb 2018 17:16:46 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '597'
       X-Ratelimit-Reset:
-      - '1518455578'
+      - '1519665705'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -60,5 +60,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
     http_version: 
-  recorded_at: Mon, 12 Feb 2018 17:07:58 GMT
+  recorded_at: Mon, 26 Feb 2018 17:16:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_short_company_no.yml
+++ b/spec/cassettes/registration_number_form_short_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 12 Feb 2018 17:07:58 GMT
+      - Mon, 26 Feb 2018 17:16:45 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '598'
       X-Ratelimit-Reset:
-      - '1518455578'
+      - '1519665705'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -64,5 +64,5 @@ http_interactions:
         Wycombe","region":"Bucks"},"jurisdiction":"england-wales","type":"ltd","undeliverable_registered_office_address":false,"sic_codes":["38110","38120","38210","38220"],"accounts":{"next_due":"2018-12-29","accounting_reference_date":{"day":"29","month":"03"},"next_accounts":{"due_on":"2018-12-29","period_start_on":"2017-03-25","overdue":false,"period_end_on":"2018-03-29"},"last_accounts":{"period_end_on":"2017-03-24","type":"full","made_up_to":"2017-03-24","period_start_on":"2016-03-26"},"next_made_up_to":"2018-03-29","overdue":false},"date_of_creation":"1969-01-16","has_insolvency_history":false,"etag":"71e17f2aaec9b698b7ff73a1cbf996dc9c88b933","has_charges":true,"company_status":"active","previous_company_names":[{"name":"BIFFA
         LIMITED","effective_from":"1969-01-16","ceased_on":"1986-04-22"}],"confirmation_statement":{"next_due":"2019-01-18","next_made_up_to":"2019-01-04","overdue":false,"last_made_up_to":"2018-01-04"},"links":{"self":"/company/00946107","filing_history":"/company/00946107/filing-history","officers":"/company/00946107/officers","charges":"/company/00946107/charges"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 12 Feb 2018 17:07:58 GMT
+  recorded_at: Mon, 26 Feb 2018 17:16:45 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_valid_company_no.yml
+++ b/spec/cassettes/registration_number_form_valid_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 12 Feb 2018 17:07:58 GMT
+      - Mon, 26 Feb 2018 17:16:45 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '599'
       X-Ratelimit-Reset:
-      - '1518455578'
+      - '1519665705'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -61,5 +61,5 @@ http_interactions:
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_made_up_to":"2017-12-31","overdue":false,"next_accounts":{"period_end_on":"2017-12-31","due_on":"2018-09-30","period_start_on":"2017-01-01","overdue":false},"last_accounts":{"made_up_to":"2016-12-31","period_start_on":"2016-01-01","period_end_on":"2016-12-31"},"accounting_reference_date":{"day":"31","month":"12"},"next_due":"2018-09-30"},"undeliverable_registered_office_address":false,"etag":"d1aac62a36df9712e7ef94c383439a6fa001fa84","company_number":"09360070","registered_office_address":{"address_line_1":"21
         Haslam Avenue","postal_code":"SM3 9ND","region":"Surrey","locality":"Sutton"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"last_made_up_to":"2017-12-15","overdue":false,"next_made_up_to":"2018-12-15","next_due":"2018-12-29"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 12 Feb 2018 17:07:58 GMT
+  recorded_at: Mon, 26 Feb 2018 17:16:45 GMT
 recorded_with: VCR 4.0.0

--- a/spec/factories/forms/key_people_form.rb
+++ b/spec/factories/forms/key_people_form.rb
@@ -1,6 +1,12 @@
 FactoryBot.define do
   factory :key_people_form do
     trait :has_required_data do
+      first_name "Foo"
+      last_name "Bar"
+      dob_year "2000"
+      dob_month "1"
+      dob_day "1"
+
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "key_people_form")) }
     end
   end

--- a/spec/factories/forms/key_people_form.rb
+++ b/spec/factories/forms/key_people_form.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       dob_year 2000
       dob_month 1
       dob_day 1
+      date_of_birth Date.new(2000, 1, 1)
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "key_people_form")) }
     end

--- a/spec/factories/forms/key_people_form.rb
+++ b/spec/factories/forms/key_people_form.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
     trait :has_required_data do
       first_name "Foo"
       last_name "Bar"
-      dob_year "2000"
-      dob_month "1"
-      dob_day "1"
+      dob_year 2000
+      dob_month 1
+      dob_day 1
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "key_people_form")) }
     end

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -4,7 +4,9 @@ FactoryBot.define do
       first_name "Kate"
       last_name "Franklin"
       position "Director"
-      date_of_birth Date.new
+      dob_day 1
+      dob_month 1
+      dob_year 2000
       person_type "Relevant"
     end
   end

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :keyPerson do
+  factory :key_person do
     trait :has_required_data do
       first_name "Kate"
       last_name "Franklin"

--- a/spec/forms/key_people_forms_spec.rb
+++ b/spec/forms/key_people_forms_spec.rb
@@ -226,6 +226,16 @@ RSpec.describe KeyPeopleForm, type: :model do
         end
       end
 
+      context "when a date of birth is not a valid date" do
+        before(:each) do
+          key_people_form.date_of_birth = nil
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
       shared_examples_for "age limits for key people" do |business_type, age_limit|
         before(:each) do
           key_people_form.business_type = business_type

--- a/spec/forms/key_people_forms_spec.rb
+++ b/spec/forms/key_people_forms_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe KeyPeopleForm, type: :model do
           key_people_form.business_type = business_type
         end
 
-        it "should not be valid when at the age limit" do
+        it "should be valid when at the age limit" do
           key_people_form.date_of_birth = Date.today - age_limit.years
           expect(key_people_form).to be_valid
         end

--- a/spec/forms/key_people_forms_spec.rb
+++ b/spec/forms/key_people_forms_spec.rb
@@ -218,6 +218,42 @@ RSpec.describe KeyPeopleForm, type: :model do
         end
       end
     end
+
+    describe "#date_of_birth" do
+      context "when a date_of_birth meets the requirements" do
+        it "is valid" do
+          expect(key_people_form).to be_valid
+        end
+      end
+
+      shared_examples_for "age limits for key people" do |business_type, age_limit|
+        before(:each) do
+          key_people_form.business_type = business_type
+        end
+
+        it "should not be valid when at the age limit" do
+          key_people_form.date_of_birth = Date.today - age_limit.years
+          expect(key_people_form).to be_valid
+        end
+
+        it "should not be valid when under the age limit" do
+          key_people_form.date_of_birth = Date.today - (age_limit.years - 1.year)
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      {
+        # Permutation table of business_type and age limit
+        "localAuthority" => 17,
+        "limitedCompany" => 16,
+        "limitedLiabilityPartnership" => 17,
+        "overseas" => 17,
+        "partnership" => 17,
+        "soleTrader" => 17
+      }.each do |business_type, age_limit|
+        it_behaves_like "age limits for key people", business_type, age_limit
+      end
+    end
   end
 
   describe "#transient_registration" do

--- a/spec/forms/key_people_forms_spec.rb
+++ b/spec/forms/key_people_forms_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe KeyPeopleForm, type: :model do
   describe "#submit" do
     context "when the form is valid" do
       let(:key_people_form) { build(:key_people_form, :has_required_data) }
-      let(:valid_params) { { reg_identifier: key_people_form.reg_identifier } }
+      let(:valid_params) do
+        { reg_identifier: key_people_form.reg_identifier,
+          first_name: key_people_form.first_name,
+          last_name: key_people_form.last_name,
+          dob_year: key_people_form.dob_year,
+          dob_month: key_people_form.dob_month,
+          dob_day: key_people_form.dob_day }
+      end
 
       it "should submit" do
         expect(key_people_form.submit(valid_params)).to eq(true)

--- a/spec/forms/key_people_forms_spec.rb
+++ b/spec/forms/key_people_forms_spec.rb
@@ -28,21 +28,11 @@ RSpec.describe KeyPeopleForm, type: :model do
     end
   end
 
-  describe "#reg_identifier" do
-    context "when a valid transient registration exists" do
-      let(:transient_registration) do
-        create(:transient_registration,
-               :has_required_data,
-               workflow_state: "key_people_form")
-      end
-      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
-      let(:key_people_form) { KeyPeopleForm.new(transient_registration) }
+  context "when a valid transient registration exists" do
+    let(:key_people_form) { build(:key_people_form, :has_required_data) }
 
+    describe "#reg_identifier" do
       context "when a reg_identifier meets the requirements" do
-        before(:each) do
-          key_people_form.reg_identifier = transient_registration.reg_identifier
-        end
-
         it "is valid" do
           expect(key_people_form).to be_valid
         end
@@ -51,6 +41,176 @@ RSpec.describe KeyPeopleForm, type: :model do
       context "when a reg_identifier is blank" do
         before(:each) do
           key_people_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#first_name" do
+      context "when a first_name meets the requirements" do
+        it "is valid" do
+          expect(key_people_form).to be_valid
+        end
+      end
+
+      context "when a first_name is blank" do
+        before(:each) do
+          key_people_form.first_name = ""
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a first_name is too long" do
+        before(:each) do
+          key_people_form.first_name = "gsm2lgu3q7cg5pcs02ftc1wtpx4lt5ghmyaclhe9qg9li7ibs5ldi3w3n1pt24pbfo0666bq"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#last_name" do
+      context "when a last_name meets the requirements" do
+        it "is valid" do
+          expect(key_people_form).to be_valid
+        end
+      end
+
+      context "when a last_name is blank" do
+        before(:each) do
+          key_people_form.last_name = ""
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a last_name is too long" do
+        before(:each) do
+          key_people_form.last_name = "gsm2lgu3q7cg5pcs02ftc1wtpx4lt5ghmyaclhe9qg9li7ibs5ldi3w3n1pt24pbfo0666bq"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#dob_day" do
+      context "when a dob_day meets the requirements" do
+        it "is valid" do
+          expect(key_people_form).to be_valid
+        end
+      end
+
+      context "when a dob_day is blank" do
+        before(:each) do
+          key_people_form.dob_day = ""
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a dob_day is not an integer" do
+        before(:each) do
+          key_people_form.dob_day = "1.5"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a dob_day is not in the correct range" do
+        before(:each) do
+          key_people_form.dob_day = "42"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#dob_month" do
+      context "when a dob_month meets the requirements" do
+        it "is valid" do
+          expect(key_people_form).to be_valid
+        end
+      end
+
+      context "when a dob_month is blank" do
+        before(:each) do
+          key_people_form.dob_month = ""
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a dob_month is not an integer" do
+        before(:each) do
+          key_people_form.dob_month = "9.75"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a dob_month is not in the correct range" do
+        before(:each) do
+          key_people_form.dob_month = "13"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#dob_year" do
+      context "when a dob_year meets the requirements" do
+        it "is valid" do
+          expect(key_people_form).to be_valid
+        end
+      end
+
+      context "when a dob_year is blank" do
+        before(:each) do
+          key_people_form.dob_year = ""
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a dob_year is not an integer" do
+        before(:each) do
+          key_people_form.dob_year = "3.14"
+        end
+
+        it "is not valid" do
+          expect(key_people_form).to_not be_valid
+        end
+      end
+
+      context "when a dob_year is not in the correct range" do
+        before(:each) do
+          key_people_form.dob_year = (Date.today + 1.year).year.to_i
         end
 
         it "is not valid" do

--- a/spec/models/key_person_spec.rb
+++ b/spec/models/key_person_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe KeyPerson, type: :model do
+  describe "#date_of_birth" do
+    context "when the provided fields make a valid date" do
+      # Can't use factories as we have to trigger the after_initialize method at correct time
+      let(:key_person) { KeyPerson.new(dob_day: 1, dob_month: 2, dob_year: 2000) }
+
+      it "should return the date when setting date of birth" do
+        expect(key_person.date_of_birth).to eq(Date.new(key_person.dob_year,
+                                                        key_person.dob_month,
+                                                        key_person.dob_day))
+      end
+    end
+
+    context "when the provided fields don't make a valid date" do
+      # Can't use factories as we have to trigger the after_initialize method at correct time
+      let(:key_person) { KeyPerson.new(dob_day: 31, dob_month: 2, dob_year: 2000) }
+
+      it "should return nil when setting date of birth" do
+        expect(key_person.date_of_birth).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -315,61 +315,6 @@ RSpec.describe Registration, type: :model do
       end
     end
 
-    describe "#first_name" do
-      context "when a registration's key person does not have a first_name" do
-        let(:key_person) { build(:keyPerson, :has_required_data, first_name: nil) }
-        let(:registration) { build(:registration, :has_required_data, keyPeople: [key_person]) }
-
-        it "is not valid" do
-          expect(registration).to_not be_valid
-        end
-      end
-    end
-
-    describe "#last_name" do
-      context "when a registration's key person does not have a last_name" do
-        let(:key_person) { build(:keyPerson, :has_required_data, last_name: nil) }
-        let(:registration) { build(:registration, :has_required_data, keyPeople: [key_person]) }
-
-        it "is not valid" do
-          expect(registration).to_not be_valid
-        end
-      end
-    end
-
-    describe "#position" do
-      context "when a registration's key person does not have a position" do
-        let(:key_person) { build(:keyPerson, :has_required_data, position: nil) }
-        let(:registration) { build(:registration, :has_required_data, keyPeople: [key_person]) }
-
-        it "is not valid" do
-          expect(registration).to_not be_valid
-        end
-      end
-    end
-
-    describe "#date_of_birth" do
-      context "when a registration's key person does not have a date_of_birth" do
-        let(:key_person) { build(:keyPerson, :has_required_data, date_of_birth: nil) }
-        let(:registration) { build(:registration, :has_required_data, keyPeople: [key_person]) }
-
-        it "is not valid" do
-          expect(registration).to_not be_valid
-        end
-      end
-    end
-
-    describe "#person_type" do
-      context "when a registration's key person does not have a person_type" do
-        let(:key_person) { build(:keyPerson, :has_required_data, person_type: nil) }
-        let(:registration) { build(:registration, :has_required_data, keyPeople: [key_person]) }
-
-        it "is not valid" do
-          expect(registration).to_not be_valid
-        end
-      end
-    end
-
     describe "#convictionSearchResult" do
       context "when a registration's key person has a convictionSearchResult" do
         let(:conviction_search_result) { build(:convictionSearchResult) }

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Registration, type: :model do
 
   describe "#keyPeople" do
     context "when a registration has one key person" do
-      let(:key_person) { build(:keyPerson, :has_required_data) }
+      let(:key_person) { build(:key_person, :has_required_data) }
       let(:registration) do
         build(:registration,
               :has_required_data,
@@ -301,8 +301,8 @@ RSpec.describe Registration, type: :model do
     end
 
     context "when a registration has multiple key people" do
-      let(:key_person_a) { build(:keyPerson, :has_required_data) }
-      let(:key_person_b) { build(:keyPerson, :has_required_data) }
+      let(:key_person_a) { build(:key_person, :has_required_data) }
+      let(:key_person_b) { build(:key_person, :has_required_data) }
       let(:registration) do
         build(:registration,
               :has_required_data,
@@ -318,7 +318,7 @@ RSpec.describe Registration, type: :model do
     describe "#convictionSearchResult" do
       context "when a registration's key person has a convictionSearchResult" do
         let(:conviction_search_result) { build(:convictionSearchResult) }
-        let(:key_person) { build(:keyPerson, :has_required_data, convictionSearchResult: conviction_search_result) }
+        let(:key_person) { build(:key_person, :has_required_data, convictionSearchResult: conviction_search_result) }
         let(:registration) do
           build(:registration,
                 :has_required_data,

--- a/spec/requests/key_people_forms_spec.rb
+++ b/spec/requests/key_people_forms_spec.rb
@@ -56,12 +56,18 @@ RSpec.describe "KeyPeopleForms", type: :request do
         context "when valid params are submitted" do
           let(:valid_params) {
             {
-              reg_identifier: transient_registration[:reg_identifier]
+              reg_identifier: transient_registration[:reg_identifier],
+              first_name: "Foo",
+              last_name: "Bar",
+              dob_day: "1",
+              dob_month: "1",
+              dob_year: "2000"
             }
           }
 
           it "updates the transient registration" do
-            # TODO: Add test once data is submitted through the form
+            post key_people_forms_path, key_people_form: valid_params
+            expect(transient_registration.reload.keyPeople.first.first_name).to eq(valid_params[:first_name])
           end
 
           it "returns a 302 response" do
@@ -104,12 +110,18 @@ RSpec.describe "KeyPeopleForms", type: :request do
 
         let(:valid_params) {
           {
-            reg_identifier: transient_registration[:reg_identifier]
+            reg_identifier: transient_registration[:reg_identifier],
+            first_name: "Foo",
+            last_name: "Bar",
+            dob_day: "1",
+            dob_month: "1",
+            dob_year: "2000"
           }
         }
 
         it "does not update the transient registration" do
-          # TODO: Add test once data is submitted through the form
+          post key_people_forms_path, key_people_form: valid_params
+          expect(transient_registration.reload.keyPeople).to_not exist
         end
 
         it "returns a 302 response" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-105

All business types have different sorts of key people whose details are required for the registration. Most can have multiple key people, but the scope of this story just covers adding one.