### PR TITLE
Correct mongoid.yml config file format

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -4,21 +4,19 @@ development:
     # Config for the registrations database
     default:
       database: <%= ENV['WCRS_REGSDB_NAME'] || 'waste-carriers' %>
-      username: <%= ENV['WCRS_REGSDB_USERNAME'] || 'mongoUser' %>
-      password: <%= ENV['WCRS_REGSDB_PASSWORD'] || 'password1234' %>
       hosts:
         - <%= ENV['WCRS_REGSDB_URL1'] || 'localhost:27017' %>
       options:
+        user: <%= ENV['WCRS_REGSDB_USERNAME'] || 'mongoUser' %>
+        password: <%= ENV['WCRS_REGSDB_PASSWORD'] || 'password1234' %>
     # Config for the users database
     users:
       database: <%= ENV['WCRS_USERSDB_NAME'] || 'waste-carriers-users' %>
-      username: <%= ENV['WCRS_USERSDB_USERNAME'] || 'mongoUser' %>
-      password: <%= ENV['WCRS_USERSDB_PASSWORD'] || 'password1234' %>
       hosts:
         - <%= ENV['WCRS_USERSDB_URL1'] || 'localhost:27017' %>
       options:
-  # Configure Mongoid specific options. (optional)
-  options:
+        user: <%= ENV['WCRS_USERSDB_USERNAME'] || 'mongoUser' %>
+        password: <%= ENV['WCRS_USERSDB_PASSWORD'] || 'password1234' %>
 production:
   clients:
     # Config for the registrations database
@@ -27,17 +25,15 @@ production:
     # Config for the users database
     users:
       uri: <%= ENV['WCRS_USERSDB_URI'] %>
-  # Configure Mongoid specific options. (optional)
-  options:
 test:
   clients:
     default:
       database: <%= ENV['WCRS_TEST_REGSDB_NAME'] || 'waste-carriers-test' %>
-      username: <%= ENV['WCRS_TEST_REGSDB_USERNAME'] || 'mongoUser' %>
-      password: <%= ENV['WCRS_TEST_REGSDB_PASSWORD'] || 'password1234' %>
       hosts:
         - <%= ENV['WCRS_TEST_REGSDB_URL1'] || 'localhost:27017' %>
       options:
+        user: <%= ENV['WCRS_TEST_REGSDB_USERNAME'] || 'mongoUser' %>
+        password: <%= ENV['WCRS_TEST_REGSDB_PASSWORD'] || 'password1234' %>
         # In the test environment we lower the retries and retry interval to
         # low amounts for fast failures.
         max_retries: 1
@@ -45,11 +41,11 @@ test:
     users:
       # Details for the user database
       database: <%= ENV['WCRS_TEST_USERSDB_NAME'] || 'waste-carriers-users-test' %>
-      username: <%= ENV['WCRS_TEST_USERSDB_USERNAME'] || 'mongoUser' %>
-      password: <%= ENV['WCRS_TEST_USERSDB_PASSWORD'] || 'password1234' %>
       hosts:
         - <%= ENV['WCRS_TEST_REGSDB_URL1'] || 'localhost:27017' %>
       options:
+        user: <%= ENV['WCRS_TEST_USERSDB_USERNAME'] || 'mongoUser' %>
+        password: <%= ENV['WCRS_TEST_USERSDB_PASSWORD'] || 'password1234' %>
         # In the test environment we lower the retries and retry interval to
         # low amounts for fast failures.
         max_retries: 1


### PR DESCRIPTION
Since we first built the renewals service we have been unable to connect to MongoDb with authentication switched on.

Having investigated the issue, it all appears to be due to changes in the format of the `mongoid.yml` file caused by Mongoid being taken in house (by MongoDB), and replacing the underlying driver Moped with the official ruby MongoDb one.

This changes resolves those formatting issues, and tests confirm that it can now connect to a MongoDb 3.6 database with authentication enabled.

WIP