### PR TITLE
On renewal start page, only users with CH no about changing it

### DIFF
--- a/app/views/renewal_start_forms/new.html.erb
+++ b/app/views/renewal_start_forms/new.html.erb
@@ -20,7 +20,9 @@
     <p><%= t(".paragraph_4") %></p>
     <ul class="list list-bullet">
       <li><%= t(".list_item_1") %></li>
+      <% if @renewal_start_form.transient_registration.company_no.present? %>
       <li><%= t(".list_item_2") %></li>
+      <% end %>
       <li><%= t(".list_item_3") %></li>
     </ul>
 


### PR DESCRIPTION
Only limited companies and LLPs have Companies House numbers, so only those users will need to worry about changing it. This change only reveals the warning about changing the number to users who already have one.