### PR TITLE
Save the position of relevant conviction people

### DIFF
--- a/app/forms/conviction_details_form.rb
+++ b/app/forms/conviction_details_form.rb
@@ -1,6 +1,4 @@
 class ConvictionDetailsForm < PersonForm
-  attr_accessor :position
-
   def position?
     true
   end

--- a/app/forms/person_form.rb
+++ b/app/forms/person_form.rb
@@ -1,5 +1,5 @@
 class PersonForm < BaseForm
-  attr_accessor :first_name, :last_name, :dob_day, :dob_month, :dob_year, :date_of_birth
+  attr_accessor :first_name, :last_name, :position, :dob_day, :dob_month, :dob_year, :date_of_birth
   attr_accessor :new_person
 
   def initialize(transient_registration)
@@ -70,12 +70,15 @@ class PersonForm < BaseForm
   private
 
   def set_up_new_person
-    KeyPerson.new(first_name: first_name,
-                  last_name: last_name,
-                  dob_day: dob_day,
-                  dob_month: dob_month,
-                  dob_year: dob_year,
-                  person_type: person_type)
+    person = KeyPerson.new(first_name: first_name,
+                           last_name: last_name,
+                           dob_day: dob_day,
+                           dob_month: dob_month,
+                           dob_year: dob_year,
+                           person_type: person_type)
+    person.position = position if position?
+
+    person
   end
 
   def all_people

--- a/spec/requests/conviction_details_forms_spec.rb
+++ b/spec/requests/conviction_details_forms_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "ConvictionDetailsForms", type: :request do
 
           it "updates the transient registration" do
             post conviction_details_forms_path, conviction_details_form: valid_params
-            expect(transient_registration.reload.keyPeople.last.first_name).to eq(valid_params[:first_name])
+            expect(transient_registration.reload.keyPeople.last.position).to eq(valid_params[:position])
           end
 
           it "returns a 302 response" do


### PR DESCRIPTION
This change fixes a bug which meant that we weren't saving the 'position' attribute when we created a new person with a relevant conviction.