### PR TITLE
 Search for a contact address by UK postcode

### DIFF
--- a/app/controllers/company_postcode_forms_controller.rb
+++ b/app/controllers/company_postcode_forms_controller.rb
@@ -1,16 +1,9 @@
-class CompanyPostcodeFormsController < FormsController
+class CompanyPostcodeFormsController < PostcodeFormsController
   def new
     super(CompanyPostcodeForm, "company_postcode_form")
   end
 
   def create
     super(CompanyPostcodeForm, "company_postcode_form")
-  end
-
-  def skip_to_manual_address
-    set_transient_registration(params[:reg_identifier])
-
-    @transient_registration.skip_to_manual_address! if form_matches_state?
-    redirect_to_correct_form
   end
 end

--- a/app/controllers/contact_postcode_forms_controller.rb
+++ b/app/controllers/contact_postcode_forms_controller.rb
@@ -1,0 +1,16 @@
+class ContactPostcodeFormsController < FormsController
+  def new
+    super(ContactPostcodeForm, "contact_postcode_form")
+  end
+
+  def create
+    super(ContactPostcodeForm, "contact_postcode_form")
+  end
+
+  # def skip_to_manual_address
+  #   set_transient_registration(params[:reg_identifier])
+  #
+  #   @transient_registration.skip_to_manual_address! if form_matches_state?
+  #   redirect_to_correct_form
+  # end
+end

--- a/app/controllers/contact_postcode_forms_controller.rb
+++ b/app/controllers/contact_postcode_forms_controller.rb
@@ -1,4 +1,4 @@
-class ContactPostcodeFormsController < FormsController
+class ContactPostcodeFormsController < PostcodeFormsController
   def new
     super(ContactPostcodeForm, "contact_postcode_form")
   end
@@ -6,11 +6,4 @@ class ContactPostcodeFormsController < FormsController
   def create
     super(ContactPostcodeForm, "contact_postcode_form")
   end
-
-  # def skip_to_manual_address
-  #   set_transient_registration(params[:reg_identifier])
-  #
-  #   @transient_registration.skip_to_manual_address! if form_matches_state?
-  #   redirect_to_correct_form
-  # end
 end

--- a/app/controllers/postcode_forms_controller.rb
+++ b/app/controllers/postcode_forms_controller.rb
@@ -1,0 +1,8 @@
+class PostcodeFormsController < FormsController
+  def skip_to_manual_address
+    set_transient_registration(params[:reg_identifier])
+
+    @transient_registration.skip_to_manual_address! if form_matches_state?
+    redirect_to_correct_form
+  end
+end

--- a/app/forms/company_address_form.rb
+++ b/app/forms/company_address_form.rb
@@ -1,6 +1,6 @@
 class CompanyAddressForm < BaseForm
   attr_accessor :business_type
-  attr_accessor :temp_postcode
+  attr_accessor :temp_company_postcode
   attr_accessor :temp_addresses
   attr_accessor :temp_address
   attr_accessor :addresses
@@ -9,7 +9,7 @@ class CompanyAddressForm < BaseForm
     super
     # We only use this for the correct microcopy
     self.business_type = @transient_registration.business_type
-    self.temp_postcode = @transient_registration.temp_postcode
+    self.temp_company_postcode = @transient_registration.temp_company_postcode
 
     look_up_addresses
     preselect_existing_address
@@ -27,10 +27,10 @@ class CompanyAddressForm < BaseForm
 
   private
 
-  # Look up addresses based on the temp_postcode
+  # Look up addresses based on the temp_company_postcode
   def look_up_addresses
-    if temp_postcode.present?
-      address_finder = AddressFinderService.new(temp_postcode)
+    if temp_company_postcode.present?
+      address_finder = AddressFinderService.new(temp_company_postcode)
       self.temp_addresses = address_finder.search_by_postcode
     else
       self.temp_addresses = []

--- a/app/forms/company_address_manual_form.rb
+++ b/app/forms/company_address_manual_form.rb
@@ -15,9 +15,9 @@ class CompanyAddressManualForm < BaseForm
     self.os_places_error = @transient_registration.temp_os_places_error
     @transient_registration.update_attributes(temp_os_places_error: nil)
 
-    # Prefill the existing address unless the temp_postcode has changed from the saved postcode
-    # Otherwise, just fill in the temp_postcode
-    saved_address_still_valid? ? prefill_existing_address : self.postcode = @transient_registration.temp_postcode
+    # Prefill the existing address unless the temp_company_postcode has changed from the saved postcode
+    # Otherwise, just fill in the temp_company_postcode
+    saved_address_still_valid? ? prefill_existing_address : self.postcode = @transient_registration.temp_company_postcode
   end
 
   def submit(params)
@@ -52,7 +52,7 @@ class CompanyAddressManualForm < BaseForm
   def saved_address_still_valid?
     return true if overseas?
     return false unless @transient_registration.registered_address
-    return true if @transient_registration.temp_postcode == @transient_registration.registered_address.postcode
+    return true if @transient_registration.temp_company_postcode == @transient_registration.registered_address.postcode
     false
   end
 

--- a/app/forms/company_postcode_form.rb
+++ b/app/forms/company_postcode_form.rb
@@ -20,7 +20,7 @@ class CompanyPostcodeForm < BaseForm
     super(attributes, params[:reg_identifier])
   end
 
-  validates_with TempPostcodeValidator, fields: [:temp_company_postcode]
+  validates_with PostcodeValidator, fields: [:temp_company_postcode]
 
   private
 

--- a/app/forms/company_postcode_form.rb
+++ b/app/forms/company_postcode_form.rb
@@ -1,18 +1,18 @@
 class CompanyPostcodeForm < BaseForm
-  attr_accessor :business_type, :temp_postcode
+  attr_accessor :business_type, :temp_company_postcode
 
   def initialize(transient_registration)
     super
-    self.temp_postcode = @transient_registration.temp_postcode
+    self.temp_company_postcode = @transient_registration.temp_company_postcode
     # We only use this for the correct microcopy
     self.business_type = @transient_registration.business_type
   end
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    self.temp_postcode = params[:temp_postcode]
+    self.temp_company_postcode = params[:temp_company_postcode]
     format_postcode
-    attributes = { temp_postcode: temp_postcode }
+    attributes = { temp_company_postcode: temp_company_postcode }
 
     # While we won't proceed if the postcode isn't valid, we should always save it in case it's needed for manual entry
     @transient_registration.update_attributes(attributes)
@@ -20,13 +20,13 @@ class CompanyPostcodeForm < BaseForm
     super(attributes, params[:reg_identifier])
   end
 
-  validates_with TempPostcodeValidator, fields: [:temp_postcode]
+  validates_with TempPostcodeValidator, fields: [:temp_company_postcode]
 
   private
 
   def format_postcode
-    return unless temp_postcode.present?
-    temp_postcode.upcase!
-    temp_postcode.strip!
+    return unless temp_company_postcode.present?
+    temp_company_postcode.upcase!
+    temp_company_postcode.strip!
   end
 end

--- a/app/forms/company_postcode_form.rb
+++ b/app/forms/company_postcode_form.rb
@@ -1,4 +1,4 @@
-class CompanyPostcodeForm < BaseForm
+class CompanyPostcodeForm < PostcodeForm
   attr_accessor :business_type, :temp_company_postcode
 
   def initialize(transient_registration)
@@ -11,7 +11,7 @@ class CompanyPostcodeForm < BaseForm
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
     self.temp_company_postcode = params[:temp_company_postcode]
-    format_postcode
+    format_postcode(temp_company_postcode)
     attributes = { temp_company_postcode: temp_company_postcode }
 
     # While we won't proceed if the postcode isn't valid, we should always save it in case it's needed for manual entry
@@ -21,12 +21,4 @@ class CompanyPostcodeForm < BaseForm
   end
 
   validates_with PostcodeValidator, fields: [:temp_company_postcode]
-
-  private
-
-  def format_postcode
-    return unless temp_company_postcode.present?
-    temp_company_postcode.upcase!
-    temp_company_postcode.strip!
-  end
 end

--- a/app/forms/contact_postcode_form.rb
+++ b/app/forms/contact_postcode_form.rb
@@ -20,7 +20,7 @@ class ContactPostcodeForm < BaseForm
     super(attributes, params[:reg_identifier])
   end
 
-  validates_with TempPostcodeValidator, fields: [:temp_contact_postcode]
+  validates_with PostcodeValidator, fields: [:temp_contact_postcode]
 
   private
 

--- a/app/forms/contact_postcode_form.rb
+++ b/app/forms/contact_postcode_form.rb
@@ -1,18 +1,18 @@
-class CompanyPostcodeForm < BaseForm
-  attr_accessor :business_type, :temp_postcode
+class ContactPostcodeForm < BaseForm
+  attr_accessor :business_type, :temp_contact_postcode
 
   def initialize(transient_registration)
     super
-    self.temp_postcode = @transient_registration.temp_postcode
+    self.temp_contact_postcode = @transient_registration.temp_contact_postcode
     # We only use this for the correct microcopy
     self.business_type = @transient_registration.business_type
   end
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    self.temp_postcode = params[:temp_postcode]
+    self.temp_contact_postcode = params[:temp_contact_postcode]
     format_postcode
-    attributes = { temp_postcode: temp_postcode }
+    attributes = { temp_contact_postcode: temp_contact_postcode }
 
     # While we won't proceed if the postcode isn't valid, we should always save it in case it's needed for manual entry
     @transient_registration.update_attributes(attributes)
@@ -20,13 +20,13 @@ class CompanyPostcodeForm < BaseForm
     super(attributes, params[:reg_identifier])
   end
 
-  validates_with TempPostcodeValidator, fields: [:temp_postcode]
+  validates_with TempPostcodeValidator, fields: [:temp_contact_postcode]
 
   private
 
   def format_postcode
-    return unless temp_postcode.present?
-    temp_postcode.upcase!
-    temp_postcode.strip!
+    return unless temp_contact_postcode.present?
+    temp_contact_postcode.upcase!
+    temp_contact_postcode.strip!
   end
 end

--- a/app/forms/contact_postcode_form.rb
+++ b/app/forms/contact_postcode_form.rb
@@ -1,17 +1,15 @@
-class ContactPostcodeForm < BaseForm
-  attr_accessor :business_type, :temp_contact_postcode
+class ContactPostcodeForm < PostcodeForm
+  attr_accessor :temp_contact_postcode
 
   def initialize(transient_registration)
     super
     self.temp_contact_postcode = @transient_registration.temp_contact_postcode
-    # We only use this for the correct microcopy
-    self.business_type = @transient_registration.business_type
   end
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
     self.temp_contact_postcode = params[:temp_contact_postcode]
-    format_postcode
+    format_postcode(temp_contact_postcode)
     attributes = { temp_contact_postcode: temp_contact_postcode }
 
     # While we won't proceed if the postcode isn't valid, we should always save it in case it's needed for manual entry
@@ -21,12 +19,4 @@ class ContactPostcodeForm < BaseForm
   end
 
   validates_with PostcodeValidator, fields: [:temp_contact_postcode]
-
-  private
-
-  def format_postcode
-    return unless temp_contact_postcode.present?
-    temp_contact_postcode.upcase!
-    temp_contact_postcode.strip!
-  end
 end

--- a/app/forms/postcode_form.rb
+++ b/app/forms/postcode_form.rb
@@ -1,0 +1,9 @@
+class PostcodeForm < BaseForm
+  private
+
+  def format_postcode(postcode)
+    return unless postcode.present?
+    postcode.upcase!
+    postcode.strip!
+  end
+end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -40,6 +40,7 @@ module CanChangeWorkflowStatus
       state :contact_name_form
       state :contact_phone_form
       state :contact_email_form
+      state :contact_postcode_form
       state :contact_address_form
 
       state :check_your_answers_form
@@ -198,10 +199,17 @@ module CanChangeWorkflowStatus
                     to: :contact_email_form
 
         transitions from: :contact_email_form,
+                    to: :contact_postcode_form
+
+        # Contact address
+
+        transitions from: :contact_postcode_form,
                     to: :contact_address_form
 
         transitions from: :contact_address_form,
                     to: :check_your_answers_form
+
+        # End contact address
 
         transitions from: :check_your_answers_form,
                     to: :declaration_form
@@ -342,11 +350,18 @@ module CanChangeWorkflowStatus
         transitions from: :contact_email_form,
                     to: :contact_phone_form
 
-        transitions from: :contact_address_form,
+        # Contact address
+
+        transitions from: :contact_postcode_form,
                     to: :contact_email_form
+
+        transitions from: :contact_address_form,
+                    to: :contact_postcode_form
 
         transitions from: :check_your_answers_form,
                     to: :contact_address_form
+
+        # End contact address
 
         transitions from: :declaration_form,
                     to: :check_your_answers_form

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -11,7 +11,7 @@ class TransientRegistration
   after_initialize :copy_data_from_registration
 
   # Attributes specific to the transient object - all others are in CanHaveRegistrationAttributes
-  field :temp_postcode, type: String
+  field :temp_company_postcode, type: String
   field :temp_contact_postcode, type: String
   field :temp_os_places_error, type: Boolean
 

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -12,6 +12,7 @@ class TransientRegistration
 
   # Attributes specific to the transient object - all others are in CanHaveRegistrationAttributes
   field :temp_postcode, type: String
+  field :temp_contact_postcode, type: String
   field :temp_os_places_error, type: Boolean
 
   # Check if the user has changed the registration type, as this incurs an additional 40GBP charge

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,16 +1,20 @@
 require "uk_postcode"
 
-class TempPostcodeValidator < ActiveModel::Validator
+class PostcodeValidator < ActiveModel::Validator
   def validate(record)
     return unless options[:fields].any?
     options[:fields].each do |field|
-      next unless value_is_present?(record, field)
-      next unless value_uses_correct_format?(record, field)
-      postcode_returns_results?(record, field)
+      validate_postcode_field(record, field)
     end
   end
 
   private
+
+  def validate_postcode_field(record, field)
+    return unless value_is_present?(record, field)
+    return unless value_uses_correct_format?(record, field)
+    postcode_returns_results?(record, field)
+  end
 
   def value_is_present?(record, field)
     return true if record.send(field).present?

--- a/app/views/company_address_forms/new.html.erb
+++ b/app/views/company_address_forms/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="form-group">
       <label class="form-label"><%= t(".postcode_label") %></label>
-      <span class="postcode"><%= @company_address_form.temp_postcode %></span>
+      <span class="postcode"><%= @company_address_form.temp_company_postcode %></span>
       <%= link_to(t(".postcode_change_link"), back_company_address_forms_path(@company_address_form.reg_identifier)) %>
     </div>
 

--- a/app/views/company_postcode_forms/new.html.erb
+++ b/app/views/company_postcode_forms/new.html.erb
@@ -6,25 +6,25 @@
 
     <h1 class="heading-large"><%= t(".heading_#{@company_postcode_form.business_type}") %></h1>
 
-    <% if @company_postcode_form.errors[:temp_postcode].any? %>
+    <% if @company_postcode_form.errors[:temp_company_postcode].any? %>
     <div class="form-group form-group-error">
     <% else %>
     <div class="form-group">
     <% end %>
-      <fieldset id="temp_postcode">
+      <fieldset id="temp_company_postcode">
         <legend class="visuallyhidden">
           <%= t(".heading_#{@company_postcode_form.business_type}") %>
         </legend>
 
-        <% if @company_postcode_form.errors[:temp_postcode].any? %>
-        <span class="error-message"><%= @company_postcode_form.errors[:temp_postcode].join(", ") %></span>
+        <% if @company_postcode_form.errors[:temp_company_postcode].any? %>
+        <span class="error-message"><%= @company_postcode_form.errors[:temp_company_postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :temp_postcode, class: "form-label" do %>
-          <%= t(".temp_postcode_label") %>
-          <span class='form-hint'><%= t(".temp_postcode_hint") %></span>
+        <%= f.label :temp_company_postcode, class: "form-label" do %>
+          <%= t(".temp_company_postcode_label") %>
+          <span class='form-hint'><%= t(".temp_company_postcode_hint") %></span>
         <% end %>
-        <%= f.text_field :temp_postcode, value: @company_postcode_form.temp_postcode, class: "form-control" %>
+        <%= f.text_field :temp_company_postcode, value: @company_postcode_form.temp_company_postcode, class: "form-control" %>
 
       </fieldset>
     </div>
@@ -34,7 +34,7 @@
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
 
-    <% if @company_postcode_form.errors.added?(:temp_postcode, :no_results) %>
+    <% if @company_postcode_form.errors.added?(:temp_company_postcode, :no_results) %>
     <div class="form-group">
       <%= link_to(t(".manual_address_link"), skip_to_manual_address_company_postcode_forms_path(@company_postcode_form.reg_identifier)) %>
     </div>

--- a/app/views/contact_postcode_forms/new.html.erb
+++ b/app/views/contact_postcode_forms/new.html.erb
@@ -6,6 +6,18 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
+    <div class="form-group">
+      <details>
+        <summary>
+          <span class="summary"><%= t(".detail_subheading") %></span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <p><%= t(".detail_paragraph_1") %></p>
+          <p><%= t(".detail_paragraph_2") %></p>
+        </div>
+      </details>
+    </div>
+
     <% if @contact_postcode_form.errors[:temp_contact_postcode].any? %>
     <div class="form-group form-group-error">
     <% else %>

--- a/app/views/contact_postcode_forms/new.html.erb
+++ b/app/views/contact_postcode_forms/new.html.erb
@@ -1,0 +1,45 @@
+<%= render("shared/back", back_path: back_contact_postcode_forms_path(@contact_postcode_form.reg_identifier)) %>
+
+<div class="text">
+  <%= form_for(@contact_postcode_form) do |f| %>
+    <%= render("shared/errors", object: @contact_postcode_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @contact_postcode_form.errors[:temp_contact_postcode].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="temp_contact_postcode">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @contact_postcode_form.errors[:temp_contact_postcode].any? %>
+        <span class="error-message"><%= @contact_postcode_form.errors[:temp_contact_postcode].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :temp_contact_postcode, class: "form-label" do %>
+          <%= t(".temp_contact_postcode_label") %>
+          <span class='form-hint'><%= t(".temp_contact_postcode_hint") %></span>
+        <% end %>
+        <%= f.text_field :temp_contact_postcode, value: @contact_postcode_form.temp_contact_postcode, class: "form-control" %>
+
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :reg_identifier, value: @contact_postcode_form.reg_identifier %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+
+    <% if @contact_postcode_form.errors.added?(:temp_contact_postcode, :no_results) %>
+    <div class="form-group">
+      <a href="#"><%= t(".manual_address_link") %></a>
+    </div>
+    <% end %>
+  <% end %>
+
+  <%= render("shared/os_terms_footer") %>
+</div>

--- a/config/locales/forms/company_postcode_forms/en.yml
+++ b/config/locales/forms/company_postcode_forms/en.yml
@@ -6,8 +6,8 @@ en:
       heading_limitedLiabilityPartnership: What's the address of the limited liability partnership?
       heading_partnership: What's the address of the partnership?
       heading_soleTrader: What's the address of the business?
-      temp_postcode_label: UK postcode
-      temp_postcode_hint: For example, BS1 5AH
+      temp_company_postcode_label: UK postcode
+      temp_company_postcode_hint: For example, BS1 5AH
       error_heading: A problem to fix
       next_button: Find address
       manual_address_link: "Enter address manually"
@@ -16,7 +16,7 @@ en:
       models:
         company_postcode_form:
           attributes:
-            temp_postcode:
+            temp_company_postcode:
               blank: "Enter a postcode"
               wrong_format: "Enter a valid UK postcode"
               no_results: "We couldn't find any addresses for that postcode. Check the postcode or enter the address manually."

--- a/config/locales/forms/contact_postcode_forms/en.yml
+++ b/config/locales/forms/contact_postcode_forms/en.yml
@@ -2,7 +2,7 @@ en:
   contact_postcode_forms:
     new:
       heading: What's the address of the person we should contact?
-      detail_heading: Why do you need to write to me?
+      detail_subheading: Why do you need to write to me?
       detail_paragraph_1: We’ll only write to you in relation to your waste carrier account. For example, if you order copy cards of your registration.
       detail_paragraph_2: Don’t worry, we won’t send junk mail to this address.
       temp_contact_postcode_label: UK postcode

--- a/config/locales/forms/contact_postcode_forms/en.yml
+++ b/config/locales/forms/contact_postcode_forms/en.yml
@@ -1,0 +1,25 @@
+en:
+  contact_postcode_forms:
+    new:
+      heading: What's the address of the person we should contact?
+      detail_heading: Why do you need to write to me?
+      detail_paragraph_1: We’ll only write to you in relation to your waste carrier account. For example, if you order copy cards of your registration.
+      detail_paragraph_2: Don’t worry, we won’t send junk mail to this address.
+      temp_contact_postcode_label: UK postcode
+      temp_contact_postcode_hint: For example, BS1 5AH
+      error_heading: A problem to fix
+      next_button: Find address
+      manual_address_link: "Enter address manually"
+  activemodel:
+    errors:
+      models:
+        contact_postcode_form:
+          attributes:
+            temp_contact_postcode:
+              blank: "Enter a postcode"
+              wrong_format: "Enter a valid UK postcode"
+              no_results: "We couldn't find any addresses for that postcode. Check the postcode or enter the address manually."
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,21 @@ Rails.application.routes.draw do
               on: :collection
             end
 
+  resources :contact_postcode_forms,
+            only: [:new, :create],
+            path: "contact-postcode",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "contact_postcode_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:reg_identifier",
+              to: "contact_postcode_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
+            end
+
   resources :contact_address_forms,
             only: [:new, :create],
             path: "contact-address",

--- a/spec/cassettes/contact_postcode_form_modified_postcode.yml
+++ b/spec/cassettes/contact_postcode_form_modified_postcode.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9190/addresses.json?postcode=BS16AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:9190
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Apr 2018 09:59:50 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAN2Y0W6bMBSGX8XimkoQgoHdkcRtkChEQFpFVS+cxG3QCI4IbKumvftMIS4QNu3CROkuIvEfw7H9n08Hk6ef0p6m8VeSSV8kTTHNsSrJUnHI0qZO4pQcpS9PEgqn9gKB0HZ9j8UfnGnkB44NwihAKJKeZSmn38tHJ4ETRr7L7jnQY76hW1IGQxVAe86CBB/zOH0t59CtkW6wUEqzfFfFVGMEjTK2oUWaZ28sxMSWHEi6JWnu0g1O4rwbjnYZLV53Lzgj1Qje7uM0PuYZzuNvxM4Ibi0sKdPYRb6jGUu2PGxxTmbsVz2c0Tec3OM46Q4ccJbHOGGiaYYMlp4TAV0GUWB7oX8P5v4yRDLoWCSDegHsgrtxLNaTIk62bPce3pfzVMnY0LodbyVnw+XiT5uub+nWRJZo9oqZD8wFmtY3derIZyn263cS6rr5Ly/xhkzoj+YAM5xZsGeO18nKGC3WCZn1VeiX3ERspENo6h+Icc0RW8wdd+FHoTi8NHiGl6FoV4/XyYgaLetGVUTSVeYbDrBGFS8Il6IqOmzAddIcrnA5ebRX4tAaa+edy9KvHq3KhhosUyRV5nBI8dpdDijV0g3V+ACKaw5UNEdgZjvuCkycCIGpfYvE0QWtc7p08+rp6vGkRk0ViZo6HGr9Vb3oW9KEjYMY15y7dwe0m7Hc3bKoI1kPesbo6tHjtgjkjKUbjrRLYzXWtBZWlW5jBYeCatwDlQk/B1RQJFLwPwFKVUzNGjfejyfdBOoBBaETrYB/C8q++ojCqLxG3p1rezOBLavnLGZ+ipb1d4cEgTcccv9S48s2OctsN7l3zZnkm5oFKzB1ke2x1Qvscuefm9C0rp7DXlfqc5shsvkZw5H4p8pelj6l/f9GpRv0BXeOB+59D63Awp0K/FzQz8GD198Au4bUzI1EMjcakrmzeg6K2/NvwFnliLMVAAA=
+    http_version: 
+  recorded_at: Mon, 09 Apr 2018 10:03:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/contact_postcode_form_no_matches_postcode.yml
+++ b/spec/cassettes/contact_postcode_form_no_matches_postcode.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9190/addresses.json?postcode=AA11AA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:9190
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 09 Apr 2018 09:59:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"error":{"message":"Parameters are not valid","statuscode":400}}'
+    http_version: 
+  recorded_at: Mon, 09 Apr 2018 10:03:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/contact_postcode_form_valid_postcode.yml
+++ b/spec/cassettes/contact_postcode_form_valid_postcode.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9190/addresses.json?postcode=BS15AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:9190
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Apr 2018 09:59:49 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOWUUW+bMBDHv4rlZx6gaULWN1NQE42aypBNXdUHJziJNbCRMduqad+9x8JSIN1LlU2T9oDA/7PvfP/7iYfvuNRKfhYGX2HPdd95/sydXbrYwU1l1IlYSCVqfPWAF4TdphFFNyxZ3UEgjAiN2D1iCQnxo4Ot/tqeDtgyzZIYNlS6thudi1ZMPTQlCxAFr61UO9Am07k3aSsobez+oHn+xWzug7bRjbLmCSRY5KISKhfKxnrDC2nHcrY3utntt9yIQ4TnpVSytoZb+UUQI/jgYkWbhjR2rw0kW1U5tyKE53DY6Cde3HJZjAMVN1byAhYDKxyUsWUSJikKCH3voL4vDuqqwsfRgrpZB40scmiZ8rJLvh4q/ZQQba/6q8Vux8B+B2uz49AyNKxVt2M8sGOJplz/nH43o2S7lRsR6G/9AJgL7Zbg7ssdc92sCxG+No0fTh+ryaXrebMXoo7rI0yUZCtGYhTRm5jQ8Dw4XbjTE5x8d/7P4zQyw0GLhC0/JRTeqzQ6E1GDnG9F6nRsfxkqfwSV34cqW7DlhwixiEYfSRBHKbqLr//vP9WrlpyJqLdC9Lsx/VGUHp8B5v82jvgGAAA=
+    http_version: 
+  recorded_at: Mon, 09 Apr 2018 10:03:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/factories/forms/company_postcode_form.rb
+++ b/spec/factories/forms/company_postcode_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :company_postcode_form do
     trait :has_required_data do
-      temp_postcode "BS1 5AH"
+      temp_company_postcode "BS1 5AH"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "company_postcode_form")) }
     end

--- a/spec/factories/forms/contact_postcode_form.rb
+++ b/spec/factories/forms/contact_postcode_form.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :contact_postcode_form do
+    trait :has_required_data do
+      temp_contact_postcode "BS1 5AH"
+
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_postcode_form")) }
+    end
+  end
+end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -10,7 +10,8 @@ FactoryBot.define do
     end
 
     trait :has_postcode do
-      temp_postcode "BS1 5AH"
+      temp_company_postcode "BS1 5AH"
+      temp_contact_postcode "BS1 5AH"
     end
   end
 end

--- a/spec/forms/company_address_manual_forms_spec.rb
+++ b/spec/forms/company_address_manual_forms_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe CompanyAddressManualForm, type: :model do
         end
       end
 
-      context "when the temp_postcode doesn't exist" do
+      context "when the temp_company_postcode doesn't exist" do
         before(:each) do
-          transient_registration.temp_postcode = nil
+          transient_registration.temp_company_postcode = nil
         end
 
         it "prefills the form with the existing address" do
@@ -31,9 +31,9 @@ RSpec.describe CompanyAddressManualForm, type: :model do
         end
       end
 
-      context "when the temp_postcode matches the existing address" do
+      context "when the temp_company_postcode matches the existing address" do
         before(:each) do
-          transient_registration.temp_postcode = transient_registration.registered_address.postcode
+          transient_registration.temp_company_postcode = transient_registration.registered_address.postcode
         end
 
         it "prefills the form with the existing address" do
@@ -41,13 +41,13 @@ RSpec.describe CompanyAddressManualForm, type: :model do
         end
       end
 
-      context "when the temp_postcode is in use and doesn't match the registered address" do
+      context "when the temp_company_postcode is in use and doesn't match the registered address" do
         before(:each) do
-          transient_registration.temp_postcode = "foo"
+          transient_registration.temp_company_postcode = "foo"
         end
 
-        it "prefills the form with the temp_postcode" do
-          expect(company_address_manual_form.postcode).to eq(transient_registration.temp_postcode)
+        it "prefills the form with the temp_company_postcode" do
+          expect(company_address_manual_form.postcode).to eq(transient_registration.temp_company_postcode)
         end
 
         it "does not prefill the form with the existing address" do

--- a/spec/forms/company_postcode_forms_spec.rb
+++ b/spec/forms/company_postcode_forms_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CompanyPostcodeForm, type: :model do
   describe "#submit" do
     context "when the form is valid" do
       let(:company_postcode_form) { build(:company_postcode_form, :has_required_data) }
-      let(:valid_params) { { reg_identifier: company_postcode_form.reg_identifier, temp_postcode: "BS1 5AH" } }
+      let(:valid_params) { { reg_identifier: company_postcode_form.reg_identifier, temp_company_postcode: "BS1 5AH" } }
 
       it "should submit" do
         VCR.use_cassette("company_postcode_form_valid_postcode") do
@@ -14,26 +14,26 @@ RSpec.describe CompanyPostcodeForm, type: :model do
 
       context "when the postcode is lowercase" do
         before(:each) do
-          valid_params[:temp_postcode] = "bs1 6ah"
+          valid_params[:temp_company_postcode] = "bs1 6ah"
         end
 
         it "upcases it" do
           VCR.use_cassette("company_postcode_form_modified_postcode") do
             company_postcode_form.submit(valid_params)
-            expect(company_postcode_form.temp_postcode).to eq("BS1 6AH")
+            expect(company_postcode_form.temp_company_postcode).to eq("BS1 6AH")
           end
         end
       end
 
       context "when the postcode has trailing spaces" do
         before(:each) do
-          valid_params[:temp_postcode] = "BS1 6AH      "
+          valid_params[:temp_company_postcode] = "BS1 6AH      "
         end
 
         it "removes them" do
           VCR.use_cassette("company_postcode_form_modified_postcode") do
             company_postcode_form.submit(valid_params)
-            expect(company_postcode_form.temp_postcode).to eq("BS1 6AH")
+            expect(company_postcode_form.temp_company_postcode).to eq("BS1 6AH")
           end
         end
       end
@@ -75,7 +75,7 @@ RSpec.describe CompanyPostcodeForm, type: :model do
     end
 
     describe "#company_postcode" do
-      context "when a company_postcode meets the requirements" do
+      context "when a temp_company_postcode meets the requirements" do
         it "is valid" do
           VCR.use_cassette("company_postcode_form_valid_postcode") do
             expect(company_postcode_form).to be_valid
@@ -83,9 +83,9 @@ RSpec.describe CompanyPostcodeForm, type: :model do
         end
       end
 
-      context "when a company_postcode is blank" do
+      context "when a temp_company_postcode is blank" do
         before(:each) do
-          company_postcode_form.temp_postcode = ""
+          company_postcode_form.temp_company_postcode = ""
         end
 
         it "is not valid" do
@@ -93,9 +93,9 @@ RSpec.describe CompanyPostcodeForm, type: :model do
         end
       end
 
-      context "when a company_postcode is in the wrong format" do
+      context "when a temp_company_postcode is in the wrong format" do
         before(:each) do
-          company_postcode_form.temp_postcode = "foo"
+          company_postcode_form.temp_company_postcode = "foo"
         end
 
         it "is not valid" do
@@ -103,9 +103,9 @@ RSpec.describe CompanyPostcodeForm, type: :model do
         end
       end
 
-      context "when a company_postcode has no matches" do
+      context "when a temp_company_postcode has no matches" do
         before(:each) do
-          company_postcode_form.temp_postcode = "AA1 1AA"
+          company_postcode_form.temp_company_postcode = "AA1 1AA"
         end
 
         it "is not valid" do

--- a/spec/forms/contact_postcode_forms_spec.rb
+++ b/spec/forms/contact_postcode_forms_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe ContactPostcodeForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:contact_postcode_form) { build(:contact_postcode_form, :has_required_data) }
+      let(:valid_params) { { reg_identifier: contact_postcode_form.reg_identifier, temp_contact_postcode: "BS1 5AH" } }
+
+      it "should submit" do
+        VCR.use_cassette("contact_postcode_form_valid_postcode") do
+          expect(contact_postcode_form.submit(valid_params)).to eq(true)
+        end
+      end
+
+      context "when the postcode is lowercase" do
+        before(:each) do
+          valid_params[:temp_contact_postcode] = "bs1 6ah"
+        end
+
+        it "upcases it" do
+          VCR.use_cassette("contact_postcode_form_modified_postcode") do
+            contact_postcode_form.submit(valid_params)
+            expect(contact_postcode_form.temp_contact_postcode).to eq("BS1 6AH")
+          end
+        end
+      end
+
+      context "when the postcode has trailing spaces" do
+        before(:each) do
+          valid_params[:temp_contact_postcode] = "BS1 6AH      "
+        end
+
+        it "removes them" do
+          VCR.use_cassette("contact_postcode_form_modified_postcode") do
+            contact_postcode_form.submit(valid_params)
+            expect(contact_postcode_form.temp_contact_postcode).to eq("BS1 6AH")
+          end
+        end
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:contact_postcode_form) { build(:contact_postcode_form, :has_required_data) }
+      let(:invalid_params) { { reg_identifier: "foo" } }
+
+      it "should not submit" do
+        expect(contact_postcode_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  context "when a form with a valid transient registration exists" do
+    let(:contact_postcode_form) { build(:contact_postcode_form, :has_required_data) }
+
+    describe "#reg_identifier" do
+      context "when a reg_identifier meets the requirements" do
+        it "is valid" do
+          VCR.use_cassette("contact_postcode_form_valid_postcode") do
+            expect(contact_postcode_form).to be_valid
+          end
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          contact_postcode_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          VCR.use_cassette("contact_postcode_form_valid_postcode") do
+            expect(contact_postcode_form).to_not be_valid
+          end
+        end
+      end
+    end
+
+    describe "#contact_postcode" do
+      context "when a contact_postcode meets the requirements" do
+        it "is valid" do
+          VCR.use_cassette("contact_postcode_form_valid_postcode") do
+            expect(contact_postcode_form).to be_valid
+          end
+        end
+      end
+
+      context "when a contact_postcode is blank" do
+        before(:each) do
+          contact_postcode_form.temp_contact_postcode = ""
+        end
+
+        it "is not valid" do
+          expect(contact_postcode_form).to_not be_valid
+        end
+      end
+
+      context "when a contact_postcode is in the wrong format" do
+        before(:each) do
+          contact_postcode_form.temp_contact_postcode = "foo"
+        end
+
+        it "is not valid" do
+          expect(contact_postcode_form).to_not be_valid
+        end
+      end
+
+      context "when a contact_postcode has no matches" do
+        before(:each) do
+          contact_postcode_form.temp_contact_postcode = "AA1 1AA"
+        end
+
+        it "is not valid" do
+          VCR.use_cassette("contact_postcode_form_no_matches_postcode") do
+            expect(contact_postcode_form).to_not be_valid
+          end
+        end
+      end
+
+      context "when a postcode search returns an error" do
+        before(:each) do
+          allow_any_instance_of(AddressFinderService).to receive(:search_by_postcode).and_return(:error)
+        end
+
+        it "is valid" do
+          expect(contact_postcode_form).to be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "contact_postcode_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:contact_postcode_form) { ContactPostcodeForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        contact_postcode_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(contact_postcode_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        contact_postcode_form.valid?
+        expect(contact_postcode_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_contact_address_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_contact_address_form_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe TransientRegistration, type: :model do
                workflow_state: "contact_address_form")
       end
 
-      it "changes to :contact_email_form after the 'back' event" do
-        expect(transient_registration).to transition_from(:contact_address_form).to(:contact_email_form).on_event(:back)
+      it "changes to :contact_postcode_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:contact_address_form).to(:contact_postcode_form).on_event(:back)
       end
 
       it "changes to :check_your_answers_form after the 'next' event" do

--- a/spec/models/workflow_states/transient_registration_contact_email_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_contact_email_form_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:contact_email_form).to(:contact_phone_form).on_event(:back)
       end
 
-      it "changes to :contact_address_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:contact_email_form).to(:contact_address_form).on_event(:next)
+      it "changes to :contact_postcode_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:contact_email_form).to(:contact_postcode_form).on_event(:next)
       end
     end
   end

--- a/spec/models/workflow_states/transient_registration_contact_postcode_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_contact_postcode_form_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :contact_postcode_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "contact_postcode_form")
+      end
+
+      it "changes to :contact_email_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:contact_postcode_form).to(:contact_email_form).on_event(:back)
+      end
+
+      it "changes to :contact_address_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:contact_postcode_form).to(:contact_address_form).on_event(:next)
+      end
+
+      # it "changes to :contact_address_manual_form after the 'skip_to_manual_address' event" do
+      #   expect(transient_registration).to transition_from(:contact_postcode_form).to(:contact_address_manual_form).on_event(:skip_to_manual_address)
+      # end
+    end
+  end
+end

--- a/spec/requests/company_postcode_forms_spec.rb
+++ b/spec/requests/company_postcode_forms_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
           let(:valid_params) {
             {
               reg_identifier: transient_registration[:reg_identifier],
-              temp_postcode: "BS1 6AH"
+              temp_company_postcode: "BS1 6AH"
             }
           }
 
@@ -71,7 +71,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
           it "updates the transient registration" do
             VCR.use_cassette("company_postcode_form_modified_postcode") do
               post company_postcode_forms_path, company_postcode_form: valid_params
-              expect(transient_registration.reload[:temp_postcode]).to eq(valid_params[:temp_postcode])
+              expect(transient_registration.reload[:temp_company_postcode]).to eq(valid_params[:temp_company_postcode])
             end
           end
 
@@ -98,7 +98,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
           let(:invalid_params) {
             {
               reg_identifier: "foo",
-              temp_postcode: "ABC123DEF456"
+              temp_company_postcode: "ABC123DEF456"
             }
           }
 
@@ -109,7 +109,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
 
           it "does not update the transient registration" do
             post company_postcode_forms_path, company_postcode_form: invalid_params
-            expect(transient_registration.reload[:temp_postcode]).to_not eq(invalid_params[:temp_postcode])
+            expect(transient_registration.reload[:temp_company_postcode]).to_not eq(invalid_params[:temp_company_postcode])
           end
         end
       end
@@ -125,7 +125,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
         let(:valid_params) {
           {
             reg_identifier: transient_registration[:reg_identifier],
-            temp_postcode: "BS1 5AH"
+            temp_company_postcode: "BS1 5AH"
           }
         }
 
@@ -136,7 +136,7 @@ RSpec.describe "CompanyPostcodeForms", type: :request do
 
         it "does not update the transient registration" do
           post company_postcode_forms_path, company_postcode_form: valid_params
-          expect(transient_registration.reload[:temp_postcode]).to_not eq(valid_params[:temp_postcode])
+          expect(transient_registration.reload[:temp_company_postcode]).to_not eq(valid_params[:temp_company_postcode])
         end
 
         it "redirects to the correct form for the state" do

--- a/spec/requests/contact_address_forms_spec.rb
+++ b/spec/requests/contact_address_forms_spec.rb
@@ -146,9 +146,9 @@ RSpec.describe "ContactAddressForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the contact_email form" do
+          it "redirects to the contact_postcode form" do
             get back_contact_address_forms_path(transient_registration[:reg_identifier])
-            expect(response).to redirect_to(new_contact_email_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_contact_postcode_form_path(transient_registration[:reg_identifier]))
           end
         end
       end

--- a/spec/requests/contact_email_forms_spec.rb
+++ b/spec/requests/contact_email_forms_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe "ContactEmailForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the contact_address form" do
+          it "redirects to the contact_postcode form" do
             post contact_email_forms_path, contact_email_form: valid_params
-            expect(response).to redirect_to(new_contact_address_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_contact_postcode_form_path(transient_registration[:reg_identifier]))
           end
         end
 

--- a/spec/requests/contact_postcode_forms_spec.rb
+++ b/spec/requests/contact_postcode_forms_spec.rb
@@ -1,0 +1,253 @@
+require "rails_helper"
+
+RSpec.describe "ContactPostcodeForms", type: :request do
+  describe "GET new_contact_postcode_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "contact_postcode_form")
+        end
+
+        it "returns a success response" do
+          get new_contact_postcode_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_contact_postcode_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "POST contact_postcode_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "contact_postcode_form")
+        end
+
+        context "when valid params are submitted" do
+          let(:valid_params) {
+            {
+              reg_identifier: transient_registration[:reg_identifier],
+              temp_contact_postcode: "BS1 6AH"
+            }
+          }
+
+          it "returns a 302 response" do
+            VCR.use_cassette("contact_postcode_form_modified_postcode") do
+              post contact_postcode_forms_path, contact_postcode_form: valid_params
+              expect(response).to have_http_status(302)
+            end
+          end
+
+          it "updates the transient registration" do
+            VCR.use_cassette("contact_postcode_form_modified_postcode") do
+              post contact_postcode_forms_path, contact_postcode_form: valid_params
+              expect(transient_registration.reload[:temp_contact_postcode]).to eq(valid_params[:temp_contact_postcode])
+            end
+          end
+
+          it "redirects to the contact_address form" do
+            VCR.use_cassette("contact_postcode_form_modified_postcode") do
+              post contact_postcode_forms_path, contact_postcode_form: valid_params
+              expect(response).to redirect_to(new_contact_address_form_path(transient_registration[:reg_identifier]))
+            end
+          end
+
+          # context "when a postcode search returns an error" do
+          #   before(:each) do
+          #     allow_any_instance_of(AddressFinderService).to receive(:search_by_postcode).and_return(:error)
+          #   end
+          #
+          #   it "redirects to the contact_address_manual form" do
+          #     post contact_postcode_forms_path, contact_postcode_form: valid_params
+          #     expect(response).to redirect_to(new_contact_address_manual_form_path(transient_registration[:reg_identifier]))
+          #   end
+          # end
+        end
+
+        context "when invalid params are submitted" do
+          let(:invalid_params) {
+            {
+              reg_identifier: "foo",
+              temp_contact_postcode: "ABC123DEF456"
+            }
+          }
+
+          it "returns a 302 response" do
+            post contact_postcode_forms_path, contact_postcode_form: invalid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "does not update the transient registration" do
+            post contact_postcode_forms_path, contact_postcode_form: invalid_params
+            expect(transient_registration.reload[:temp_contact_postcode]).to_not eq(invalid_params[:temp_contact_postcode])
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        let(:valid_params) {
+          {
+            reg_identifier: transient_registration[:reg_identifier],
+            temp_contact_postcode: "BS1 5AH"
+          }
+        }
+
+        it "returns a 302 response" do
+          post contact_postcode_forms_path, contact_postcode_form: valid_params
+          expect(response).to have_http_status(302)
+        end
+
+        it "does not update the transient registration" do
+          post contact_postcode_forms_path, contact_postcode_form: valid_params
+          expect(transient_registration.reload[:temp_contact_postcode]).to_not eq(valid_params[:temp_contact_postcode])
+        end
+
+        it "redirects to the correct form for the state" do
+          post contact_postcode_forms_path, contact_postcode_form: valid_params
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "GET back_contact_postcode_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "contact_postcode_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_contact_postcode_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the contact_email form" do
+            get back_contact_postcode_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_contact_email_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_contact_postcode_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_contact_postcode_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
+
+  # describe "GET skip_to_manual_address_contact_postcode_forms_path" do
+  #   context "when a valid user is signed in" do
+  #     let(:user) { create(:user) }
+  #     before(:each) do
+  #       sign_in(user)
+  #     end
+  #
+  #     context "when a valid transient registration exists" do
+  #       let(:transient_registration) do
+  #         create(:transient_registration,
+  #                :has_required_data,
+  #                :has_postcode,
+  #                account_email: user.email,
+  #                workflow_state: "contact_postcode_form")
+  #       end
+  #
+  #       context "when the skip_to_manual_address action is triggered" do
+  #         it "returns a 302 response" do
+  #           get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to have_http_status(302)
+  #         end
+  #
+  #         it "redirects to the contact_address_manual form" do
+  #           get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to redirect_to(new_contact_address_manual_form_path(transient_registration[:reg_identifier]))
+  #         end
+  #       end
+  #     end
+  #
+  #     context "when the transient registration is in the wrong state" do
+  #       let(:transient_registration) do
+  #         create(:transient_registration,
+  #                :has_required_data,
+  #                :has_postcode,
+  #                account_email: user.email,
+  #                workflow_state: "renewal_start_form")
+  #       end
+  #
+  #       context "when the skip_to_manual_address action is triggered" do
+  #         it "returns a 302 response" do
+  #           get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to have_http_status(302)
+  #         end
+  #
+  #         it "redirects to the correct form for the state" do
+  #           get skip_to_manual_address_contact_postcode_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-112

"What's the address of the person we should contact?" Add forms to allow UK-based users to enter a postcode so they can search for a contact address. Selection and saving of the contact address will be added in a separate PR to keep things manageable.

This should function the same way as the registered address forms earlier in the process.

Non-UK users or users who choose to enter their addresses manually will see a separate form (to be worked on as a separate feature).