### PR TITLE
Check which country users are based in

### DIFF
--- a/app/controllers/location_forms_controller.rb
+++ b/app/controllers/location_forms_controller.rb
@@ -1,0 +1,9 @@
+class LocationFormsController < FormsController
+  def new
+    super(LocationForm, "location_form")
+  end
+
+  def create
+    super(LocationForm, "location_form")
+  end
+end

--- a/app/controllers/register_in_northern_ireland_forms_controller.rb
+++ b/app/controllers/register_in_northern_ireland_forms_controller.rb
@@ -1,0 +1,9 @@
+class RegisterInNorthernIrelandFormsController < FormsController
+  def new
+    super(RegisterInNorthernIrelandForm, "register_in_northern_ireland_form")
+  end
+
+  def create
+    super(RegisterInNorthernIrelandForm, "register_in_northern_ireland_form")
+  end
+end

--- a/app/controllers/register_in_scotland_forms_controller.rb
+++ b/app/controllers/register_in_scotland_forms_controller.rb
@@ -1,0 +1,9 @@
+class RegisterInScotlandFormsController < FormsController
+  def new
+    super(RegisterInScotlandForm, "register_in_scotland_form")
+  end
+
+  def create
+    super(RegisterInScotlandForm, "register_in_scotland_form")
+  end
+end

--- a/app/controllers/register_in_wales_forms_controller.rb
+++ b/app/controllers/register_in_wales_forms_controller.rb
@@ -1,0 +1,9 @@
+class RegisterInWalesFormsController < FormsController
+  def new
+    super(RegisterInWalesForm, "register_in_wales_form")
+  end
+
+  def create
+    super(RegisterInWalesForm, "register_in_wales_form")
+  end
+end

--- a/app/forms/business_type_form.rb
+++ b/app/forms/business_type_form.rb
@@ -18,7 +18,6 @@ class BusinessTypeForm < BaseForm
                                                 limitedCompany
                                                 limitedLiabilityPartnership
                                                 localAuthority
-                                                overseas
                                                 partnership
                                                 soleTrader] }
 end

--- a/app/forms/company_address_manual_form.rb
+++ b/app/forms/company_address_manual_form.rb
@@ -67,7 +67,7 @@ class CompanyAddressManualForm < BaseForm
   end
 
   def add_or_replace_address(params)
-    address = Address.create_from_manual_entry(params, business_type)
+    address = Address.create_from_manual_entry(params, @transient_registration.overseas?)
     address.assign_attributes(address_type: "REGISTERED")
 
     # Update the transient object's nested addresses, replacing any existing registered address

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -11,6 +11,9 @@ class LocationForm < BaseForm
     self.location = params[:location]
     attributes = { location: location }
 
+    # Set the business type to overseas when required as we use this for microcopy
+    attributes[:business_type] = "overseas" if location == "overseas"
+
     super(attributes, params[:reg_identifier])
   end
 

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -13,4 +13,10 @@ class LocationForm < BaseForm
 
     super(attributes, params[:reg_identifier])
   end
+
+  validates :location, inclusion: { in: %w[england
+                                           northern_ireland
+                                           scotland
+                                           wales
+                                           overseas] }
 end

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -1,0 +1,17 @@
+class LocationForm < BaseForm
+  # TODO: Define accessible attributes, eg attr_accessor :field
+
+  def initialize(transient_registration)
+    super
+    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+  end
+
+  def submit(params)
+    # Assign the params for validation and pass them to the BaseForm method for updating
+    # TODO: Define allowed params, eg self.field = params[:field]
+    # TODO: Include attributes to update in the attributes hash, eg { field: field }
+    attributes = {}
+
+    super(attributes, params[:reg_identifier])
+  end
+end

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -1,16 +1,15 @@
 class LocationForm < BaseForm
-  # TODO: Define accessible attributes, eg attr_accessor :field
+  attr_accessor :location
 
   def initialize(transient_registration)
     super
-    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+    self.location = @transient_registration.location
   end
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    # TODO: Define allowed params, eg self.field = params[:field]
-    # TODO: Include attributes to update in the attributes hash, eg { field: field }
-    attributes = {}
+    self.location = params[:location]
+    attributes = { location: location }
 
     super(attributes, params[:reg_identifier])
   end

--- a/app/forms/register_in_northern_ireland_form.rb
+++ b/app/forms/register_in_northern_ireland_form.rb
@@ -1,0 +1,17 @@
+class RegisterInNorthernIrelandForm < BaseForm
+  # TODO: Define accessible attributes, eg attr_accessor :field
+
+  def initialize(transient_registration)
+    super
+    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+  end
+
+  def submit(params)
+    # Assign the params for validation and pass them to the BaseForm method for updating
+    # TODO: Define allowed params, eg self.field = params[:field]
+    # TODO: Include attributes to update in the attributes hash, eg { field: field }
+    attributes = {}
+
+    super(attributes, params[:reg_identifier])
+  end
+end

--- a/app/forms/register_in_scotland_form.rb
+++ b/app/forms/register_in_scotland_form.rb
@@ -1,0 +1,17 @@
+class RegisterInScotlandForm < BaseForm
+  # TODO: Define accessible attributes, eg attr_accessor :field
+
+  def initialize(transient_registration)
+    super
+    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+  end
+
+  def submit(params)
+    # Assign the params for validation and pass them to the BaseForm method for updating
+    # TODO: Define allowed params, eg self.field = params[:field]
+    # TODO: Include attributes to update in the attributes hash, eg { field: field }
+    attributes = {}
+
+    super(attributes, params[:reg_identifier])
+  end
+end

--- a/app/forms/register_in_wales_form.rb
+++ b/app/forms/register_in_wales_form.rb
@@ -1,0 +1,17 @@
+class RegisterInWalesForm < BaseForm
+  # TODO: Define accessible attributes, eg attr_accessor :field
+
+  def initialize(transient_registration)
+    super
+    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+  end
+
+  def submit(params)
+    # Assign the params for validation and pass them to the BaseForm method for updating
+    # TODO: Define allowed params, eg self.field = params[:field]
+    # TODO: Include attributes to update in the attributes hash, eg { field: field }
+    attributes = {}
+
+    super(attributes, params[:reg_identifier])
+  end
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -25,10 +25,10 @@ class Address
   field :firstOrOnlyEasting, as: :first_or_only_easting,              type: Integer
   field :firstOrOnlyNorthing, as: :first_or_only_northing,            type: Integer
 
-  def self.create_from_manual_entry(params, business_type)
+  def self.create_from_manual_entry(params, overseas)
     address = Address.new
 
-    address[:address_mode] = if business_type == "overseas"
+    address[:address_mode] = if overseas
                                "manual-foreign"
                              else
                                "manual-uk"

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -74,7 +74,7 @@ module CanChangeWorkflowStatus
 
         transitions from: :location_form,
                     to: :other_businesses_form,
-                    if: :overseas_address?
+                    if: :based_overseas?
 
         transitions from: :location_form,
                     to: :business_type_form
@@ -152,7 +152,7 @@ module CanChangeWorkflowStatus
 
         transitions from: :company_name_form,
                     to: :company_address_manual_form,
-                    if: :overseas_address?
+                    if: :based_overseas?
 
         transitions from: :company_name_form,
                     to: :company_postcode_form
@@ -248,7 +248,7 @@ module CanChangeWorkflowStatus
 
         transitions from: :other_businesses_form,
                     to: :location_form,
-                    if: :overseas_address?
+                    if: :based_overseas?
 
         transitions from: :other_businesses_form,
                     to: :business_type_form
@@ -305,7 +305,7 @@ module CanChangeWorkflowStatus
 
         transitions from: :company_address_manual_form,
                     to: :company_name_form,
-                    if: :overseas_address?
+                    if: :based_overseas?
 
         transitions from: :company_address_manual_form,
                     to: :company_postcode_form
@@ -383,7 +383,8 @@ module CanChangeWorkflowStatus
   private
 
   def skip_registration_number?
-    %w[localAuthority overseas partnership soleTrader].include?(business_type)
+    return true if overseas?
+    %w[localAuthority partnership soleTrader].include?(business_type)
   end
 
   # Charity registrations should be lower tier
@@ -414,8 +415,8 @@ module CanChangeWorkflowStatus
     is_main_service == true
   end
 
-  def overseas_address?
-    business_type == "overseas" || location == "overseas"
+  def based_overseas?
+    overseas?
   end
 
   def registered_address_was_manually_entered?

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -10,10 +10,13 @@ module CanChangeWorkflowStatus
     aasm column: :workflow_state do
       # States / forms
       state :renewal_start_form, initial: true
-      state :location_form
-      state :business_type_form
 
-      state :smart_answers_form
+      state :location_form
+      state :register_in_northern_ireland_form
+      state :register_in_scotland_form
+      state :register_in_wales_form
+
+      state :business_type_form
 
       state :other_businesses_form
       state :service_provided_form
@@ -55,8 +58,21 @@ module CanChangeWorkflowStatus
         transitions from: :renewal_start_form,
                     to: :location_form
 
+        # Location
+
         transitions from: :location_form,
                     to: :business_type_form
+
+        transitions from: :register_in_northern_ireland_form,
+                    to: :business_type_form
+
+        transitions from: :register_in_scotland_form,
+                    to: :business_type_form
+
+        transitions from: :register_in_wales_form,
+                    to: :business_type_form
+
+        # End location
 
         transitions from: :business_type_form,
                     to: :cannot_renew_lower_tier_form,
@@ -181,8 +197,21 @@ module CanChangeWorkflowStatus
       end
 
       event :back do
+        # Location
+
         transitions from: :location_form,
                     to: :renewal_start_form
+
+        transitions from: :register_in_northern_ireland_form,
+                    to: :location_form
+
+        transitions from: :register_in_scotland_form,
+                    to: :location_form
+
+        transitions from: :register_in_wales_form,
+                    to: :location_form
+
+        # End location
 
         transitions from: :business_type_form,
                     to: :location_form

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -230,9 +230,25 @@ module CanChangeWorkflowStatus
         # End location
 
         transitions from: :business_type_form,
+                    to: :register_in_northern_ireland_form,
+                    if: :should_register_in_northern_ireland?
+
+        transitions from: :business_type_form,
+                    to: :register_in_scotland_form,
+                    if: :should_register_in_scotland?
+
+        transitions from: :business_type_form,
+                    to: :register_in_wales_form,
+                    if: :should_register_in_wales?
+
+        transitions from: :business_type_form,
                     to: :location_form
 
         # Smart answers
+
+        transitions from: :other_businesses_form,
+                    to: :location_form,
+                    if: :overseas_address?
 
         transitions from: :other_businesses_form,
                     to: :business_type_form

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -61,6 +61,22 @@ module CanChangeWorkflowStatus
         # Location
 
         transitions from: :location_form,
+                    to: :register_in_northern_ireland_form,
+                    if: :should_register_in_northern_ireland?
+
+        transitions from: :location_form,
+                    to: :register_in_scotland_form,
+                    if: :should_register_in_scotland?
+
+        transitions from: :location_form,
+                    to: :register_in_wales_form,
+                    if: :should_register_in_wales?
+
+        transitions from: :location_form,
+                    to: :other_businesses_form,
+                    if: :overseas_address?
+
+        transitions from: :location_form,
                     to: :business_type_form
 
         transitions from: :register_in_northern_ireland_form,
@@ -383,7 +399,7 @@ module CanChangeWorkflowStatus
   end
 
   def overseas_address?
-    business_type == "overseas"
+    business_type == "overseas" || location == "overseas"
   end
 
   def registered_address_was_manually_entered?
@@ -393,5 +409,17 @@ module CanChangeWorkflowStatus
 
   def skip_to_manual_address?
     temp_os_places_error
+  end
+
+  def should_register_in_northern_ireland?
+    location == "northern_ireland"
+  end
+
+  def should_register_in_scotland?
+    location == "scotland"
+  end
+
+  def should_register_in_wales?
+    location == "wales"
   end
 end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -10,6 +10,7 @@ module CanChangeWorkflowStatus
     aasm column: :workflow_state do
       # States / forms
       state :renewal_start_form, initial: true
+      state :location_form
       state :business_type_form
 
       state :smart_answers_form
@@ -52,6 +53,9 @@ module CanChangeWorkflowStatus
       # Transitions
       event :next do
         transitions from: :renewal_start_form,
+                    to: :location_form
+
+        transitions from: :location_form,
                     to: :business_type_form
 
         transitions from: :business_type_form,
@@ -177,8 +181,11 @@ module CanChangeWorkflowStatus
       end
 
       event :back do
-        transitions from: :business_type_form,
+        transitions from: :location_form,
                     to: :renewal_start_form
+
+        transitions from: :business_type_form,
+                    to: :location_form
 
         # Smart answers
 

--- a/app/models/concerns/can_check_business_type_changes.rb
+++ b/app/models/concerns/can_check_business_type_changes.rb
@@ -7,32 +7,28 @@ module CanCheckBusinessTypeChanges
       old_type = Registration.where(reg_identifier: reg_identifier).first.business_type
 
       case old_type
-      # If there's no change to the business type, it's valid
+      # If the old type and the new type are the same, it's valid
       when business_type
         true
-      # Otherwise, check based on what the previous type was
+      # Otherwise, check if the change is allowed based on the previous type
       when "authority"
-        matches_allowed_types?(["localAuthority"])
-      when "charity"
-        matches_allowed_types?(["overseas"])
+        changing_to?("localAuthority")
       when "limitedCompany"
-        matches_allowed_types?(["limitedLiabilityPartnership", "overseas"])
+        changing_to?("limitedLiabilityPartnership")
       when "partnership"
-        matches_allowed_types?(["limitedLiabilityPartnership", "overseas"])
+        changing_to?("limitedLiabilityPartnership")
       when "publicBody"
-        matches_allowed_types?(["localAuthority"])
-      when "soleTrader"
-        matches_allowed_types?(["overseas"])
-      # If the old type was none of the above, it's invalid
+        changing_to?("localAuthority")
+      # There are no valid changes for charity or soleTrader
       else
         false
       end
     end
-  end
 
-  private
+    private
 
-  def matches_allowed_types?(valid_types)
-    valid_types.include?(business_type)
+    def changing_to?(value)
+      business_type == value
+    end
   end
 end

--- a/app/models/concerns/can_have_registration_attributes.rb
+++ b/app/models/concerns/can_have_registration_attributes.rb
@@ -48,5 +48,9 @@ module CanHaveRegistrationAttributes
       return nil unless addresses.present?
       addresses.where(address_type: "REGISTERED").first
     end
+
+    def overseas?
+      location == "overseas"
+    end
   end
 end

--- a/app/models/concerns/can_have_registration_attributes.rb
+++ b/app/models/concerns/can_have_registration_attributes.rb
@@ -21,6 +21,7 @@ module CanHaveRegistrationAttributes
     field :uuid,                                            type: String
     field :tier,                                            type: String
     field :registrationType, as: :registration_type,        type: String
+    field :location,                                        type: String
     field :businessType, as: :business_type,                type: String
     field :otherBusinesses, as: :other_businesses,          type: Boolean
     field :isMainService, as: :is_main_service,             type: Boolean

--- a/app/views/business_type_forms/new.html.erb
+++ b/app/views/business_type_forms/new.html.erb
@@ -44,10 +44,6 @@
           <%= f.radio_button :business_type, 'charity' %>
           <%= f.label :business_type, t(".option_charity"), value: 'charity' %>
         </div>
-        <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'overseas' %>
-          <%= f.label :business_type, t(".option_overseas"), value: 'overseas' %>
-        </div>
       </fieldset>
     </div>
 

--- a/app/views/location_forms/new.html.erb
+++ b/app/views/location_forms/new.html.erb
@@ -1,0 +1,32 @@
+<%= render("shared/back", back_path: back_location_forms_path(@location_form.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@location_form) do |f| %>
+    <%= render("shared/errors", object: @location_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @location_form.errors[:location].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="location">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @location_form.errors[:location].any? %>
+        <span class="error-message"><%= @location_form.errors[:location].join(", ") %></span>
+        <% end %>
+
+        <p>Form fields go here</p>
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :reg_identifier, value: @location_form.reg_identifier %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/location_forms/new.html.erb
+++ b/app/views/location_forms/new.html.erb
@@ -6,6 +6,17 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
+    <div class="form-group">
+      <details>
+        <summary>
+          <span class="summary"><%= t(".location_detail_subheading") %></span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <p><%= t(".location_detail_paragraph") %></p>
+        </div>
+      </details>
+    </div>
+
     <% if @location_form.errors[:location].any? %>
     <div class="form-group form-group-error">
     <% else %>
@@ -20,7 +31,26 @@
         <span class="error-message"><%= @location_form.errors[:location].join(", ") %></span>
         <% end %>
 
-        <p>Form fields go here</p>
+        <div class="multiple-choice">
+          <%= f.radio_button :location, 'england' %>
+          <%= f.label :location, t(".option_england"), value: 'england' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :location, 'northern_ireland' %>
+          <%= f.label :location, t(".option_northern_ireland"), value: 'northern_ireland' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :location, 'scotland' %>
+          <%= f.label :location, t(".option_scotland"), value: 'scotland' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :location, 'wales' %>
+          <%= f.label :location, t(".option_wales"), value: 'wales' %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :location, 'overseas' %>
+          <%= f.label :location, t(".option_overseas"), value: 'overseas' %>
+        </div>
       </fieldset>
     </div>
 

--- a/app/views/register_in_northern_ireland_forms/new.html.erb
+++ b/app/views/register_in_northern_ireland_forms/new.html.erb
@@ -1,0 +1,18 @@
+<%= render("shared/back", back_path: back_register_in_northern_ireland_forms_path(@register_in_northern_ireland_form.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@register_in_northern_ireland_form) do |f| %>
+    <%= render("shared/errors", object: @register_in_northern_ireland_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <p><%= t(".text") %></p>
+    </div>
+
+    <%= f.hidden_field :reg_identifier, value: @register_in_northern_ireland_form.reg_identifier %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/register_in_northern_ireland_forms/new.html.erb
+++ b/app/views/register_in_northern_ireland_forms/new.html.erb
@@ -7,7 +7,10 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <div class="form-group">
-      <p><%= t(".text") %></p>
+      <p><%= t(".paragraph_1") %></p>
+      <p><%= t(".paragraph_2") %> <a href="https://www.gov.uk/waste-carrier-or-broker-registration-northern-ireland/northern-ireland-environment-agency"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_3") %></p>
+      <p><%= t(".paragraph_4") %></p>
     </div>
 
     <%= f.hidden_field :reg_identifier, value: @register_in_northern_ireland_form.reg_identifier %>

--- a/app/views/register_in_scotland_forms/new.html.erb
+++ b/app/views/register_in_scotland_forms/new.html.erb
@@ -7,7 +7,10 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <div class="form-group">
-      <p><%= t(".text") %></p>
+      <p><%= t(".paragraph_1") %></p>
+      <p><%= t(".paragraph_2") %> <a href="https://www.gov.uk/waste-carrier-or-broker-registration-scotland"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_3") %></p>
+      <p><%= t(".paragraph_4") %></p>
     </div>
 
     <%= f.hidden_field :reg_identifier, value: @register_in_scotland_form.reg_identifier %>

--- a/app/views/register_in_scotland_forms/new.html.erb
+++ b/app/views/register_in_scotland_forms/new.html.erb
@@ -1,0 +1,18 @@
+<%= render("shared/back", back_path: back_register_in_scotland_forms_path(@register_in_scotland_form.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@register_in_scotland_form) do |f| %>
+    <%= render("shared/errors", object: @register_in_scotland_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <p><%= t(".text") %></p>
+    </div>
+
+    <%= f.hidden_field :reg_identifier, value: @register_in_scotland_form.reg_identifier %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/register_in_wales_forms/new.html.erb
+++ b/app/views/register_in_wales_forms/new.html.erb
@@ -1,0 +1,18 @@
+<%= render("shared/back", back_path: back_register_in_wales_forms_path(@register_in_wales_form.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@register_in_wales_form) do |f| %>
+    <%= render("shared/errors", object: @register_in_wales_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <p><%= t(".text") %></p>
+    </div>
+
+    <%= f.hidden_field :reg_identifier, value: @register_in_wales_form.reg_identifier %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/register_in_wales_forms/new.html.erb
+++ b/app/views/register_in_wales_forms/new.html.erb
@@ -7,7 +7,10 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <div class="form-group">
-      <p><%= t(".text") %></p>
+      <p><%= t(".paragraph_1") %></p>
+      <p><%= t(".paragraph_2") %> <a href="https://www.gov.uk/register-as-a-waste-carrier-broker-or-dealer-wales"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_3") %></p>
+      <p><%= t(".paragraph_4") %></p>
     </div>
 
     <%= f.hidden_field :reg_identifier, value: @register_in_wales_form.reg_identifier %>

--- a/config/locales/forms/business_type_forms/en.yml
+++ b/config/locales/forms/business_type_forms/en.yml
@@ -8,7 +8,6 @@ en:
       option_individual: Individual (eg a sole trader)
       option_partnership: Partnership
       option_charity: Charity or trust
-      option_overseas: Based overseas
       help: Not sure? Call our helpline on 03708 506 506.
       error_heading: Something is wrong
       next_button: Continue

--- a/config/locales/forms/location_forms/en.yml
+++ b/config/locales/forms/location_forms/en.yml
@@ -15,6 +15,8 @@ en:
       models:
         location_form:
           attributes:
+            location:
+              inclusion: "You must answer this question"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/config/locales/forms/location_forms/en.yml
+++ b/config/locales/forms/location_forms/en.yml
@@ -2,6 +2,13 @@ en:
   location_forms:
     new:
       heading: Where is your principal place of business?
+      location_detail_subheading: What is the principal place of business?
+      location_detail_paragraph: "Normally, it’s the place where orders are received and dealt with and the day-to-day running of the business takes place. If your business is registered, it’ll be where the registered address is."
+      option_england: England
+      option_northern_ireland: Northern Ireland
+      option_scotland: Scotland
+      option_wales: Wales
+      option_overseas: Not in the United Kingdom
       next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/location_forms/en.yml
+++ b/config/locales/forms/location_forms/en.yml
@@ -1,0 +1,14 @@
+en:
+  location_forms:
+    new:
+      heading: Where is your principal place of business?
+      next_button: Continue
+  activemodel:
+    errors:
+      models:
+        location_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/register_in_northern_ireland_forms/en.yml
+++ b/config/locales/forms/register_in_northern_ireland_forms/en.yml
@@ -2,8 +2,12 @@ en:
   register_in_northern_ireland_forms:
     new:
       heading: You should register in Northern Ireland
-      text: Text goes here
-      next_button: I still want to register in England
+      paragraph_1: Each country has its own register of waste carriers and you are encouraged to register with the appropriate authority for it.
+      paragraph_2: In Northern Ireland you need to register with Northern Ireland Environment Agency (NIEA). For details on how, visit
+      service_link: Register or renew as a waste carrier, broker or dealer (Northern Ireland)
+      paragraph_3: You can still complete the process and register in England with the Environment Agency, but you may find this makes it harder for your customers to verify you’re a registered waste carrier.
+      paragraph_4: If you have any questions about this, please contact our helpline on 03708 506 506.
+      next_button: Continue registering in England
   activemodel:
     errors:
       models:

--- a/config/locales/forms/register_in_northern_ireland_forms/en.yml
+++ b/config/locales/forms/register_in_northern_ireland_forms/en.yml
@@ -1,0 +1,15 @@
+en:
+  register_in_northern_ireland_forms:
+    new:
+      heading: You should register in Northern Ireland
+      text: Text goes here
+      next_button: I still want to register in England
+  activemodel:
+    errors:
+      models:
+        register_in_northern_ireland_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/register_in_scotland_forms/en.yml
+++ b/config/locales/forms/register_in_scotland_forms/en.yml
@@ -2,8 +2,12 @@ en:
   register_in_scotland_forms:
     new:
       heading: You should register in Scotland
-      text: Text goes here
-      next_button: I still want to register in England
+      paragraph_1: Each country has its own register of waste carriers and you are encouraged to register with the appropriate authority for it.
+      paragraph_2: In Scotland you need to register with the Scottish Environment Protection Agency (SEPA). For details on how, visit
+      service_link: Register or renew as a waste carrier or broker (Scotland)
+      paragraph_3: You can still complete the process and register in England with the Environment Agency, but you may find this makes it harder for your customers to verify you’re a registered waste carrier.
+      paragraph_4: If you have any questions about this, please contact our helpline on 03708 506 506.
+      next_button: Continue registering in England
   activemodel:
     errors:
       models:

--- a/config/locales/forms/register_in_scotland_forms/en.yml
+++ b/config/locales/forms/register_in_scotland_forms/en.yml
@@ -1,0 +1,15 @@
+en:
+  register_in_scotland_forms:
+    new:
+      heading: You should register in Scotland
+      text: Text goes here
+      next_button: I still want to register in England
+  activemodel:
+    errors:
+      models:
+        register_in_scotland_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/register_in_wales_forms/en.yml
+++ b/config/locales/forms/register_in_wales_forms/en.yml
@@ -1,0 +1,15 @@
+en:
+  register_in_wales_forms:
+    new:
+      heading: You should register in Wales
+      text: Text goes here
+      next_button: I still want to register in England
+  activemodel:
+    errors:
+      models:
+        register_in_wales_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/register_in_wales_forms/en.yml
+++ b/config/locales/forms/register_in_wales_forms/en.yml
@@ -2,8 +2,12 @@ en:
   register_in_wales_forms:
     new:
       heading: You should register in Wales
-      text: Text goes here
-      next_button: I still want to register in England
+      paragraph_1: Each country has its own register of waste carriers and you are encouraged to register with the appropriate authority for it.
+      paragraph_2: In Wales you need to register with Natural Resources Wales (NRW). For details on how, visit
+      service_link: Register or renew as a waste carrier, broker or dealer (Wales)
+      paragraph_3: You can still complete the process and register in England with the Environment Agency, but you may find this makes it harder for your customers to verify you’re a registered waste carrier.
+      paragraph_4: If you have any questions about this, please contact our helpline on 03708 506 506.
+      next_button: Continue registering in England
   activemodel:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,36 @@ Rails.application.routes.draw do
               on: :collection
             end
 
+  resources :register_in_northern_ireland_forms,
+            only: [:new, :create],
+            path: "register-in-northern-ireland",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "register_in_northern_ireland_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
+  resources :register_in_scotland_forms,
+            only: [:new, :create],
+            path: "register-in-scotland",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "register_in_scotland_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
+  resources :register_in_wales_forms,
+            only: [:new, :create],
+            path: "register-in-wales",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "register_in_wales_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :business_type_forms,
             only: [:new, :create],
             path: "business-type",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,16 @@ Rails.application.routes.draw do
             path: "renew",
             path_names: { new: "/:reg_identifier" }
 
+  resources :location_forms,
+            only: [:new, :create],
+            path: "location",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "location_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :business_type_forms,
             only: [:new, :create],
             path: "business-type",

--- a/spec/cassettes/company_postcode_form_modified_postcode.yml
+++ b/spec/cassettes/company_postcode_form_modified_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 23 Feb 2018 15:48:24 GMT
+      - Mon, 12 Mar 2018 14:22:52 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAN2Y0W6bMBSGX8XimkoQgoHdkcRtkChEQFpFVS+cxG3QCI4IbKumvftMIS4QNu3CROkuIvEfw7H9n08Hk6ef0p6m8VeSSV8kTTHNsSrJUnHI0qZO4pQcpS9PEgqn9gKB0HZ9j8UfnGnkB44NwihAKJKeZSmn38tHJ4ETRr7L7jnQY76hW1IGQxVAe86CBB/zOH0t59CtkW6wUEqzfFfFVGMEjTK2oUWaZ28sxMSWHEi6JWnu0g1O4rwbjnYZLV53Lzgj1Qje7uM0PuYZzuNvxM4Ibi0sKdPYRb6jGUu2PGxxTmbsVz2c0Tec3OM46Q4ccJbHOGGiaYYMlp4TAV0GUWB7oX8P5v4yRDLoWCSDegHsgrtxLNaTIk62bPce3pfzVMnY0LodbyVnw+XiT5uub+nWRJZo9oqZD8wFmtY3derIZyn263cS6rr5Ly/xhkzoj+YAM5xZsGeO18nKGC3WCZn1VeiX3ERspENo6h+Icc0RW8wdd+FHoTi8NHiGl6FoV4/XyYgaLetGVUTSVeYbDrBGFS8Il6IqOmzAddIcrnA5ebRX4tAaa+edy9KvHq3KhhosUyRV5nBI8dpdDijV0g3V+ACKaw5UNEdgZjvuCkycCIGpfYvE0QWtc7p08+rp6vGkRk0ViZo6HGr9Vb3oW9KEjYMY15y7dwe0m7Hc3bKoI1kPesbo6tHjtgjkjKUbjrRLYzXWtBZWlW5jBYeCatwDlQk/B1RQJFLwPwFKVUzNGjfejyfdBOoBBaETrYB/C8q++ojCqLxG3p1rezOBLavnLGZ+ipb1d4cEgTcccv9S48s2OctsN7l3zZnkm5oFKzB1ke2x1Qvscuefm9C0rp7DXlfqc5shsvkZw5H4p8pelj6l/f9GpRv0BXeOB+59D63Awp0K/FzQz8GD198Au4bUzI1EMjcakrmzeg6K2/NvwFnliLMVAAA=
     http_version: 
-  recorded_at: Fri, 23 Feb 2018 15:48:24 GMT
+  recorded_at: Mon, 12 Mar 2018 14:27:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_postcode_form_no_matches_postcode.yml
+++ b/spec/cassettes/company_postcode_form_no_matches_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Fri, 23 Feb 2018 15:48:24 GMT
+      - Mon, 12 Mar 2018 14:22:53 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -30,5 +30,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":{"message":"Parameters are not valid","statuscode":400}}'
     http_version: 
-  recorded_at: Fri, 23 Feb 2018 15:48:25 GMT
+  recorded_at: Mon, 12 Mar 2018 14:27:51 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_postcode_form_valid_postcode.yml
+++ b/spec/cassettes/company_postcode_form_valid_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 23 Feb 2018 14:54:15 GMT
+      - Mon, 12 Mar 2018 14:22:52 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAOWUUW+bMBDHv4rlZx6gaULWN1NQE42aypBNXdUHJziJNbCRMduqad+9x8JSIN1LlU2T9oDA/7PvfP/7iYfvuNRKfhYGX2HPdd95/sydXbrYwU1l1IlYSCVqfPWAF4TdphFFNyxZ3UEgjAiN2D1iCQnxo4Ot/tqeDtgyzZIYNlS6thudi1ZMPTQlCxAFr61UO9Am07k3aSsobez+oHn+xWzug7bRjbLmCSRY5KISKhfKxnrDC2nHcrY3utntt9yIQ4TnpVSytoZb+UUQI/jgYkWbhjR2rw0kW1U5tyKE53DY6Cde3HJZjAMVN1byAhYDKxyUsWUSJikKCH3voL4vDuqqwsfRgrpZB40scmiZ8rJLvh4q/ZQQba/6q8Vux8B+B2uz49AyNKxVt2M8sGOJplz/nH43o2S7lRsR6G/9AJgL7Zbg7ssdc92sCxG+No0fTh+ryaXrebMXoo7rI0yUZCtGYhTRm5jQ8Dw4XbjTE5x8d/7P4zQyw0GLhC0/JRTeqzQ6E1GDnG9F6nRsfxkqfwSV34cqW7DlhwixiEYfSRBHKbqLr//vP9WrlpyJqLdC9Lsx/VGUHp8B5v82jvgGAAA=
     http_version: 
-  recorded_at: Fri, 23 Feb 2018 14:54:15 GMT
+  recorded_at: Mon, 12 Mar 2018 14:27:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_changed_company_no.yml
+++ b/spec/cassettes/registration_number_form_changed_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 26 Feb 2018 17:17:07 GMT
+      - Tue, 13 Mar 2018 10:16:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '595'
       X-Ratelimit-Reset:
-      - '1519665705'
+      - '1520936486'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -62,5 +62,5 @@ http_interactions:
         House Woodland Road","postal_code":"CT18 8DL","address_line_2":"Lyminge"},"accounts":{"last_accounts":{"period_end_on":"2017-02-28","period_start_on":"2016-03-01","made_up_to":"2017-02-28"},"accounting_reference_date":{"day":"28","month":"02"},"overdue":false,"next_due":"2018-11-30","next_made_up_to":"2018-02-28","next_accounts":{"overdue":false,"due_on":"2018-11-30","period_end_on":"2018-02-28","period_start_on":"2017-03-01"}},"company_name":"JIM
         GARRAHY''S FUDGE KITCHEN LIMITED","date_of_creation":"1983-03-24","sic_codes":["10822"],"undeliverable_registered_office_address":false,"last_full_members_list_date":"2015-11-20","type":"ltd","has_been_liquidated":false,"company_number":"01709418","jurisdiction":"england-wales","has_insolvency_history":false,"etag":"079ea458cdac90941922af7f7742f1d7cdf14cd1","has_charges":true,"company_status":"active","confirmation_statement":{"next_due":"2018-12-04","next_made_up_to":"2018-11-20","overdue":false,"last_made_up_to":"2017-11-20"},"links":{"self":"/company/01709418","filing_history":"/company/01709418/filing-history","officers":"/company/01709418/officers","charges":"/company/01709418/charges","persons_with_significant_control_statements":"/company/01709418/persons-with-significant-control-statements"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 26 Feb 2018 17:17:07 GMT
+  recorded_at: Tue, 13 Mar 2018 10:16:47 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_inactive_company_no.yml
+++ b/spec/cassettes/registration_number_form_inactive_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 26 Feb 2018 17:16:46 GMT
+      - Tue, 13 Mar 2018 10:16:27 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '596'
       X-Ratelimit-Reset:
-      - '1519665705'
+      - '1520936486'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Mon, 26 Feb 2018 17:16:46 GMT
+  recorded_at: Tue, 13 Mar 2018 10:16:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_not_found_company_no.yml
+++ b/spec/cassettes/registration_number_form_not_found_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 26 Feb 2018 17:16:46 GMT
+      - Tue, 13 Mar 2018 10:16:27 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '597'
       X-Ratelimit-Reset:
-      - '1519665705'
+      - '1520936486'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -60,5 +60,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
     http_version: 
-  recorded_at: Mon, 26 Feb 2018 17:16:46 GMT
+  recorded_at: Tue, 13 Mar 2018 10:16:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_short_company_no.yml
+++ b/spec/cassettes/registration_number_form_short_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 26 Feb 2018 17:16:45 GMT
+      - Tue, 13 Mar 2018 10:16:26 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '598'
       X-Ratelimit-Reset:
-      - '1519665705'
+      - '1520936486'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -64,5 +64,5 @@ http_interactions:
         Wycombe","region":"Bucks"},"jurisdiction":"england-wales","type":"ltd","undeliverable_registered_office_address":false,"sic_codes":["38110","38120","38210","38220"],"accounts":{"next_due":"2018-12-29","accounting_reference_date":{"day":"29","month":"03"},"next_accounts":{"due_on":"2018-12-29","period_start_on":"2017-03-25","overdue":false,"period_end_on":"2018-03-29"},"last_accounts":{"period_end_on":"2017-03-24","type":"full","made_up_to":"2017-03-24","period_start_on":"2016-03-26"},"next_made_up_to":"2018-03-29","overdue":false},"date_of_creation":"1969-01-16","has_insolvency_history":false,"etag":"71e17f2aaec9b698b7ff73a1cbf996dc9c88b933","has_charges":true,"company_status":"active","previous_company_names":[{"name":"BIFFA
         LIMITED","effective_from":"1969-01-16","ceased_on":"1986-04-22"}],"confirmation_statement":{"next_due":"2019-01-18","next_made_up_to":"2019-01-04","overdue":false,"last_made_up_to":"2018-01-04"},"links":{"self":"/company/00946107","filing_history":"/company/00946107/filing-history","officers":"/company/00946107/officers","charges":"/company/00946107/charges"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 26 Feb 2018 17:16:45 GMT
+  recorded_at: Tue, 13 Mar 2018 10:16:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/registration_number_form_valid_company_no.yml
+++ b/spec/cassettes/registration_number_form_valid_company_no.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 26 Feb 2018 17:16:45 GMT
+      - Tue, 13 Mar 2018 10:16:26 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '599'
       X-Ratelimit-Reset:
-      - '1519665705'
+      - '1520936486'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -61,5 +61,5 @@ http_interactions:
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_made_up_to":"2017-12-31","overdue":false,"next_accounts":{"period_end_on":"2017-12-31","due_on":"2018-09-30","period_start_on":"2017-01-01","overdue":false},"last_accounts":{"made_up_to":"2016-12-31","period_start_on":"2016-01-01","period_end_on":"2016-12-31"},"accounting_reference_date":{"day":"31","month":"12"},"next_due":"2018-09-30"},"undeliverable_registered_office_address":false,"etag":"d1aac62a36df9712e7ef94c383439a6fa001fa84","company_number":"09360070","registered_office_address":{"address_line_1":"21
         Haslam Avenue","postal_code":"SM3 9ND","region":"Surrey","locality":"Sutton"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"last_made_up_to":"2017-12-15","overdue":false,"next_made_up_to":"2018-12-15","next_due":"2018-12-29"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 26 Feb 2018 17:16:45 GMT
+  recorded_at: Tue, 13 Mar 2018 10:16:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/factories/forms/location_form.rb
+++ b/spec/factories/forms/location_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :location_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "location_form")) }
+    end
+  end
+end

--- a/spec/factories/forms/location_form.rb
+++ b/spec/factories/forms/location_form.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :location_form do
     trait :has_required_data do
+      location "england"
+
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "location_form")) }
     end
   end

--- a/spec/factories/forms/register_in_northern_ireland_form.rb
+++ b/spec/factories/forms/register_in_northern_ireland_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :register_in_northern_ireland_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "register_in_northern_ireland_form")) }
+    end
+  end
+end

--- a/spec/factories/forms/register_in_scotland_form.rb
+++ b/spec/factories/forms/register_in_scotland_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :register_in_scotland_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "register_in_scotland_form")) }
+    end
+  end
+end

--- a/spec/factories/forms/register_in_wales_form.rb
+++ b/spec/factories/forms/register_in_wales_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :register_in_wales_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "register_in_wales_form")) }
+    end
+  end
+end

--- a/spec/forms/location_forms_spec.rb
+++ b/spec/forms/location_forms_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe LocationForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:location_form) { build(:location_form, :has_required_data) }
+      let(:valid_params) { { reg_identifier: location_form.reg_identifier } }
+
+      it "should submit" do
+        expect(location_form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:location_form) { build(:location_form, :has_required_data) }
+      let(:invalid_params) { { reg_identifier: "foo" } }
+
+      it "should not submit" do
+        expect(location_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  context "when a valid transient registration exists" do
+    let(:transient_registration) do
+      create(:transient_registration,
+             :has_required_data,
+             workflow_state: "location_form")
+    end
+    # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+    let(:location_form) { LocationForm.new(transient_registration) }
+
+    describe "#reg_identifier" do
+      context "when a reg_identifier meets the requirements" do
+        before(:each) do
+          location_form.reg_identifier = transient_registration.reg_identifier
+        end
+
+        it "is valid" do
+          expect(location_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          location_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(location_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "location_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:location_form) { LocationForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        location_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(location_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        location_form.valid?
+        expect(location_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/forms/location_forms_spec.rb
+++ b/spec/forms/location_forms_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe LocationForm, type: :model do
   describe "#submit" do
     context "when the form is valid" do
       let(:location_form) { build(:location_form, :has_required_data) }
-      let(:valid_params) { { reg_identifier: location_form.reg_identifier } }
+      let(:valid_params) do
+        {
+          reg_identifier: location_form.reg_identifier,
+          location: location_form.location
+        }
+      end
 
       it "should submit" do
         expect(location_form.submit(valid_params)).to eq(true)
@@ -22,20 +27,10 @@ RSpec.describe LocationForm, type: :model do
   end
 
   context "when a valid transient registration exists" do
-    let(:transient_registration) do
-      create(:transient_registration,
-             :has_required_data,
-             workflow_state: "location_form")
-    end
-    # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
-    let(:location_form) { LocationForm.new(transient_registration) }
+    let(:location_form) { build(:location_form, :has_required_data) }
 
     describe "#reg_identifier" do
       context "when a reg_identifier meets the requirements" do
-        before(:each) do
-          location_form.reg_identifier = transient_registration.reg_identifier
-        end
-
         it "is valid" do
           expect(location_form).to be_valid
         end
@@ -44,6 +39,34 @@ RSpec.describe LocationForm, type: :model do
       context "when a reg_identifier is blank" do
         before(:each) do
           location_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(location_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#location" do
+      context "when a location meets the requirements" do
+        it "is valid" do
+          expect(location_form).to be_valid
+        end
+      end
+
+      context "when a location is blank" do
+        before(:each) do
+          location_form.location = ""
+        end
+
+        it "is not valid" do
+          expect(location_form).to_not be_valid
+        end
+      end
+
+      context "when a location is not in the allowed list" do
+        before(:each) do
+          location_form.location = "foo"
         end
 
         it "is not valid" do

--- a/spec/forms/register_in_northern_ireland_forms_spec.rb
+++ b/spec/forms/register_in_northern_ireland_forms_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe RegisterInNorthernIrelandForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:register_in_northern_ireland_form) { build(:register_in_northern_ireland_form, :has_required_data) }
+      let(:valid_params) do
+        {
+          reg_identifier: register_in_northern_ireland_form.reg_identifier
+        }
+      end
+
+      it "should submit" do
+        expect(register_in_northern_ireland_form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:register_in_northern_ireland_form) { build(:register_in_northern_ireland_form, :has_required_data) }
+      let(:invalid_params) { { reg_identifier: "foo" } }
+
+      it "should not submit" do
+        expect(register_in_northern_ireland_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  context "when a valid transient registration exists" do
+    let(:register_in_northern_ireland_form) { build(:register_in_northern_ireland_form, :has_required_data) }
+
+    describe "#reg_identifier" do
+      context "when a reg_identifier meets the requirements" do
+        it "is valid" do
+          expect(register_in_northern_ireland_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          register_in_northern_ireland_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(register_in_northern_ireland_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "register_in_northern_ireland_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:register_in_northern_ireland_form) { RegisterInNorthernIrelandForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        register_in_northern_ireland_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(register_in_northern_ireland_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        register_in_northern_ireland_form.valid?
+        expect(register_in_northern_ireland_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/forms/register_in_scotland_forms_spec.rb
+++ b/spec/forms/register_in_scotland_forms_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe RegisterInScotlandForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:register_in_scotland_form) { build(:register_in_scotland_form, :has_required_data) }
+      let(:valid_params) do
+        {
+          reg_identifier: register_in_scotland_form.reg_identifier
+        }
+      end
+
+      it "should submit" do
+        expect(register_in_scotland_form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:register_in_scotland_form) { build(:register_in_scotland_form, :has_required_data) }
+      let(:invalid_params) { { reg_identifier: "foo" } }
+
+      it "should not submit" do
+        expect(register_in_scotland_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  context "when a valid transient registration exists" do
+    let(:register_in_scotland_form) { build(:register_in_scotland_form, :has_required_data) }
+
+    describe "#reg_identifier" do
+      context "when a reg_identifier meets the requirements" do
+        it "is valid" do
+          expect(register_in_scotland_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          register_in_scotland_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(register_in_scotland_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "register_in_scotland_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:register_in_scotland_form) { RegisterInScotlandForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        register_in_scotland_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(register_in_scotland_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        register_in_scotland_form.valid?
+        expect(register_in_scotland_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/forms/register_in_wales_forms_spec.rb
+++ b/spec/forms/register_in_wales_forms_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe RegisterInWalesForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:register_in_wales_form) { build(:register_in_wales_form, :has_required_data) }
+      let(:valid_params) do
+        {
+          reg_identifier: register_in_wales_form.reg_identifier
+        }
+      end
+
+      it "should submit" do
+        expect(register_in_wales_form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:register_in_wales_form) { build(:register_in_wales_form, :has_required_data) }
+      let(:invalid_params) { { reg_identifier: "foo" } }
+
+      it "should not submit" do
+        expect(register_in_wales_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  context "when a valid transient registration exists" do
+    let(:register_in_wales_form) { build(:register_in_wales_form, :has_required_data) }
+
+    describe "#reg_identifier" do
+      context "when a reg_identifier meets the requirements" do
+        it "is valid" do
+          expect(register_in_wales_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          register_in_wales_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(register_in_wales_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "register_in_wales_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:register_in_wales_form) { RegisterInWalesForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        register_in_wales_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(register_in_wales_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        register_in_wales_form.valid?
+        expect(register_in_wales_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
@@ -49,20 +49,19 @@ RSpec.describe TransientRegistration, type: :model do
         {
           # Permutation table of old business_type, new business_type and the state that should result
           # Example where the business_type doesn't change:
-          %w[limitedCompany limitedCompany] => :other_businesses_form,
-          %w[charity charity]               => :cannot_renew_lower_tier_form,
+          %w[limitedCompany limitedCompany]              => :other_businesses_form,
+          %w[charity charity]                            => :cannot_renew_lower_tier_form,
           # Examples where the business_type change is allowed and not allowed:
-          %w[authority localAuthority]      => :other_businesses_form,
-          %w[authority limitedCompany]      => :cannot_renew_type_change_form,
-          %w[charity limitedCompany]        => :cannot_renew_type_change_form,
-          %w[limitedCompany overseas]       => :other_businesses_form,
-          %w[limitedCompany soleTrader]     => :cannot_renew_type_change_form,
-          %w[partnership overseas]          => :other_businesses_form,
-          %w[partnership soleTrader]        => :cannot_renew_type_change_form,
-          %w[publicBody localAuthority]     => :other_businesses_form,
-          %w[publicBody soleTrader]         => :cannot_renew_type_change_form,
-          %w[soleTrader overseas]           => :other_businesses_form,
-          %w[soleTrader limitedCompany]     => :cannot_renew_type_change_form,
+          %w[authority localAuthority]                   => :other_businesses_form,
+          %w[authority limitedCompany]                   => :cannot_renew_type_change_form,
+          %w[charity limitedCompany]                     => :cannot_renew_type_change_form,
+          %w[limitedCompany limitedLiabilityPartnership] => :other_businesses_form,
+          %w[limitedCompany soleTrader]                  => :cannot_renew_type_change_form,
+          %w[partnership limitedLiabilityPartnership]    => :other_businesses_form,
+          %w[partnership soleTrader]                     => :cannot_renew_type_change_form,
+          %w[publicBody localAuthority]                  => :other_businesses_form,
+          %w[publicBody soleTrader]                      => :cannot_renew_type_change_form,
+          %w[soleTrader limitedCompany]                  => :cannot_renew_type_change_form,
           # Example where the business_type was invalid to begin with:
           %w[foo limitedCompany]            => :cannot_renew_type_change_form
         }.each do |business_types, next_form|

--- a/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe TransientRegistration, type: :model do
       end
 
       context "when the 'back' event happens" do
-        it "changes to :renewal_start_form" do
-          expect(transient_registration).to transition_from(:business_type_form).to(:renewal_start_form).on_event(:back)
+        it "changes to :location_form" do
+          expect(transient_registration).to transition_from(:business_type_form).to(:location_form).on_event(:back)
         end
       end
 

--- a/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
@@ -10,8 +10,24 @@ RSpec.describe TransientRegistration, type: :model do
       end
 
       context "when the 'back' event happens" do
-        it "changes to :location_form" do
-          expect(transient_registration).to transition_from(:business_type_form).to(:location_form).on_event(:back)
+        shared_examples_for "'back' transition from business_type_form" do |location, back_state|
+          before(:each) do
+            transient_registration.location = location
+          end
+
+          it "should transition to the correct back state" do
+            expect(transient_registration).to transition_from(:business_type_form).to(back_state).on_event(:back)
+          end
+        end
+
+        {
+          # Permutation table of location and the state that should result
+          "england"          => :location_form,
+          "northern_ireland" => :register_in_northern_ireland_form,
+          "scotland"         => :register_in_scotland_form,
+          "wales"            => :register_in_wales_form
+        }.each do |location, back_form|
+          it_behaves_like "'back' transition from business_type_form", location, back_form
         end
       end
 

--- a/spec/models/workflow_states/transient_registration_company_address_manual_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_company_address_manual_form_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe TransientRegistration, type: :model do
                workflow_state: "company_address_manual_form")
       end
 
-      context "when the business_type is 'overseas'" do
-        before(:each) { transient_registration.business_type = "overseas" }
+      context "when the business is 'overseas'" do
+        before(:each) { transient_registration.location = "overseas" }
 
         it "changes to :company_name_form after the 'back' event" do
           expect(transient_registration).to transition_from(:company_address_manual_form).to(:company_name_form).on_event(:back)
         end
       end
 
-      context "when the business_type is not 'overseas'" do
-        before(:each) { transient_registration.business_type = "limitedCompany" }
+      context "when the business is not 'overseas'" do
+        before(:each) { transient_registration.location = "england" }
 
         it "changes to :company_postcode_form after the 'back' event" do
           expect(transient_registration).to transition_from(:company_address_manual_form).to(:company_postcode_form).on_event(:back)

--- a/spec/models/workflow_states/transient_registration_company_name_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_company_name_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TransientRegistration, type: :model do
       context "when the business type is localAuthority" do
         before(:each) { transient_registration.business_type = "localAuthority" }
 
-        it "changes to :renewal_infromation_form after the 'back' event" do
+        it "changes to :renewal_information_form after the 'back' event" do
           expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
         end
       end
@@ -33,18 +33,10 @@ RSpec.describe TransientRegistration, type: :model do
         end
       end
 
-      context "when the business type is overseas" do
-        before(:each) { transient_registration.business_type = "overseas" }
-
-        it "changes to :renewal_infromation_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
-        end
-      end
-
       context "when the business type is partnership" do
         before(:each) { transient_registration.business_type = "partnership" }
 
-        it "changes to :renewal_infromation_form after the 'back' event" do
+        it "changes to :renewal_information_form after the 'back' event" do
           expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
         end
       end
@@ -52,24 +44,28 @@ RSpec.describe TransientRegistration, type: :model do
       context "when the business type is soleTrader" do
         before(:each) { transient_registration.business_type = "soleTrader" }
 
-        it "changes to :renewal_infromation_form after the 'back' event" do
+        it "changes to :renewal_information_form after the 'back' event" do
           expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
         end
       end
 
-      context "when the business type is not overseas" do
-        before(:each) { transient_registration.business_type = "limitedCompany" }
+      context "when the location is overseas" do
+        before(:each) { transient_registration.location = "overseas" }
 
-        it "changes to :company_postcode_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:company_name_form).to(:company_postcode_form).on_event(:next)
+        it "changes to :renewal_information_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:company_name_form).to(:renewal_information_form).on_event(:back)
         end
-      end
-
-      context "when the business type is overseas" do
-        before(:each) { transient_registration.business_type = "overseas" }
 
         it "changes to :company_address_manual_form after the 'next' event" do
           expect(transient_registration).to transition_from(:company_name_form).to(:company_address_manual_form).on_event(:next)
+        end
+      end
+
+      context "when the location is not overseas" do
+        before(:each) { transient_registration.location = "england" }
+
+        it "changes to :company_postcode_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:company_name_form).to(:company_postcode_form).on_event(:next)
         end
       end
     end

--- a/spec/models/workflow_states/transient_registration_location_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_location_form_spec.rb
@@ -13,8 +13,44 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:location_form).to(:renewal_start_form).on_event(:back)
       end
 
-      it "changes to :business_type_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:location_form).to(:business_type_form).on_event(:next)
+      context "when the location is 'england'" do
+        before(:each) { transient_registration.location = "england" }
+
+        it "changes to :business_type_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:location_form).to(:business_type_form).on_event(:next)
+        end
+      end
+
+      context "when the location is 'northern_ireland'" do
+        before(:each) { transient_registration.location = "northern_ireland" }
+
+        it "changes to :register_in_northern_ireland_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:location_form).to(:register_in_northern_ireland_form).on_event(:next)
+        end
+      end
+
+      context "when the location is 'scotland'" do
+        before(:each) { transient_registration.location = "scotland" }
+
+        it "changes to :register_in_scotland_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:location_form).to(:register_in_scotland_form).on_event(:next)
+        end
+      end
+
+      context "when the location is 'wales'" do
+        before(:each) { transient_registration.location = "wales" }
+
+        it "changes to :register_in_wales_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:location_form).to(:register_in_wales_form).on_event(:next)
+        end
+      end
+
+      context "when the location is 'overseas'" do
+        before(:each) { transient_registration.location = "overseas" }
+
+        it "changes to :other_businesses_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:location_form).to(:other_businesses_form).on_event(:next)
+        end
       end
     end
   end

--- a/spec/models/workflow_states/transient_registration_location_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_location_form_spec.rb
@@ -13,43 +13,26 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:location_form).to(:renewal_start_form).on_event(:back)
       end
 
-      context "when the location is 'england'" do
-        before(:each) { transient_registration.location = "england" }
+      context "when the 'next' event happens" do
+        shared_examples_for "'next' transition from location_form" do |location, next_state|
+          before(:each) do
+            transient_registration.location = location
+          end
 
-        it "changes to :business_type_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:location_form).to(:business_type_form).on_event(:next)
+          it "should transition to the correct next state" do
+            expect(transient_registration).to transition_from(:location_form).to(next_state).on_event(:next)
+          end
         end
-      end
 
-      context "when the location is 'northern_ireland'" do
-        before(:each) { transient_registration.location = "northern_ireland" }
-
-        it "changes to :register_in_northern_ireland_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:location_form).to(:register_in_northern_ireland_form).on_event(:next)
-        end
-      end
-
-      context "when the location is 'scotland'" do
-        before(:each) { transient_registration.location = "scotland" }
-
-        it "changes to :register_in_scotland_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:location_form).to(:register_in_scotland_form).on_event(:next)
-        end
-      end
-
-      context "when the location is 'wales'" do
-        before(:each) { transient_registration.location = "wales" }
-
-        it "changes to :register_in_wales_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:location_form).to(:register_in_wales_form).on_event(:next)
-        end
-      end
-
-      context "when the location is 'overseas'" do
-        before(:each) { transient_registration.location = "overseas" }
-
-        it "changes to :other_businesses_form after the 'next' event" do
-          expect(transient_registration).to transition_from(:location_form).to(:other_businesses_form).on_event(:next)
+        {
+          # Permutation table of location and the state that should result
+          "england"          => :business_type_form,
+          "northern_ireland" => :register_in_northern_ireland_form,
+          "scotland"         => :register_in_scotland_form,
+          "wales"            => :register_in_wales_form,
+          "overseas"         => :other_businesses_form
+        }.each do |location, next_form|
+          it_behaves_like "'next' transition from location_form", location, next_form
         end
       end
     end

--- a/spec/models/workflow_states/transient_registration_location_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_location_form_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :location_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "location_form")
+      end
+
+      it "changes to :renewal_start_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:location_form).to(:renewal_start_form).on_event(:back)
+      end
+
+      it "changes to :business_type_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:location_form).to(:business_type_form).on_event(:next)
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_other_businesses_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_other_businesses_form_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:other_businesses_form).to(:business_type_form).on_event(:back)
       end
 
+      context "when the business is overseas" do
+        before(:each) { transient_registration.location = "overseas" }
+
+        it "transitions to :location_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:other_businesses_form).to(:location_form).on_event(:back)
+        end
+      end
+
       context "when the business does not carry waste for other businesses or households" do
         before(:each) { transient_registration.other_businesses = false }
 

--- a/spec/models/workflow_states/transient_registration_register_in_northern_ireland_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_register_in_northern_ireland_form_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :register_in_northern_ireland_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "register_in_northern_ireland_form")
+      end
+
+      it "changes to :location_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:register_in_northern_ireland_form).to(:location_form).on_event(:back)
+      end
+
+      it "changes to :business_type_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:register_in_northern_ireland_form).to(:business_type_form).on_event(:next)
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_register_in_scotland_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_register_in_scotland_form_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :register_in_scotland_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "register_in_scotland_form")
+      end
+
+      it "changes to :location_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:register_in_scotland_form).to(:location_form).on_event(:back)
+      end
+
+      it "changes to :business_type_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:register_in_scotland_form).to(:business_type_form).on_event(:next)
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_register_in_wales_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_register_in_wales_form_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :register_in_wales_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "register_in_wales_form")
+      end
+
+      it "changes to :location_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:register_in_wales_form).to(:location_form).on_event(:back)
+      end
+
+      it "changes to :business_type_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:register_in_wales_form).to(:business_type_form).on_event(:next)
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_renewal_information_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_renewal_information_form_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe TransientRegistration, type: :model do
         end
       end
 
-      context "when the business type is overseas" do
-        before(:each) { transient_registration.business_type = "overseas" }
+      context "when the location is overseas" do
+        before(:each) { transient_registration.location = "overseas" }
 
         it "changes to :company_name_form after the 'next' event" do
           expect(transient_registration).to transition_from(:renewal_information_form).to(:company_name_form).on_event(:next)

--- a/spec/models/workflow_states/transient_registration_renewal_start_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_renewal_start_form_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to_not allow_event :back
       end
 
-      it "changes to :business_type_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:renewal_start_form).to(:business_type_form).on_event(:next)
+      it "changes to :location_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:renewal_start_form).to(:location_form).on_event(:next)
       end
     end
   end

--- a/spec/requests/business_type_forms_spec.rb
+++ b/spec/requests/business_type_forms_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
           let(:valid_params) {
             {
               reg_identifier: transient_registration[:reg_identifier],
-              business_type: "overseas"
+              business_type: "limitedLiabilityPartnership"
             }
           }
 

--- a/spec/requests/business_type_forms_spec.rb
+++ b/spec/requests/business_type_forms_spec.rb
@@ -196,9 +196,9 @@ RSpec.describe "BusinessTypeForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the renewal start form" do
+          it "redirects to the location form" do
             get back_business_type_forms_path(transient_registration[:reg_identifier])
-            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_location_form_path(transient_registration[:reg_identifier]))
           end
         end
       end

--- a/spec/requests/company_address_manual_forms_spec.rb
+++ b/spec/requests/company_address_manual_forms_spec.rb
@@ -187,8 +187,8 @@ RSpec.describe "CompanyAddressManualForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          context "when the business_type is 'overseas'" do
-            before(:each) { transient_registration.update_attributes(business_type: "overseas") }
+          context "when the location is 'overseas'" do
+            before(:each) { transient_registration.update_attributes(location: "overseas") }
 
             it "redirects to the company_name form" do
               get back_company_address_manual_forms_path(transient_registration[:reg_identifier])
@@ -196,8 +196,8 @@ RSpec.describe "CompanyAddressManualForms", type: :request do
             end
           end
 
-          context "when the business_type is not 'overseas'" do
-            before(:each) { transient_registration.update_attributes(business_type: "limitedCompany") }
+          context "when the location is not 'overseas'" do
+            before(:each) { transient_registration.update_attributes(location: "england") }
 
             it "redirects to the company_postcode form" do
               get back_company_address_manual_forms_path(transient_registration[:reg_identifier])

--- a/spec/requests/company_name_forms_spec.rb
+++ b/spec/requests/company_name_forms_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe "CompanyNameForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          context "when the business type is not overseas" do
-            before(:each) { transient_registration.update_attributes(business_type: "limitedCompany") }
+          context "when the location is not overseas" do
+            before(:each) { transient_registration.update_attributes(location: "england") }
 
             it "redirects to the company_postcode form" do
               post company_name_forms_path, company_name_form: valid_params
@@ -80,8 +80,8 @@ RSpec.describe "CompanyNameForms", type: :request do
             end
           end
 
-          context "when the business type is overseas" do
-            before(:each) { transient_registration.update_attributes(business_type: "overseas") }
+          context "when the location is overseas" do
+            before(:each) { transient_registration.update_attributes(location: "overseas") }
 
             it "redirects to the company_address_manual form" do
               post company_name_forms_path, company_name_form: valid_params
@@ -191,8 +191,8 @@ RSpec.describe "CompanyNameForms", type: :request do
             end
           end
 
-          context "when the business type is overseas" do
-            before(:each) { transient_registration.update_attributes(business_type: "overseas") }
+          context "when the location is overseas" do
+            before(:each) { transient_registration.update_attributes(location: "overseas") }
 
             it "redirects to the renewal_information form" do
               get back_company_name_forms_path(transient_registration[:reg_identifier])

--- a/spec/requests/location_forms_spec.rb
+++ b/spec/requests/location_forms_spec.rb
@@ -56,12 +56,14 @@ RSpec.describe "LocationForms", type: :request do
         context "when valid params are submitted" do
           let(:valid_params) {
             {
-              reg_identifier: transient_registration[:reg_identifier]
+              reg_identifier: transient_registration[:reg_identifier],
+              location: "england"
             }
           }
 
           it "updates the transient registration" do
-            # TODO: Add test once data is submitted through the form
+            post location_forms_path, location_form: valid_params
+            expect(transient_registration.reload[:location]).to eq(valid_params[:location])
           end
 
           it "returns a 302 response" do
@@ -78,7 +80,8 @@ RSpec.describe "LocationForms", type: :request do
         context "when invalid params are submitted" do
           let(:invalid_params) {
             {
-              reg_identifier: "foo"
+              reg_identifier: "foo",
+              location: "bar"
             }
           }
 
@@ -89,7 +92,7 @@ RSpec.describe "LocationForms", type: :request do
 
           it "does not update the transient registration" do
             post location_forms_path, location_form: invalid_params
-            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+            expect(transient_registration.reload[:location]).to_not eq(invalid_params[:location])
           end
         end
       end
@@ -104,12 +107,14 @@ RSpec.describe "LocationForms", type: :request do
 
         let(:valid_params) {
           {
-            reg_identifier: transient_registration[:reg_identifier]
+            reg_identifier: transient_registration[:reg_identifier],
+            location: "England"
           }
         }
 
         it "does not update the transient registration" do
-          # TODO: Add test once data is submitted through the form
+          post location_forms_path, location_form: valid_params
+          expect(transient_registration.reload[:location]).to_not eq(valid_params[:location])
         end
 
         it "returns a 302 response" do

--- a/spec/requests/location_forms_spec.rb
+++ b/spec/requests/location_forms_spec.rb
@@ -1,0 +1,178 @@
+require "rails_helper"
+
+RSpec.describe "LocationForms", type: :request do
+  describe "GET new_location_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "location_form")
+        end
+
+        it "returns a success response" do
+          get new_location_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "contact_name_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_location_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_contact_name_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "POST location_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "location_form")
+        end
+
+        context "when valid params are submitted" do
+          let(:valid_params) {
+            {
+              reg_identifier: transient_registration[:reg_identifier]
+            }
+          }
+
+          it "updates the transient registration" do
+            # TODO: Add test once data is submitted through the form
+          end
+
+          it "returns a 302 response" do
+            post location_forms_path, location_form: valid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            post location_forms_path, location_form: valid_params
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+
+        context "when invalid params are submitted" do
+          let(:invalid_params) {
+            {
+              reg_identifier: "foo"
+            }
+          }
+
+          it "returns a 302 response" do
+            post location_forms_path, location_form: invalid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "does not update the transient registration" do
+            post location_forms_path, location_form: invalid_params
+            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "company_name_form")
+        end
+
+        let(:valid_params) {
+          {
+            reg_identifier: transient_registration[:reg_identifier]
+          }
+        }
+
+        it "does not update the transient registration" do
+          # TODO: Add test once data is submitted through the form
+        end
+
+        it "returns a 302 response" do
+          post location_forms_path, location_form: valid_params
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the correct form for the state" do
+          post location_forms_path, location_form: valid_params
+          expect(response).to redirect_to(new_company_name_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_location_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "location_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_location_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the renewal_start form" do
+            get back_location_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "company_name_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_location_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_location_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_company_name_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/register_in_northern_ireland_forms_spec.rb
+++ b/spec/requests/register_in_northern_ireland_forms_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.describe "RegisterInNorthernIrelandForms", type: :request do
+  describe "GET new_register_in_northern_ireland_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_northern_ireland_form")
+        end
+
+        it "returns a success response" do
+          get new_register_in_northern_ireland_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_register_in_northern_ireland_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "POST register_in_northern_ireland_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_northern_ireland_form")
+        end
+
+        context "when valid params are submitted" do
+          let(:valid_params) {
+            {
+              reg_identifier: transient_registration[:reg_identifier]
+            }
+          }
+
+          it "returns a 302 response" do
+            post register_in_northern_ireland_forms_path, register_in_northern_ireland_form: valid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            post register_in_northern_ireland_forms_path, register_in_northern_ireland_form: valid_params
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+
+        context "when invalid params are submitted" do
+          let(:invalid_params) {
+            {
+              reg_identifier: "foo"
+            }
+          }
+
+          it "returns a 302 response" do
+            post register_in_northern_ireland_forms_path, register_in_northern_ireland_form: invalid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "does not update the transient registration" do
+            post register_in_northern_ireland_forms_path, register_in_northern_ireland_form: invalid_params
+            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        let(:valid_params) {
+          {
+            reg_identifier: transient_registration[:reg_identifier]
+          }
+        }
+
+        it "returns a 302 response" do
+          post register_in_northern_ireland_forms_path, register_in_northern_ireland_form: valid_params
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the correct form for the state" do
+          post register_in_northern_ireland_forms_path, register_in_northern_ireland_form: valid_params
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_register_in_northern_ireland_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_northern_ireland_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_register_in_northern_ireland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the location form" do
+            get back_register_in_northern_ireland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_location_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_register_in_northern_ireland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_register_in_northern_ireland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/register_in_scotland_forms_spec.rb
+++ b/spec/requests/register_in_scotland_forms_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.describe "RegisterInScotlandForms", type: :request do
+  describe "GET new_register_in_scotland_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_scotland_form")
+        end
+
+        it "returns a success response" do
+          get new_register_in_scotland_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_register_in_scotland_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "POST register_in_scotland_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_scotland_form")
+        end
+
+        context "when valid params are submitted" do
+          let(:valid_params) {
+            {
+              reg_identifier: transient_registration[:reg_identifier]
+            }
+          }
+
+          it "returns a 302 response" do
+            post register_in_scotland_forms_path, register_in_scotland_form: valid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            post register_in_scotland_forms_path, register_in_scotland_form: valid_params
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+
+        context "when invalid params are submitted" do
+          let(:invalid_params) {
+            {
+              reg_identifier: "foo"
+            }
+          }
+
+          it "returns a 302 response" do
+            post register_in_scotland_forms_path, register_in_scotland_form: invalid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "does not update the transient registration" do
+            post register_in_scotland_forms_path, register_in_scotland_form: invalid_params
+            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        let(:valid_params) {
+          {
+            reg_identifier: transient_registration[:reg_identifier]
+          }
+        }
+
+        it "returns a 302 response" do
+          post register_in_scotland_forms_path, register_in_scotland_form: valid_params
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the correct form for the state" do
+          post register_in_scotland_forms_path, register_in_scotland_form: valid_params
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_register_in_scotland_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_scotland_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_register_in_scotland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the location form" do
+            get back_register_in_scotland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_location_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_register_in_scotland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_register_in_scotland_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/register_in_wales_forms_spec.rb
+++ b/spec/requests/register_in_wales_forms_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.describe "RegisterInWalesForms", type: :request do
+  describe "GET new_register_in_wales_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_wales_form")
+        end
+
+        it "returns a success response" do
+          get new_register_in_wales_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_register_in_wales_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "POST register_in_wales_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_wales_form")
+        end
+
+        context "when valid params are submitted" do
+          let(:valid_params) {
+            {
+              reg_identifier: transient_registration[:reg_identifier]
+            }
+          }
+
+          it "returns a 302 response" do
+            post register_in_wales_forms_path, register_in_wales_form: valid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            post register_in_wales_forms_path, register_in_wales_form: valid_params
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+
+        context "when invalid params are submitted" do
+          let(:invalid_params) {
+            {
+              reg_identifier: "foo"
+            }
+          }
+
+          it "returns a 302 response" do
+            post register_in_wales_forms_path, register_in_wales_form: invalid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "does not update the transient registration" do
+            post register_in_wales_forms_path, register_in_wales_form: invalid_params
+            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        let(:valid_params) {
+          {
+            reg_identifier: transient_registration[:reg_identifier]
+          }
+        }
+
+        it "returns a 302 response" do
+          post register_in_wales_forms_path, register_in_wales_form: valid_params
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the correct form for the state" do
+          post register_in_wales_forms_path, register_in_wales_form: valid_params
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_register_in_wales_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "register_in_wales_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_register_in_wales_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the location form" do
+            get back_register_in_wales_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_location_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_register_in_wales_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_register_in_wales_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/renewal_information_forms_spec.rb
+++ b/spec/requests/renewal_information_forms_spec.rb
@@ -60,10 +60,6 @@ RSpec.describe "RenewalInformationForms", type: :request do
             }
           }
 
-          it "updates the transient registration" do
-            # TODO: Add test once data is submitted through the form
-          end
-
           it "returns a 302 response" do
             post renewal_information_forms_path, renewal_information_form: valid_params
             expect(response).to have_http_status(302)
@@ -96,8 +92,8 @@ RSpec.describe "RenewalInformationForms", type: :request do
             end
           end
 
-          context "when the business type is overseas" do
-            before(:each) { transient_registration.update_attributes(business_type: "overseas") }
+          context "when the location is overseas" do
+            before(:each) { transient_registration.update_attributes(location: "overseas") }
 
             it "redirects to the company_name form" do
               post renewal_information_forms_path, renewal_information_form: valid_params
@@ -156,10 +152,6 @@ RSpec.describe "RenewalInformationForms", type: :request do
             reg_identifier: transient_registration[:reg_identifier]
           }
         }
-
-        it "does not update the transient registration" do
-          # TODO: Add test once data is submitted through the form
-        end
 
         it "returns a 302 response" do
           post renewal_information_forms_path, renewal_information_form: valid_params

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe "RenewalStartForms", type: :request do
                 create(:transient_registration,
                        :has_required_data,
                        account_email: user.email,
-                       workflow_state: "business_type_form")
+                       workflow_state: "location_form")
               end
 
               it "redirects to the form for the current state" do
                 get new_renewal_start_form_path(transient_registration[:reg_identifier])
-                expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+                expect(response).to redirect_to(new_location_form_path(transient_registration[:reg_identifier]))
               end
             end
           end
@@ -193,7 +193,7 @@ RSpec.describe "RenewalStartForms", type: :request do
 
               it "redirects to the business type form" do
                 post renewal_start_forms_path, renewal_start_form: valid_params
-                expect(response).to redirect_to(new_business_type_form_path(valid_params[:reg_identifier]))
+                expect(response).to redirect_to(new_location_form_path(valid_params[:reg_identifier]))
               end
             end
 
@@ -227,7 +227,7 @@ RSpec.describe "RenewalStartForms", type: :request do
 
           it "redirects to the business type form" do
             post renewal_start_forms_path, renewal_start_form: valid_params
-            expect(response).to redirect_to(new_business_type_form_path(valid_params[:reg_identifier]))
+            expect(response).to redirect_to(new_location_form_path(valid_params[:reg_identifier]))
           end
 
           it "does not create a new transient registration" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-238

This PR adds a new form to ask where the business is based - England, Wales, Scotland, Northern Ireland or overseas.

Wales, Scotland and Northern Ireland have their own registers for waste carriers. This form will allow us to direct those users to the correct service which they should be registering with. Users can continue to register with the EA if they want, but this will at least make them aware of the other registry.

Overseas users operating in England should register with the EA - however, there are some differences in what forms they see (for example, the address forms). Currently we filter them out using the 'overseas' option on the business type form, but 'overseas' makes a lot more sense as a location than a business type.