### PR TITLE
Add fieldset with correct id to declaration form

### DIFF
--- a/app/views/declaration_forms/new.html.erb
+++ b/app/views/declaration_forms/new.html.erb
@@ -11,10 +11,12 @@
     </ul>
 
     <div class="form-group">
-      <div class="multiple-choice">
-        <%= f.check_box :declaration %>
-        <%= f.label :declaration, t(".declaration_text") %>
-      </div>
+      <fieldset id="declaration">
+        <div class="multiple-choice">
+          <%= f.check_box :declaration %>
+          <%= f.label :declaration, t(".declaration_text") %>
+        </div>
+      </fieldset>
     </div>
 
     <p><%= link_to t(".privacy_link_text"), page_path("privacy"),  target: "_blank" %></p>


### PR DESCRIPTION
Validation errors should link to the field where the error is. This change adds a fieldset with the correct id to the declaration form, so if the box isn't ticked, the link goes to the box.