### PR TITLE
Loosen restrictions on Devise version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "airbrake", "5.8.1"
 gem "cancancan", "~> 1.10"
 
 # Use Devise for user authentication
-gem "devise", "~> 4.3.0"
+gem "devise", ">= 4.4.3"
 
 # GOV.UK styling
 gem "govuk_elements_rails", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bson (4.3.0)
     builder (3.2.3)
-    byebug (10.0.1)
+    byebug (10.0.2)
     cancancan (1.17.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -63,10 +63,10 @@ GEM
     crass (1.0.3)
     database_cleaner (1.6.2)
     debug_inspector (0.0.3)
-    devise (4.3.0)
+    devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -265,7 +265,7 @@ DEPENDENCIES
   cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   database_cleaner
-  devise (~> 4.3.0)
+  devise (>= 4.4.3)
   dotenv-rails
   factory_bot_rails
   govuk_elements_rails (~> 3.1)
@@ -292,7 +292,6 @@ DEPENDENCIES
   vcr (~> 4.0)
   web-console (~> 2.0)
   webmock (~> 3.3)
-
 
 RUBY VERSION
    ruby 2.4.2p198


### PR DESCRIPTION
Devise 4.4.0 included a breaking change to validations which caused our tests to fail: https://github.com/DEFRA/waste-carriers-renewals/issues/20

This issue is now fixed in later versions, so we can upgrade it again.

Also includes a bonus ByeBug upgrade from running bundle update.