### PR TITLE
Add contact email address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "rest-client", "~> 2.0"
 gem "secure_headers", "~> 5.0"
 
 gem "uk_postcode", require: false
+gem "validates_email_format_of", require: false
 
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     useragent (0.16.10)
+    validates_email_format_of (1.6.3)
+      i18n
     vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
@@ -289,6 +291,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   uk_postcode
+  validates_email_format_of
   vcr (~> 4.0)
   web-console (~> 2.0)
   webmock (~> 3.3)

--- a/app/forms/contact_email_form.rb
+++ b/app/forms/contact_email_form.rb
@@ -1,16 +1,17 @@
 class ContactEmailForm < BaseForm
-  # TODO: Define accessible attributes, eg attr_accessor :field
+  attr_accessor :contact_email, :confirmed_email
 
   def initialize(transient_registration)
     super
-    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+    self.contact_email = @transient_registration.contact_email
+    self.confirmed_email = @transient_registration.contact_email
   end
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    # TODO: Define allowed params, eg self.field = params[:field]
-    # TODO: Include attributes to update in the attributes hash, eg { field: field }
-    attributes = {}
+    self.contact_email = params[:contact_email]
+    self.confirmed_email = params[:confirmed_email]
+    attributes = { contact_email: contact_email }
 
     super(attributes, params[:reg_identifier])
   end

--- a/app/forms/contact_email_form.rb
+++ b/app/forms/contact_email_form.rb
@@ -1,3 +1,5 @@
+require "validates_email_format_of"
+
 class ContactEmailForm < BaseForm
   attr_accessor :contact_email, :confirmed_email
 
@@ -15,4 +17,6 @@ class ContactEmailForm < BaseForm
 
     super(attributes, params[:reg_identifier])
   end
+
+  validates_with ContactEmailValidator
 end

--- a/app/validators/contact_email_validator.rb
+++ b/app/validators/contact_email_validator.rb
@@ -1,0 +1,40 @@
+require "validates_email_format_of"
+
+class ContactEmailValidator < ActiveModel::Validator
+  def validate(record)
+    return false unless fields_are_filled_in?(record)
+    valid_format?(record)
+    confirmation_matches?(record)
+  end
+
+  private
+
+  def fields_are_filled_in?(record)
+    valid = true
+
+    unless record.contact_email.present?
+      record.errors.add(:contact_email, :blank)
+      valid = false
+    end
+
+    unless record.confirmed_email.present?
+      record.errors.add(:confirmed_email, :blank)
+      valid = false
+    end
+
+    valid
+  end
+
+  def valid_format?(record)
+    # validate_email_format returns nil if the validation passes
+    return true unless ValidatesEmailFormatOf.validate_email_format(record.contact_email)
+    record.errors.add(:contact_email, :invalid_format)
+    false
+  end
+
+  def confirmation_matches?(record)
+    return true if record.contact_email == record.confirmed_email
+    record.errors.add(:confirmed_email, :does_not_match)
+    false
+  end
+end

--- a/app/views/contact_email_forms/new.html.erb
+++ b/app/views/contact_email_forms/new.html.erb
@@ -1,24 +1,47 @@
 <%= render("shared/back", back_path: back_contact_email_forms_path(@contact_email_form.reg_identifier)) %>
 
-<% if @contact_email_form.errors.any? %>
-
-  <h1 class="heading-large"><%= t(".error_heading") %></h1>
-
-  <% @contact_email_form.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-
-<% else %>
-
+<div class="text">
   <%= form_for(@contact_email_form) do |f| %>
     <%= render("shared/errors", object: @contact_email_form) %>
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @contact_email_form.errors[:contact_email].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="contact_email">
+        <% if @contact_email_form.errors[:contact_email].any? %>
+        <span class="error-message"><%= @contact_email_form.errors[:contact_email].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :contact_email, class: "form-label" do %>
+          <%= t(".contact_email_label") %>
+          <span class='form-hint'><%= t(".contact_email_hint") %></span>
+        <% end %>
+        <%= f.email_field :contact_email, value: @contact_email_form.contact_email, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <% if @contact_email_form.errors[:confirmed_email].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="confirmed_email">
+        <% if @contact_email_form.errors[:confirmed_email].any? %>
+        <span class="error-message"><%= @contact_email_form.errors[:confirmed_email].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :confirmed_email, t(".confirmed_email_label"), class: "form-label" %>
+        <%= f.email_field :confirmed_email, value: @contact_email_form.confirmed_email, class: "form-control" %>
+      </fieldset>
+    </div>
 
     <%= f.hidden_field :reg_identifier, value: @contact_email_form.reg_identifier %>
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
   <% end %>
-
-<% end %>
+</div>

--- a/config/locales/forms/contact_email_forms/en.yml
+++ b/config/locales/forms/contact_email_forms/en.yml
@@ -3,6 +3,9 @@ en:
     new:
       heading: What's the email address of the person we should contact?
       error_heading: Something is wrong
+      contact_email_label: Email address
+      contact_email_hint: We’ll send a confirmation to this address
+      confirmed_email_label: Confirm email address
       next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/contact_email_forms/en.yml
+++ b/config/locales/forms/contact_email_forms/en.yml
@@ -12,6 +12,12 @@ en:
       models:
         contact_email_form:
           attributes:
+            contact_email:
+              blank: "Enter an email address"
+              invalid_format: "Enter a valid email address - there’s a mistake in that one"
+            confirmed_email:
+              blank: "Enter your email address again to confirm it"
+              does_not_match: "The email addresses you’ve entered don’t match"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/spec/factories/forms/contact_email_form.rb
+++ b/spec/factories/forms/contact_email_form.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :contact_email_form do
     trait :has_required_data do
+      contact_email "foo@example.com"
+      confirmed_email "foo@example.com"
+
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_email_form")) }
     end
   end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
       company_name "Acme Waste"
       registration_type "carrier_broker_dealer"
       company_no "09360070" # We need to use a valid company number
+      contact_email "foo@example.com"
 
       metaData { build(:metaData) }
       addresses { [build(:address)] }

--- a/spec/forms/contact_email_forms_spec.rb
+++ b/spec/forms/contact_email_forms_spec.rb
@@ -4,7 +4,13 @@ RSpec.describe ContactEmailForm, type: :model do
   describe "#submit" do
     context "when the form is valid" do
       let(:contact_email_form) { build(:contact_email_form, :has_required_data) }
-      let(:valid_params) { { reg_identifier: contact_email_form.reg_identifier } }
+      let(:valid_params) do
+        {
+          reg_identifier: contact_email_form.reg_identifier,
+          contact_email: contact_email_form.contact_email,
+          confirmed_email: contact_email_form.contact_email
+        }
+      end
 
       it "should submit" do
         expect(contact_email_form.submit(valid_params)).to eq(true)
@@ -48,12 +54,43 @@ RSpec.describe ContactEmailForm, type: :model do
           expect(contact_email_form).to be_valid
         end
       end
+
+      context "when contact_email and confirmed_email are blank" do
+        before(:each) do
+          # Update both email fields so we know invalidity isn't triggered by them being different
+          contact_email_form.contact_email = ""
+          contact_email_form.confirmed_email = contact_email_form.contact_email
+        end
+
+        it "is not valid" do
+          expect(contact_email_form).to_not be_valid
+        end
+      end
+
+      context "when a contact_email is in an incorrect format" do
+        before(:each) do
+          contact_email_form.contact_email = "foo"
+          contact_email_form.confirmed_email = contact_email_form.contact_email
+        end
+
+        it "is not valid" do
+          expect(contact_email_form).to_not be_valid
+        end
+      end
     end
 
     describe "#confirmed_email" do
       context "when a confirmed_email meets the requirements" do
         it "is valid" do
           expect(contact_email_form).to be_valid
+        end
+      end
+
+      context "when a confirmed_email does not match the contact_email" do
+        before(:each) { contact_email_form.confirmed_email = "no_matchy@example.com" }
+
+        it "is not valid" do
+          expect(contact_email_form).to_not be_valid
         end
       end
     end

--- a/spec/forms/contact_email_forms_spec.rb
+++ b/spec/forms/contact_email_forms_spec.rb
@@ -21,21 +21,11 @@ RSpec.describe ContactEmailForm, type: :model do
     end
   end
 
-  describe "#reg_identifier" do
-    context "when a valid transient registration exists" do
-      let(:transient_registration) do
-        create(:transient_registration,
-               :has_required_data,
-               workflow_state: "contact_email_form")
-      end
-      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
-      let(:contact_email_form) { ContactEmailForm.new(transient_registration) }
+  context "when a valid transient registration exists" do
+    let(:contact_email_form) { build(:contact_email_form, :has_required_data) }
 
+    describe "#reg_identifier" do
       context "when a reg_identifier meets the requirements" do
-        before(:each) do
-          contact_email_form.reg_identifier = transient_registration.reg_identifier
-        end
-
         it "is valid" do
           expect(contact_email_form).to be_valid
         end
@@ -48,6 +38,22 @@ RSpec.describe ContactEmailForm, type: :model do
 
         it "is not valid" do
           expect(contact_email_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#contact_email" do
+      context "when a contact_email meets the requirements" do
+        it "is valid" do
+          expect(contact_email_form).to be_valid
+        end
+      end
+    end
+
+    describe "#confirmed_email" do
+      context "when a confirmed_email meets the requirements" do
+        it "is valid" do
+          expect(contact_email_form).to be_valid
         end
       end
     end

--- a/spec/requests/contact_email_forms_spec.rb
+++ b/spec/requests/contact_email_forms_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "ContactEmailForms", type: :request do
           let(:valid_params) {
             {
               reg_identifier: transient_registration[:reg_identifier],
-              contact_email: "foo@example.com",
-              confirmed_email: "foo@example.com"
+              contact_email: "bar.baz@example.com",
+              confirmed_email: "bar.baz@example.com"
             }
           }
 
@@ -110,8 +110,8 @@ RSpec.describe "ContactEmailForms", type: :request do
         let(:valid_params) {
           {
             reg_identifier: transient_registration[:reg_identifier],
-            contact_email: "foo@example.com",
-            confirmed_email: "foo@example.com"
+            contact_email: "bar.baz@example.com",
+            confirmed_email: "bar.baz@example.com"
           }
         }
 

--- a/spec/requests/contact_email_forms_spec.rb
+++ b/spec/requests/contact_email_forms_spec.rb
@@ -56,12 +56,15 @@ RSpec.describe "ContactEmailForms", type: :request do
         context "when valid params are submitted" do
           let(:valid_params) {
             {
-              reg_identifier: transient_registration[:reg_identifier]
+              reg_identifier: transient_registration[:reg_identifier],
+              contact_email: "foo@example.com",
+              confirmed_email: "foo@example.com"
             }
           }
 
           it "updates the transient registration" do
-            # TODO: Add test once data is submitted through the form
+            post contact_email_forms_path, contact_email_form: valid_params
+            expect(transient_registration.reload.contact_email).to eq(valid_params[:contact_email])
           end
 
           it "returns a 302 response" do
@@ -78,7 +81,9 @@ RSpec.describe "ContactEmailForms", type: :request do
         context "when invalid params are submitted" do
           let(:invalid_params) {
             {
-              reg_identifier: "foo"
+              reg_identifier: "foo",
+              contact_email: "bar",
+              confirmed_email: "baz"
             }
           }
 
@@ -89,7 +94,7 @@ RSpec.describe "ContactEmailForms", type: :request do
 
           it "does not update the transient registration" do
             post contact_email_forms_path, contact_email_form: invalid_params
-            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+            expect(transient_registration.reload[:contact_email]).to_not eq(invalid_params[:contact_email])
           end
         end
       end
@@ -104,12 +109,15 @@ RSpec.describe "ContactEmailForms", type: :request do
 
         let(:valid_params) {
           {
-            reg_identifier: transient_registration[:reg_identifier]
+            reg_identifier: transient_registration[:reg_identifier],
+            contact_email: "foo@example.com",
+            confirmed_email: "foo@example.com"
           }
         }
 
         it "does not update the transient registration" do
-          # TODO: Add test once data is submitted through the form
+          post contact_email_forms_path, contact_email_form: valid_params
+          expect(transient_registration.reload.contact_email).to_not eq(valid_params[:contact_email])
         end
 
         it "returns a 302 response" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-111

Implement form for "What's the email address of the person we should contact?". This form should be pre-filled with the contact_email which was originally provided. The field should also validate as being in the correct format for an email address, and be tagged as an "email" field so mobile users get the correct keyboard.