### PR TITLE
Rescue SocketErrors for Companies House lookup

### DIFF
--- a/app/services/companies_house_service.rb
+++ b/app/services/companies_house_service.rb
@@ -26,6 +26,10 @@ class CompaniesHouseService
       Airbrake.notify(e)
       Rails.logger.error "Companies House error: " + e.to_s
       :error
+    rescue SocketError => e
+      Airbrake.notify(e)
+      Rails.logger.error "Companies House error: " + e.to_s
+      :error
     end
   end
 


### PR DESCRIPTION
When we send a company no to Companies House for validation, we should rescue any SocketErrors we get back and present a nicely formatted error instead. This still blocks progression but at least it doesn't show a scary error page.

(Ran into this one while working offline)