### PR TITLE
 Clean data when creating and saving transient registrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem "rest-client", "~> 2.0"
 
 gem "secure_headers", "~> 5.0"
 
+# Validations
+gem "phonelib", require: false
 gem "uk_postcode", require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     origin (2.3.1)
     orm_adapter (0.5.0)
+    phonelib (0.6.20)
     public_suffix (3.0.2)
     rack (1.6.9)
     rack-test (0.6.3)
@@ -276,6 +277,7 @@ DEPENDENCIES
   loofah (>= 2.2.1)
   mongo (= 2.4.3)
   mongoid (~> 5.2)
+  phonelib
   rails (= 4.2.10)
   rails-html-sanitizer (>= 1.0.4)
   rails_12factor

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -50,11 +50,14 @@ class BaseForm
   def strip_excess_whitespace(attributes)
     # Loop over each value and strip the whitespace, or strip the whitespace from values nested within it
     attributes.each_pair do |_key, value|
-      strip_string(value) if value.is_a?(String)
-      strip_hash(value) if value.is_a?(Hash)
-      strip_array(value) if value.is_a?(Array)
+      if value.is_a?(String)
+        strip_string(value)
+      elsif value.is_a?(Hash)
+        strip_hash(value)
+      elsif value.is_a?(Array)
+        strip_array(value)
+      end
     end
-    attributes
   end
 
   def strip_string(string)

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -1,5 +1,6 @@
 class BaseForm
   include ActiveModel::Model
+  include CanStripWhitespace
   attr_accessor :reg_identifier, :transient_registration
 
   def initialize(transient_registration)
@@ -12,7 +13,7 @@ class BaseForm
     # Additional attributes are set in individual form subclasses
     self.reg_identifier = reg_identifier
 
-    attributes = strip_excess_whitespace(attributes)
+    attributes = strip_whitespace(attributes)
 
     # Update the transient registration with params from the registration if valid
     if valid?
@@ -42,35 +43,6 @@ class BaseForm
     return if @transient_registration.valid?
     @transient_registration.errors.each do |_attribute, message|
       errors[:base] << message
-    end
-  end
-
-  # Whitespace stripping
-
-  def strip_excess_whitespace(attributes)
-    # Loop over each value and strip the whitespace, or strip the whitespace from values nested within it
-    attributes.each_pair do |_key, value|
-      if value.is_a?(String)
-        strip_string(value)
-      elsif value.is_a?(Hash)
-        strip_hash(value)
-      elsif value.is_a?(Array)
-        strip_array(value)
-      end
-    end
-  end
-
-  def strip_string(string)
-    string.strip!
-  end
-
-  def strip_hash(hash)
-    strip_excess_whitespace(hash)
-  end
-
-  def strip_array(array)
-    array.each do |nested_object|
-      strip_excess_whitespace(nested_object.attributes)
     end
   end
 end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -12,6 +12,8 @@ class BaseForm
     # Additional attributes are set in individual form subclasses
     self.reg_identifier = reg_identifier
 
+    attributes = strip_excess_whitespace(attributes)
+
     # Update the transient registration with params from the registration if valid
     if valid?
       @transient_registration.update_attributes(attributes)
@@ -40,6 +42,32 @@ class BaseForm
     return if @transient_registration.valid?
     @transient_registration.errors.each do |_attribute, message|
       errors[:base] << message
+    end
+  end
+
+  # Whitespace stripping
+
+  def strip_excess_whitespace(attributes)
+    # Loop over each value and strip the whitespace, or strip the whitespace from values nested within it
+    attributes.each_pair do |_key, value|
+      strip_string(value) if value.is_a?(String)
+      strip_hash(value) if value.is_a?(Hash)
+      strip_array(value) if value.is_a?(Array)
+    end
+    attributes
+  end
+
+  def strip_string(string)
+    string.strip!
+  end
+
+  def strip_hash(hash)
+    strip_excess_whitespace(hash)
+  end
+
+  def strip_array(array)
+    array.each do |nested_object|
+      strip_excess_whitespace(nested_object.attributes)
     end
   end
 end

--- a/app/forms/company_name_form.rb
+++ b/app/forms/company_name_form.rb
@@ -10,7 +10,6 @@ class CompanyNameForm < BaseForm
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    params[:company_name].strip! if params[:company_name].present?
     self.company_name = params[:company_name]
     attributes = { company_name: company_name }
 

--- a/app/helpers/registrations_helper.rb
+++ b/app/helpers/registrations_helper.rb
@@ -1,2 +1,0 @@
-module RegistrationsHelper
-end

--- a/app/models/concerns/can_strip_whitespace.rb
+++ b/app/models/concerns/can_strip_whitespace.rb
@@ -1,0 +1,34 @@
+# Used to clean up excess whitespace from the start and end of fields
+module CanStripWhitespace
+  extend ActiveSupport::Concern
+
+  # Expects a hash of attributes or a Mongoid object
+  def strip_whitespace(attributes)
+    # Loop over each value and strip the whitespace, or strip the whitespace from values nested within it
+    attributes.each_pair do |_key, value|
+      if value.is_a?(String)
+        strip_string(value)
+      elsif value.is_a?(Hash)
+        strip_hash(value)
+      elsif value.is_a?(Array)
+        strip_array(value)
+      end
+    end
+  end
+
+  private
+
+  def strip_string(string)
+    string.strip!
+  end
+
+  def strip_hash(hash)
+    strip_whitespace(hash)
+  end
+
+  def strip_array(array)
+    array.each do |nested_object|
+      strip_whitespace(nested_object.attributes)
+    end
+  end
+end

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -50,6 +50,11 @@ class TransientRegistration
                                                 "conviction_sign_offs")
 
     assign_attributes(strip_whitespace(attributes))
+    remove_invalid_attributes
+  end
+
+  def remove_invalid_attributes
+    self.phone_number = nil unless PhoneNumberValidator.new.validate(self)
   end
 
   # Check if a transient renewal already exists for this registration so we don't have

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -3,6 +3,7 @@ class TransientRegistration
   include CanHaveRegistrationAttributes
   include CanChangeWorkflowStatus
   include CanCheckBusinessTypeChanges
+  include CanStripWhitespace
 
   validates_with RegIdentifierValidator
   validate :no_renewal_in_progress?, on: :create
@@ -37,16 +38,18 @@ class TransientRegistration
 
     # Don't copy object IDs as Mongo should generate new unique ones
     # Don't copy smart answers as we want users to use the latest version of the questions
-    assign_attributes(registration.attributes.except("_id",
-                                                     "otherBusinesses",
-                                                     "isMainService",
-                                                     "constructionWaste",
-                                                     "onlyAMF",
-                                                     "addresses",
-                                                     "keyPeople",
-                                                     "declaredConvictions",
-                                                     "convictionSearchResult",
-                                                     "conviction_sign_offs"))
+    attributes = registration.attributes.except("_id",
+                                                "otherBusinesses",
+                                                "isMainService",
+                                                "constructionWaste",
+                                                "onlyAMF",
+                                                "addresses",
+                                                "keyPeople",
+                                                "declaredConvictions",
+                                                "convictionSearchResult",
+                                                "conviction_sign_offs")
+
+    assign_attributes(strip_whitespace(attributes))
   end
 
   # Check if a transient renewal already exists for this registration so we don't have

--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -1,0 +1,6 @@
+class PhoneNumberValidator < ActiveModel::Validator
+  def validate(record)
+    return false unless record.phone_number.present?
+    Phonelib.valid?(record.phone_number)
+  end
+end

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,2 @@
+require "phonelib"
+Phonelib.default_country = "GB"

--- a/spec/factories/forms/base_form.rb
+++ b/spec/factories/forms/base_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :base_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data)) }
+    end
+  end
+end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
       company_name "Acme Waste"
       registration_type "carrier_broker_dealer"
       company_no "09360070" # We need to use a valid company number
+      phone_number "03708 506506"
 
       metaData { build(:metaData) }
       addresses { [build(:address)] }

--- a/spec/forms/base_forms_spec.rb
+++ b/spec/forms/base_forms_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe BaseForm, type: :model do
+  describe "#submit" do
+    let(:base_form) { build(:base_form, :has_required_data) }
+
+    it "should strip excess whitespace from attributes" do
+      attributes = { company_name: " test " }
+
+      base_form.submit(attributes, base_form.reg_identifier)
+      expect(base_form.transient_registration.company_name).to eq("test")
+    end
+
+    it "should strip excess whitespace from attributes within an array" do
+      attributes = { keyPeople: [build(:key_person, :main, first_name: " test ")] }
+
+      base_form.submit(attributes, base_form.reg_identifier)
+      expect(base_form.transient_registration.main_people.first.first_name).to eq("test")
+    end
+
+    it "should strip excess whitespace from attributes within a hash" do
+      attributes = { metaData: { revoked_reason: " test " } }
+
+      base_form.submit(attributes, base_form.reg_identifier)
+      expect(base_form.transient_registration.metaData.revoked_reason).to eq("test")
+    end
+  end
+end

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
 
 RSpec.describe TransientRegistration, type: :model do
+  describe "#initialize" do
+    context "when the source registration has whitespace in its attributes" do
+      let(:registration) do
+        create(:registration,
+               :has_required_data,
+               company_name: " test ")
+      end
+
+      it "strips the whitespace from the attributes" do
+        transient_registration = TransientRegistration.new(reg_identifier: registration.reg_identifier)
+        expect(transient_registration.company_name).to eq("test")
+      end
+    end
+  end
+
   describe "#reg_identifier" do
     context "when a TransientRegistration is created" do
       let(:transient_registration) do

--- a/spec/models/transient_registration_spec.rb
+++ b/spec/models/transient_registration_spec.rb
@@ -14,6 +14,31 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration.company_name).to eq("test")
       end
     end
+
+    context "when the source registration has a valid phone_number" do
+      let(:registration) do
+        create(:registration,
+               :has_required_data)
+      end
+
+      it "imports it" do
+        transient_registration = TransientRegistration.new(reg_identifier: registration.reg_identifier)
+        expect(transient_registration.phone_number).to eq(registration.phone_number)
+      end
+    end
+
+    context "when the source registration has an invalid phone_number" do
+      let(:registration) do
+        create(:registration,
+               :has_required_data,
+               phone_number: "test")
+      end
+
+      it "does not import it" do
+        transient_registration = TransientRegistration.new(reg_identifier: registration.reg_identifier)
+        expect(transient_registration.phone_number).to eq(nil)
+      end
+    end
   end
 
   describe "#reg_identifier" do


### PR DESCRIPTION
This change adds some features to improve our data quality.

This means removing excess whitespace at the start or end of the field. Some forms do this on saving but others don't, so we should try to implement this across all forms in a standardised way instead. We should also do this when we import data from a Registration to a TransientRegistration object.

There are also some fields, like phone numbers, which previously have not been validated as closely as we would have liked. It doesn't make sense to prefill a field with a value which will then be considered invalid, so we should run some validations on importing the data when the TransientRegistration is created. (For more discussion on this, see https://eaflood.atlassian.net/browse/WC-131)