### PR TITLE
Fix routing issue for overseas users and smart answers

### DIFF
--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -76,7 +76,7 @@ module CanChangeWorkflowStatus
                     if: :should_register_in_wales?
 
         transitions from: :location_form,
-                    to: :other_businesses_form,
+                    to: :tier_check_form,
                     if: :based_overseas?
 
         transitions from: :location_form,

--- a/spec/models/workflow_states/transient_registration_location_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_location_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe TransientRegistration, type: :model do
           "northern_ireland" => :register_in_northern_ireland_form,
           "scotland"         => :register_in_scotland_form,
           "wales"            => :register_in_wales_form,
-          "overseas"         => :other_businesses_form
+          "overseas"         => :tier_check_form
         }.each do |location, next_form|
           it_behaves_like "'next' transition from location_form", location, next_form
         end


### PR DESCRIPTION
Due to a routing bug, users who said they were based outside of the UK were sent straight into smart answers without getting the option to skip it. This change fixes that issue.