### PR TITLE
Fall back to title from 'new' action

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,9 @@ module ApplicationHelper
     return content_for :title if content_for?(:title)
     # Otherwise, look up translation key based on controller path, action name and .title
     # Solution from https://coderwall.com/p/a1pj7w/rails-page-titles-with-the-right-amount-of-magic
-    t("#{controller_path.tr('/', '.')}.#{action_name}.title", default: "")
+    title = t("#{controller_path.tr('/', '.')}.#{action_name}.title", default: "")
+    return title if title.present?
+    # Default to title for "new" action if the current action doesn't return anything
+    t("#{controller_path.tr('/', '.')}.new.title", default: "")
   end
 end


### PR DESCRIPTION
We get custom title attributes from I18n based on the action_name. However, if there isn't one provided for that action, we can fall back to whatever is provided for the 'new' action.

This means that when we hit the 'create' action in a validation error, we can fall back to the title for the 'new' action instead (or provide a custom one if we want).