### PR TITLE
Fix bugs with saved addresses

### DIFF
--- a/app/forms/address_form.rb
+++ b/app/forms/address_form.rb
@@ -28,6 +28,7 @@ class AddressForm < BaseForm
   # If an address has already been assigned to the transient registration, pre-select it
   def preselect_existing_address
     return unless @transient_registration.addresses.present?
+    return unless saved_address
     return unless saved_address.uprn.present?
     selected_address = temp_addresses.detect { |address| address["uprn"] == saved_address.uprn.to_s }
     self.temp_address = selected_address["uprn"] if selected_address.present?

--- a/app/forms/address_form.rb
+++ b/app/forms/address_form.rb
@@ -27,11 +27,15 @@ class AddressForm < BaseForm
 
   # If an address has already been assigned to the transient registration, pre-select it
   def preselect_existing_address
-    return unless @transient_registration.addresses.present?
-    return unless saved_address
-    return unless saved_address.uprn.present?
+    return unless can_preselect_address?
     selected_address = temp_addresses.detect { |address| address["uprn"] == saved_address.uprn.to_s }
     self.temp_address = selected_address["uprn"] if selected_address.present?
+  end
+
+  def can_preselect_address?
+    return false unless saved_address
+    return false unless saved_address.uprn.present?
+    true
   end
 
   def add_or_replace_address(selected_address_uprn)

--- a/app/forms/company_address_form.rb
+++ b/app/forms/company_address_form.rb
@@ -19,7 +19,7 @@ class CompanyAddressForm < AddressForm
   end
 
   def saved_address
-    @transient_registration.contact_address
+    @transient_registration.registered_address
   end
 
   def address_type


### PR DESCRIPTION
There were two issues leftover from the address refactoring:

- The company address select dropdown was trying to prefill with the contact address
- If we called saved_address.uprn and there was no saved_address, we got an error

This commit fixes those.