### PR TITLE
Make smart answers optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,11 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
-# Ignore all logfiles and tempfiles.
+# Ignore logfiles, tempfiles and OS-specific files
 /log/*
 !/log/.keep
 /tmp
+.DS_Store
 
 # Ignore test coverage reports
 /coverage

--- a/app/controllers/tier_check_forms_controller.rb
+++ b/app/controllers/tier_check_forms_controller.rb
@@ -1,0 +1,9 @@
+class TierCheckFormsController < FormsController
+  def new
+    super(TierCheckForm, "tier_check_form")
+  end
+
+  def create
+    super(TierCheckForm, "tier_check_form")
+  end
+end

--- a/app/forms/tier_check_form.rb
+++ b/app/forms/tier_check_form.rb
@@ -1,17 +1,18 @@
 class TierCheckForm < BaseForm
-  # TODO: Define accessible attributes, eg attr_accessor :field
+  attr_accessor :temp_tier_check
 
   def initialize(transient_registration)
     super
-    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+    self.temp_tier_check = @transient_registration.temp_tier_check
   end
 
   def submit(params)
     # Assign the params for validation and pass them to the BaseForm method for updating
-    # TODO: Define allowed params, eg self.field = params[:field]
-    # TODO: Include attributes to update in the attributes hash, eg { field: field }
-    attributes = {}
+    self.temp_tier_check = convert_to_boolean(params[:temp_tier_check])
+    attributes = { temp_tier_check: temp_tier_check }
 
     super(attributes, params[:reg_identifier])
   end
+
+  validates :temp_tier_check, inclusion: { in: [true, false] }
 end

--- a/app/forms/tier_check_form.rb
+++ b/app/forms/tier_check_form.rb
@@ -1,0 +1,17 @@
+class TierCheckForm < BaseForm
+  # TODO: Define accessible attributes, eg attr_accessor :field
+
+  def initialize(transient_registration)
+    super
+    # TODO: Define params to get from transient_registration, eg self.field = @transient_registration.field
+  end
+
+  def submit(params)
+    # Assign the params for validation and pass them to the BaseForm method for updating
+    # TODO: Define allowed params, eg self.field = params[:field]
+    # TODO: Include attributes to update in the attributes hash, eg { field: field }
+    attributes = {}
+
+    super(attributes, params[:reg_identifier])
+  end
+end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -18,6 +18,7 @@ module CanChangeWorkflowStatus
 
       state :business_type_form
 
+      state :tier_check_form
       state :other_businesses_form
       state :service_provided_form
       state :construction_demolition_form

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -98,13 +98,16 @@ module CanChangeWorkflowStatus
                     if: :switch_to_lower_tier_based_on_business_type?
 
         transitions from: :business_type_form,
-                    to: :other_businesses_form,
+                    to: :tier_check_form,
                     if: :business_type_change_valid?
 
         transitions from: :business_type_form,
                     to: :cannot_renew_type_change_form
 
         # Smart answers
+
+        transitions from: :tier_check_form,
+                    to: :other_businesses_form
 
         transitions from: :other_businesses_form,
                     to: :construction_demolition_form,
@@ -275,12 +278,15 @@ module CanChangeWorkflowStatus
 
         # Smart answers
 
-        transitions from: :other_businesses_form,
+        transitions from: :tier_check_form,
                     to: :location_form,
                     if: :based_overseas?
 
-        transitions from: :other_businesses_form,
+        transitions from: :tier_check_form,
                     to: :business_type_form
+
+        transitions from: :other_businesses_form,
+                    to: :tier_check_form
 
         transitions from: :service_provided_form,
                     to: :other_businesses_form

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -107,6 +107,10 @@ module CanChangeWorkflowStatus
         # Smart answers
 
         transitions from: :tier_check_form,
+                    to: :cbd_type_form,
+                    if: :skip_tier_check?
+
+        transitions from: :tier_check_form,
                     to: :other_businesses_form
 
         transitions from: :other_businesses_form,
@@ -302,6 +306,10 @@ module CanChangeWorkflowStatus
                     to: :service_provided_form
 
         transitions from: :cbd_type_form,
+                    to: :tier_check_form,
+                    if: :skip_tier_check?
+
+        transitions from: :cbd_type_form,
                     to: :construction_demolition_form,
                     if: :only_carries_own_waste?
 
@@ -468,6 +476,10 @@ module CanChangeWorkflowStatus
     # The form prepends 0s to make up the length, so we should do this for the old number to match
     old_company_no = "0#{old_company_no}" while old_company_no.length < 8
     old_company_no != company_no
+  end
+
+  def skip_tier_check?
+    temp_tier_check == false
   end
 
   def only_carries_own_waste?

--- a/app/models/transient_registration.rb
+++ b/app/models/transient_registration.rb
@@ -15,6 +15,7 @@ class TransientRegistration
   field :temp_company_postcode, type: String
   field :temp_contact_postcode, type: String
   field :temp_os_places_error, type: Boolean
+  field :temp_tier_check, type: Boolean
 
   # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
   def registration_type_changed?

--- a/app/views/tier_check_forms/new.html.erb
+++ b/app/views/tier_check_forms/new.html.erb
@@ -1,24 +1,66 @@
 <%= render("shared/back", back_path: back_tier_check_forms_path(@tier_check_form.reg_identifier)) %>
 
-<% if @tier_check_form.errors.any? %>
-
-  <h1 class="heading-large"><%= t(".error_heading") %></h1>
-
-  <% @tier_check_form.errors.full_messages.each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-
-<% else %>
-
+<div class="text">
   <%= form_for(@tier_check_form) do |f| %>
     <%= render("shared/errors", object: @tier_check_form) %>
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <p><%= t(".paragraph_1") %></p>
+    <p><%= t(".paragraph_2") %></p>
+    <p><%= t(".paragraph_3") %></p>
+
+    <div class="form-group">
+      <details>
+        <summary>
+          <span class="summary"><%= t(".tier_details_subheading") %></span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <p><%= t(".tier_details_paragraph_1") %></p>
+          <p class="strong"><%= t(".tier_details_paragraph_2") %></p>
+          <ul class="list list-bullet">
+            <% t(".tier_details_list_1").each do |item| %>
+            <li><%= item[:item] %></li>
+            <% end %>
+          </ul>
+          <p class="strong"><%= t(".tier_details_paragraph_3") %></p>
+          <ul class="list list-bullet">
+            <% t(".tier_details_list_2").each do |item| %>
+            <li><%= item[:item] %></li>
+            <% end %>
+          </ul>
+        </div>
+      </details>
+    </div>
+
+    <% if @tier_check_form.errors[:temp_tier_check].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="temp_tier_check">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @tier_check_form.errors[:temp_tier_check].any? %>
+        <span class="error-message"><%= @tier_check_form.errors[:temp_tier_check].join(", ") %></span>
+        <% end %>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_tier_check, "true" %>
+          <%= f.label :temp_tier_check, t(".options.true"), value: "true" %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_tier_check, "false" %>
+          <%= f.label :temp_tier_check, t(".options.false"), value: "false" %>
+        </div>
+      </fieldset>
+    </div>
 
     <%= f.hidden_field :reg_identifier, value: @tier_check_form.reg_identifier %>
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
   <% end %>
-
-<% end %>
+</div>

--- a/app/views/tier_check_forms/new.html.erb
+++ b/app/views/tier_check_forms/new.html.erb
@@ -1,0 +1,24 @@
+<%= render("shared/back", back_path: back_tier_check_forms_path(@tier_check_form.reg_identifier)) %>
+
+<% if @tier_check_form.errors.any? %>
+
+  <h1 class="heading-large"><%= t(".error_heading") %></h1>
+
+  <% @tier_check_form.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+
+<% else %>
+
+  <%= form_for(@tier_check_form) do |f| %>
+    <%= render("shared/errors", object: @tier_check_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= f.hidden_field :reg_identifier, value: @tier_check_form.reg_identifier %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+
+<% end %>

--- a/config/locales/forms/tier_check_forms/en.yml
+++ b/config/locales/forms/tier_check_forms/en.yml
@@ -1,0 +1,16 @@
+en:
+  tier_check_forms:
+    new:
+      title: Check your tier
+      heading: Check your tier
+      error_heading: Something is wrong
+      next_button: Continue
+  activemodel:
+    errors:
+      models:
+        tier_check_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/locales/forms/tier_check_forms/en.yml
+++ b/config/locales/forms/tier_check_forms/en.yml
@@ -27,6 +27,8 @@ en:
       models:
         tier_check_form:
           attributes:
+            temp_tier_check:
+              inclusion: "You must answer this question"
             reg_identifier:
               invalid_format: "The registration ID is not in a valid format"
               no_registration: "There is no registration matching this ID"

--- a/config/locales/forms/tier_check_forms/en.yml
+++ b/config/locales/forms/tier_check_forms/en.yml
@@ -2,7 +2,24 @@ en:
   tier_check_forms:
     new:
       title: Check your tier
-      heading: Check your tier
+      heading: You are renewing an upper tier registration
+      paragraph_1: "If you're not sure if you should be upper or lower tier, you can answer a few questions about your business's activities to check."
+      paragraph_2: The questions only relate to your business activities and what type of waste you currently deal with.
+      paragraph_3: "Upper tier registrations need to be renewed every 3 years for a cost. Lower tier registrations are free and don’t expire."
+      tier_details_subheading: "What’s the difference between upper and lower tier?"
+      tier_details_paragraph_1: This depends on what waste you deal with and who creates it.
+      tier_details_paragraph_2: "You need an upper tier registration if you do any of the following:"
+      tier_details_list_1:
+        - item: transport other people's waste (for example, a skip company)
+        - item: carry construction or demolition waste
+        - item: buy and/or sell waste or arrange for others to carry it
+      tier_details_paragraph_3: "If your activities are limited to the categories below, you only need a lower tier registration:"
+      tier_details_list_2:
+        - item: "You ONLY deal with waste you produce in the course of carrying out your business – for example, a hairdresser dealing with hair clippings. This does not include construction or demolition waste"
+        - item: "You ONLY deal with waste from mines or quarries, from agricultural premises, or animal by-products"
+      options:
+        "true": I want to check if my tier is correct before renewing
+        "false": I am happy to skip this check
       error_heading: Something is wrong
       next_button: Continue
   activemodel:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,16 @@ Rails.application.routes.draw do
               on: :collection
             end
 
+  resources :tier_check_forms,
+            only: [:new, :create],
+            path: "tier-check",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "tier_check_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :other_businesses_forms,
             only: [:new, :create],
             path: "other-businesses",

--- a/spec/cassettes/contact_postcode_form_modified_postcode.yml
+++ b/spec/cassettes/contact_postcode_form_modified_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 09:59:50 GMT
+      - Mon, 23 Apr 2018 10:05:41 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAN2Y0W6bMBSGX8XimkoQgoHdkcRtkChEQFpFVS+cxG3QCI4IbKumvftMIS4QNu3CROkuIvEfw7H9n08Hk6ef0p6m8VeSSV8kTTHNsSrJUnHI0qZO4pQcpS9PEgqn9gKB0HZ9j8UfnGnkB44NwihAKJKeZSmn38tHJ4ETRr7L7jnQY76hW1IGQxVAe86CBB/zOH0t59CtkW6wUEqzfFfFVGMEjTK2oUWaZ28sxMSWHEi6JWnu0g1O4rwbjnYZLV53Lzgj1Qje7uM0PuYZzuNvxM4Ibi0sKdPYRb6jGUu2PGxxTmbsVz2c0Tec3OM46Q4ccJbHOGGiaYYMlp4TAV0GUWB7oX8P5v4yRDLoWCSDegHsgrtxLNaTIk62bPce3pfzVMnY0LodbyVnw+XiT5uub+nWRJZo9oqZD8wFmtY3derIZyn263cS6rr5Ly/xhkzoj+YAM5xZsGeO18nKGC3WCZn1VeiX3ERspENo6h+Icc0RW8wdd+FHoTi8NHiGl6FoV4/XyYgaLetGVUTSVeYbDrBGFS8Il6IqOmzAddIcrnA5ebRX4tAaa+edy9KvHq3KhhosUyRV5nBI8dpdDijV0g3V+ACKaw5UNEdgZjvuCkycCIGpfYvE0QWtc7p08+rp6vGkRk0ViZo6HGr9Vb3oW9KEjYMY15y7dwe0m7Hc3bKoI1kPesbo6tHjtgjkjKUbjrRLYzXWtBZWlW5jBYeCatwDlQk/B1RQJFLwPwFKVUzNGjfejyfdBOoBBaETrYB/C8q++ojCqLxG3p1rezOBLavnLGZ+ipb1d4cEgTcccv9S48s2OctsN7l3zZnkm5oFKzB1ke2x1Qvscuefm9C0rp7DXlfqc5shsvkZw5H4p8pelj6l/f9GpRv0BXeOB+59D63Awp0K/FzQz8GD198Au4bUzI1EMjcakrmzeg6K2/NvwFnliLMVAAA=
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 10:03:21 GMT
+  recorded_at: Mon, 23 Apr 2018 10:05:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/contact_postcode_form_no_matches_postcode.yml
+++ b/spec/cassettes/contact_postcode_form_no_matches_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 09 Apr 2018 09:59:51 GMT
+      - Mon, 23 Apr 2018 10:05:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -30,5 +30,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":{"message":"Parameters are not valid","statuscode":400}}'
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 10:03:21 GMT
+  recorded_at: Mon, 23 Apr 2018 10:05:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/contact_postcode_form_valid_postcode.yml
+++ b/spec/cassettes/contact_postcode_form_valid_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Apr 2018 09:59:49 GMT
+      - Mon, 23 Apr 2018 10:05:41 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAOWUUW+bMBDHv4rlZx6gaULWN1NQE42aypBNXdUHJziJNbCRMduqad+9x8JSIN1LlU2T9oDA/7PvfP/7iYfvuNRKfhYGX2HPdd95/sydXbrYwU1l1IlYSCVqfPWAF4TdphFFNyxZ3UEgjAiN2D1iCQnxo4Ot/tqeDtgyzZIYNlS6thudi1ZMPTQlCxAFr61UO9Am07k3aSsobez+oHn+xWzug7bRjbLmCSRY5KISKhfKxnrDC2nHcrY3utntt9yIQ4TnpVSytoZb+UUQI/jgYkWbhjR2rw0kW1U5tyKE53DY6Cde3HJZjAMVN1byAhYDKxyUsWUSJikKCH3voL4vDuqqwsfRgrpZB40scmiZ8rJLvh4q/ZQQba/6q8Vux8B+B2uz49AyNKxVt2M8sGOJplz/nH43o2S7lRsR6G/9AJgL7Zbg7ssdc92sCxG+No0fTh+ryaXrebMXoo7rI0yUZCtGYhTRm5jQ8Dw4XbjTE5x8d/7P4zQyw0GLhC0/JRTeqzQ6E1GDnG9F6nRsfxkqfwSV34cqW7DlhwixiEYfSRBHKbqLr//vP9WrlpyJqLdC9Lsx/VGUHp8B5v82jvgGAAA=
     http_version: 
-  recorded_at: Mon, 09 Apr 2018 10:03:21 GMT
+  recorded_at: Mon, 23 Apr 2018 10:05:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/factories/forms/tier_check_form.rb
+++ b/spec/factories/forms/tier_check_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :tier_check_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "tier_check_form")) }
+    end
+  end
+end

--- a/spec/factories/forms/tier_check_form.rb
+++ b/spec/factories/forms/tier_check_form.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :tier_check_form do
     trait :has_required_data do
+      temp_tier_check false
+
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "tier_check_form")) }
     end
   end

--- a/spec/forms/declare_convictions_forms_spec.rb
+++ b/spec/forms/declare_convictions_forms_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe DeclareConvictionsForm, type: :model do
 
       context "when a declared_convictions is false" do
         before(:each) do
-          declare_convictions_form.declared_convictions = true
+          declare_convictions_form.declared_convictions = false
         end
 
         it "is valid" do

--- a/spec/forms/tier_check_forms_spec.rb
+++ b/spec/forms/tier_check_forms_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe TierCheckForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:tier_check_form) { build(:tier_check_form, :has_required_data) }
+      let(:valid_params) { { reg_identifier: tier_check_form.reg_identifier } }
+
+      it "should submit" do
+        expect(tier_check_form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:tier_check_form) { build(:tier_check_form, :has_required_data) }
+      let(:invalid_params) { { reg_identifier: "foo" } }
+
+      it "should not submit" do
+        expect(tier_check_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  context "when a valid transient registration exists" do
+    let(:tier_check_form) { build(:tier_check_form, :has_required_data) }
+
+    describe "#reg_identifier" do
+      it "is valid" do
+        expect(tier_check_form).to be_valid
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          tier_check_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(tier_check_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "tier_check_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:tier_check_form) { TierCheckForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        tier_check_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(tier_check_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        tier_check_form.valid?
+        expect(tier_check_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/forms/tier_check_forms_spec.rb
+++ b/spec/forms/tier_check_forms_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe TierCheckForm, type: :model do
   describe "#submit" do
     context "when the form is valid" do
       let(:tier_check_form) { build(:tier_check_form, :has_required_data) }
-      let(:valid_params) { { reg_identifier: tier_check_form.reg_identifier } }
+      let(:valid_params) do
+        {
+          reg_identifier: tier_check_form.reg_identifier,
+          temp_tier_check: "false"
+        }
+      end
 
       it "should submit" do
         expect(tier_check_form.submit(valid_params)).to eq(true)
@@ -32,6 +37,48 @@ RSpec.describe TierCheckForm, type: :model do
       context "when a reg_identifier is blank" do
         before(:each) do
           tier_check_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(tier_check_form).to_not be_valid
+        end
+      end
+    end
+
+    describe "#temp_tier_check" do
+      context "when a temp_tier_check is true" do
+        before(:each) do
+          tier_check_form.temp_tier_check = true
+        end
+
+        it "is valid" do
+          expect(tier_check_form).to be_valid
+        end
+      end
+
+      context "when a temp_tier_check is false" do
+        before(:each) do
+          tier_check_form.temp_tier_check = false
+        end
+
+        it "is valid" do
+          expect(tier_check_form).to be_valid
+        end
+      end
+
+      context "when a temp_tier_check is not a boolean" do
+        before(:each) do
+          tier_check_form.temp_tier_check = "foo"
+        end
+
+        it "is not valid" do
+          expect(tier_check_form).to_not be_valid
+        end
+      end
+
+      context "when a temp_tier_check is blank" do
+        before(:each) do
+          tier_check_form.temp_tier_check = ""
         end
 
         it "is not valid" do

--- a/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_business_type_form_spec.rb
@@ -49,17 +49,17 @@ RSpec.describe TransientRegistration, type: :model do
         {
           # Permutation table of old business_type, new business_type and the state that should result
           # Example where the business_type doesn't change:
-          %w[limitedCompany limitedCompany]              => :other_businesses_form,
+          %w[limitedCompany limitedCompany]              => :tier_check_form,
           %w[charity charity]                            => :cannot_renew_lower_tier_form,
           # Examples where the business_type change is allowed and not allowed:
-          %w[authority localAuthority]                   => :other_businesses_form,
+          %w[authority localAuthority]                   => :tier_check_form,
           %w[authority limitedCompany]                   => :cannot_renew_type_change_form,
           %w[charity limitedCompany]                     => :cannot_renew_type_change_form,
-          %w[limitedCompany limitedLiabilityPartnership] => :other_businesses_form,
+          %w[limitedCompany limitedLiabilityPartnership] => :tier_check_form,
           %w[limitedCompany soleTrader]                  => :cannot_renew_type_change_form,
-          %w[partnership limitedLiabilityPartnership]    => :other_businesses_form,
+          %w[partnership limitedLiabilityPartnership]    => :tier_check_form,
           %w[partnership soleTrader]                     => :cannot_renew_type_change_form,
-          %w[publicBody localAuthority]                  => :other_businesses_form,
+          %w[publicBody localAuthority]                  => :tier_check_form,
           %w[publicBody soleTrader]                      => :cannot_renew_type_change_form,
           %w[soleTrader limitedCompany]                  => :cannot_renew_type_change_form,
           # Example where the business_type was invalid to begin with:

--- a/spec/models/workflow_states/transient_registration_cbd_type_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_cbd_type_form_spec.rb
@@ -9,30 +9,42 @@ RSpec.describe TransientRegistration, type: :model do
                workflow_state: "cbd_type_form")
       end
 
-      context "when the business doesn't carry waste for other businesses or households" do
-        before(:each) { transient_registration.other_businesses = false }
+      context "when temp_tier_check is false" do
+        before(:each) { transient_registration.temp_tier_check = false }
 
-        it "changes to :construction_demolition_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:cbd_type_form).to(:construction_demolition_form).on_event(:back)
+        it "transitions to :tier_check_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:cbd_type_form).to(:tier_check_form).on_event(:back)
         end
       end
 
-      context "when the business carries waste produced by its customers" do
-        before(:each) { transient_registration.is_main_service = true }
+      context "when temp_tier_check is true" do
+        before(:each) { transient_registration.temp_tier_check = true }
 
-        it "changes to :waste_types_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:cbd_type_form).to(:waste_types_form).on_event(:back)
-        end
-      end
+        context "when the business doesn't carry waste for other businesses or households" do
+          before(:each) { transient_registration.other_businesses = false }
 
-      context "when the business carries carries waste for other businesses but produces that waste" do
-        before(:each) do
-          transient_registration.other_businesses = true
-          transient_registration.is_main_service = false
+          it "changes to :construction_demolition_form after the 'back' event" do
+            expect(transient_registration).to transition_from(:cbd_type_form).to(:construction_demolition_form).on_event(:back)
+          end
         end
 
-        it "changes to :construction_demolition_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:cbd_type_form).to(:construction_demolition_form).on_event(:back)
+        context "when the business carries waste produced by its customers" do
+          before(:each) { transient_registration.is_main_service = true }
+
+          it "changes to :waste_types_form after the 'back' event" do
+            expect(transient_registration).to transition_from(:cbd_type_form).to(:waste_types_form).on_event(:back)
+          end
+        end
+
+        context "when the business carries carries waste for other businesses but produces that waste" do
+          before(:each) do
+            transient_registration.other_businesses = true
+            transient_registration.is_main_service = false
+          end
+
+          it "changes to :construction_demolition_form after the 'back' event" do
+            expect(transient_registration).to transition_from(:cbd_type_form).to(:construction_demolition_form).on_event(:back)
+          end
         end
       end
 

--- a/spec/models/workflow_states/transient_registration_other_businesses_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_other_businesses_form_spec.rb
@@ -9,16 +9,8 @@ RSpec.describe TransientRegistration, type: :model do
                workflow_state: "other_businesses_form")
       end
 
-      it "transitions to :business_type_form after the 'back' event" do
-        expect(transient_registration).to transition_from(:other_businesses_form).to(:business_type_form).on_event(:back)
-      end
-
-      context "when the business is overseas" do
-        before(:each) { transient_registration.location = "overseas" }
-
-        it "transitions to :location_form after the 'back' event" do
-          expect(transient_registration).to transition_from(:other_businesses_form).to(:location_form).on_event(:back)
-        end
+      it "transitions to :tier_check_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:other_businesses_form).to(:tier_check_form).on_event(:back)
       end
 
       context "when the business does not carry waste for other businesses or households" do

--- a/spec/models/workflow_states/transient_registration_tier_check_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_tier_check_form_spec.rb
@@ -21,8 +21,20 @@ RSpec.describe TransientRegistration, type: :model do
         end
       end
 
-      it "transitions to :other_businesses_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:tier_check_form).to(:other_businesses_form).on_event(:next)
+      context "when temp_tier_check is true" do
+        before(:each) { transient_registration.temp_tier_check = true }
+
+        it "transitions to :other_businesses_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:tier_check_form).to(:other_businesses_form).on_event(:next)
+        end
+      end
+
+      context "when temp_tier_check is false" do
+        before(:each) { transient_registration.temp_tier_check = false }
+
+        it "transitions to :cbd_type_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:tier_check_form).to(:cbd_type_form).on_event(:next)
+        end
       end
     end
   end

--- a/spec/models/workflow_states/transient_registration_tier_check_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_tier_check_form_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :tier_check_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "tier_check_form")
+      end
+
+      it "transitions to :business_type_form after the 'back' event" do
+        expect(transient_registration).to transition_from(:tier_check_form).to(:business_type_form).on_event(:back)
+      end
+
+      context "when the business is overseas" do
+        before(:each) { transient_registration.location = "overseas" }
+
+        it "transitions to :location_form after the 'back' event" do
+          expect(transient_registration).to transition_from(:tier_check_form).to(:location_form).on_event(:back)
+        end
+      end
+
+      it "transitions to :other_businesses_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:tier_check_form).to(:other_businesses_form).on_event(:next)
+      end
+    end
+  end
+end

--- a/spec/requests/business_type_forms_spec.rb
+++ b/spec/requests/business_type_forms_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
 
           it "redirects to the smart answers form" do
             post business_type_forms_path, business_type_form: valid_params
-            expect(response).to redirect_to(new_other_businesses_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_tier_check_form_path(transient_registration[:reg_identifier]))
           end
         end
 
@@ -93,7 +93,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
 
           it "redirects to the smart answers form" do
             post business_type_forms_path, business_type_form: valid_params
-            expect(response).to redirect_to(new_other_businesses_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_tier_check_form_path(transient_registration[:reg_identifier]))
           end
         end
 
@@ -208,7 +208,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
           create(:transient_registration,
                  :has_required_data,
                  account_email: user.email,
-                 workflow_state: "other_businesses_form")
+                 workflow_state: "location_form")
         end
 
         context "when the back action is triggered" do
@@ -219,7 +219,7 @@ RSpec.describe "BusinessTypeForms", type: :request do
 
           it "redirects to the correct form for the state" do
             get back_business_type_forms_path(transient_registration[:reg_identifier])
-            expect(response).to redirect_to(new_other_businesses_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_location_form_path(transient_registration[:reg_identifier]))
           end
         end
       end

--- a/spec/requests/other_businesses_forms_spec.rb
+++ b/spec/requests/other_businesses_forms_spec.rb
@@ -163,9 +163,9 @@ RSpec.describe "OtherBusinessesForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the business_type form" do
+          it "redirects to the tier_check form" do
             get back_other_businesses_forms_path(transient_registration[:reg_identifier])
-            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_tier_check_form_path(transient_registration[:reg_identifier]))
           end
         end
       end

--- a/spec/requests/tier_check_forms_spec.rb
+++ b/spec/requests/tier_check_forms_spec.rb
@@ -1,0 +1,178 @@
+require "rails_helper"
+
+RSpec.describe "TierCheckForms", type: :request do
+  describe "GET new_tier_check_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "tier_check_form")
+        end
+
+        it "returns a success response" do
+          get new_tier_check_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_tier_check_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+
+  describe "POST tier_check_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "tier_check_form")
+        end
+
+        context "when valid params are submitted" do
+          let(:valid_params) {
+            {
+              reg_identifier: transient_registration[:reg_identifier]
+            }
+          }
+
+          it "updates the transient registration" do
+            # TODO: Add test once data is submitted through the form
+          end
+
+          # it "returns a 302 response" do
+          #   post tier_check_forms_path, tier_check_form: valid_params
+          #   expect(response).to have_http_status(302)
+          # end
+
+          # it "redirects to the renewal_complete form" do
+          #   post tier_check_forms_path, tier_check_form: valid_params
+          #   expect(response).to redirect_to(new_renewal_complete_form_path(transient_registration[:reg_identifier]))
+          # end
+        end
+
+        context "when invalid params are submitted" do
+          let(:invalid_params) {
+            {
+              reg_identifier: "foo"
+            }
+          }
+
+          it "returns a 302 response" do
+            post tier_check_forms_path, tier_check_form: invalid_params
+            expect(response).to have_http_status(302)
+          end
+
+          it "does not update the transient registration" do
+            post tier_check_forms_path, tier_check_form: invalid_params
+            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        let(:valid_params) {
+          {
+            reg_identifier: transient_registration[:reg_identifier]
+          }
+        }
+
+        it "does not update the transient registration" do
+          # TODO: Add test once data is submitted through the form
+        end
+
+        it "returns a 302 response" do
+          post tier_check_forms_path, tier_check_form: valid_params
+          expect(response).to have_http_status(302)
+        end
+
+        it "redirects to the correct form for the state" do
+          post tier_check_forms_path, tier_check_form: valid_params
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+  #
+  # describe "GET back_tier_check_forms_path" do
+  #   context "when a valid user is signed in" do
+  #     let(:user) { create(:user) }
+  #     before(:each) do
+  #       sign_in(user)
+  #     end
+  #
+  #     context "when a valid transient registration exists" do
+  #       let(:transient_registration) do
+  #         create(:transient_registration,
+  #                :has_required_data,
+  #                account_email: user.email,
+  #                workflow_state: "tier_check_form")
+  #       end
+  #
+  #       context "when the back action is triggered" do
+  #         it "returns a 302 response" do
+  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to have_http_status(302)
+  #         end
+  #
+  #         it "redirects to the payment_summary form" do
+  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to redirect_to(new_payment_summary_form_path(transient_registration[:reg_identifier]))
+  #         end
+  #       end
+  #     end
+  #
+  #     context "when the transient registration is in the wrong state" do
+  #       let(:transient_registration) do
+  #         create(:transient_registration,
+  #                :has_required_data,
+  #                account_email: user.email,
+  #                workflow_state: "renewal_start_form")
+  #       end
+  #
+  #       context "when the back action is triggered" do
+  #         it "returns a 302 response" do
+  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to have_http_status(302)
+  #         end
+  #
+  #         it "redirects to the correct form for the state" do
+  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
+  #           expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
+end

--- a/spec/requests/tier_check_forms_spec.rb
+++ b/spec/requests/tier_check_forms_spec.rb
@@ -56,29 +56,32 @@ RSpec.describe "TierCheckForms", type: :request do
         context "when valid params are submitted" do
           let(:valid_params) {
             {
-              reg_identifier: transient_registration[:reg_identifier]
+              reg_identifier: transient_registration[:reg_identifier],
+              temp_tier_check: "true"
             }
           }
 
           it "updates the transient registration" do
-            # TODO: Add test once data is submitted through the form
+            post tier_check_forms_path, tier_check_form: valid_params
+            expect(transient_registration.reload[:temp_tier_check]).to eq(true)
           end
 
-          # it "returns a 302 response" do
-          #   post tier_check_forms_path, tier_check_form: valid_params
-          #   expect(response).to have_http_status(302)
-          # end
+          it "returns a 302 response" do
+            post tier_check_forms_path, tier_check_form: valid_params
+            expect(response).to have_http_status(302)
+          end
 
-          # it "redirects to the renewal_complete form" do
-          #   post tier_check_forms_path, tier_check_form: valid_params
-          #   expect(response).to redirect_to(new_renewal_complete_form_path(transient_registration[:reg_identifier]))
-          # end
+          it "redirects to the other_businesses form" do
+            post tier_check_forms_path, tier_check_form: valid_params
+            expect(response).to redirect_to(new_other_businesses_form_path(transient_registration[:reg_identifier]))
+          end
         end
 
         context "when invalid params are submitted" do
           let(:invalid_params) {
             {
-              reg_identifier: "foo"
+              reg_identifier: "foo",
+              temp_tier_check: "bar"
             }
           }
 
@@ -89,7 +92,7 @@ RSpec.describe "TierCheckForms", type: :request do
 
           it "does not update the transient registration" do
             post tier_check_forms_path, tier_check_form: invalid_params
-            expect(transient_registration.reload[:reg_identifier]).to_not eq(invalid_params[:reg_identifier])
+            expect(transient_registration.reload[:temp_tier_check]).to_not eq(invalid_params[:temp_tier_check])
           end
         end
       end
@@ -104,12 +107,14 @@ RSpec.describe "TierCheckForms", type: :request do
 
         let(:valid_params) {
           {
-            reg_identifier: transient_registration[:reg_identifier]
+            reg_identifier: transient_registration[:reg_identifier],
+            temp_tier_check: "true"
           }
         }
 
         it "does not update the transient registration" do
-          # TODO: Add test once data is submitted through the form
+          post tier_check_forms_path, tier_check_form: valid_params
+          expect(transient_registration.reload[:temp_tier_check]).to_not eq(true)
         end
 
         it "returns a 302 response" do
@@ -124,55 +129,55 @@ RSpec.describe "TierCheckForms", type: :request do
       end
     end
   end
-  #
-  # describe "GET back_tier_check_forms_path" do
-  #   context "when a valid user is signed in" do
-  #     let(:user) { create(:user) }
-  #     before(:each) do
-  #       sign_in(user)
-  #     end
-  #
-  #     context "when a valid transient registration exists" do
-  #       let(:transient_registration) do
-  #         create(:transient_registration,
-  #                :has_required_data,
-  #                account_email: user.email,
-  #                workflow_state: "tier_check_form")
-  #       end
-  #
-  #       context "when the back action is triggered" do
-  #         it "returns a 302 response" do
-  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
-  #           expect(response).to have_http_status(302)
-  #         end
-  #
-  #         it "redirects to the payment_summary form" do
-  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
-  #           expect(response).to redirect_to(new_payment_summary_form_path(transient_registration[:reg_identifier]))
-  #         end
-  #       end
-  #     end
-  #
-  #     context "when the transient registration is in the wrong state" do
-  #       let(:transient_registration) do
-  #         create(:transient_registration,
-  #                :has_required_data,
-  #                account_email: user.email,
-  #                workflow_state: "renewal_start_form")
-  #       end
-  #
-  #       context "when the back action is triggered" do
-  #         it "returns a 302 response" do
-  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
-  #           expect(response).to have_http_status(302)
-  #         end
-  #
-  #         it "redirects to the correct form for the state" do
-  #           get back_tier_check_forms_path(transient_registration[:reg_identifier])
-  #           expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
-  #         end
-  #       end
-  #     end
-  #   end
-  # end
+
+  describe "GET back_tier_check_forms_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "tier_check_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_tier_check_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the business_type form" do
+            get back_tier_check_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_business_type_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+
+      context "when the transient registration is in the wrong state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        context "when the back action is triggered" do
+          it "returns a 302 response" do
+            get back_tier_check_forms_path(transient_registration[:reg_identifier])
+            expect(response).to have_http_status(302)
+          end
+
+          it "redirects to the correct form for the state" do
+            get back_tier_check_forms_path(transient_registration[:reg_identifier])
+            expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-275

In order to reduce the number of pages users have to go through, and to give more choice for those who have good knowledge of what the difference is between lower and upper tier, we will make smart answers optional.

We have already tested this in user research without issue, and the team feels it better highlights that smart answers is an aid and not an approval or clarification of what users can do (which testing has shown some view it as).

This story covers implementing the version contained in the prototype into the production renewals service.