### PR TITLE
Configure Tidelift to not check Rails version

### DIFF
--- a/.tidelift.yml
+++ b/.tidelift.yml
@@ -1,0 +1,7 @@
+ci:
+  # don't run outdated test on any dependencies called rails from Rubygems
+  platform:
+    Rubygems:
+      rails:
+        tests:
+          outdated: skip


### PR DESCRIPTION
We are sticking with Rails 4 for the time being, so this config change should stop PRs from getting blocked because newer versions are available.