### PR TITLE
'Application received' page for renewals with a pending conviction check or payment

### DIFF
--- a/app/controllers/renewal_received_forms_controller.rb
+++ b/app/controllers/renewal_received_forms_controller.rb
@@ -1,0 +1,10 @@
+class RenewalReceivedFormsController < FormsController
+  def new
+    super(RenewalReceivedForm, "renewal_received_form")
+  end
+
+  # Overwrite create and go_back as you shouldn't be able to submit or go back
+  def create; end
+
+  def go_back; end
+end

--- a/app/forms/renewal_received_form.rb
+++ b/app/forms/renewal_received_form.rb
@@ -1,6 +1,9 @@
 class RenewalReceivedForm < BaseForm
+  attr_accessor :contact_email
+
   def initialize(transient_registration)
     super
+    self.contact_email = @transient_registration.contact_email
   end
 
   # Override BaseForm method as users shouldn't be able to submit this form

--- a/app/forms/renewal_received_form.rb
+++ b/app/forms/renewal_received_form.rb
@@ -1,0 +1,8 @@
+class RenewalReceivedForm < BaseForm
+  def initialize(transient_registration)
+    super
+  end
+
+  # Override BaseForm method as users shouldn't be able to submit this form
+  def submit; end
+end

--- a/app/forms/renewal_received_form.rb
+++ b/app/forms/renewal_received_form.rb
@@ -1,9 +1,11 @@
 class RenewalReceivedForm < BaseForm
-  attr_accessor :contact_email
+  attr_accessor :contact_email, :pending_convictions_check, :pending_payment
 
   def initialize(transient_registration)
     super
     self.contact_email = @transient_registration.contact_email
+    self.pending_convictions_check = @transient_registration.conviction_check_required?
+    self.pending_payment = (@transient_registration.temp_payment_method == "bank_transfer")
   end
 
   # Override BaseForm method as users shouldn't be able to submit this form

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -255,6 +255,10 @@ module CanChangeWorkflowStatus
                     to: :bank_transfer_form
 
         transitions from: :worldpay_form,
+                    to: :renewal_received_form,
+                    if: :pending_convictions_check?
+
+        transitions from: :worldpay_form,
                     to: :renewal_complete_form
 
         transitions from: :bank_transfer_form,
@@ -545,5 +549,9 @@ module CanChangeWorkflowStatus
 
   def paying_by_card?
     temp_payment_method == "card"
+  end
+
+  def pending_convictions_check?
+    conviction_check_required?
   end
 end

--- a/app/models/concerns/can_change_workflow_status.rb
+++ b/app/models/concerns/can_change_workflow_status.rb
@@ -53,6 +53,7 @@ module CanChangeWorkflowStatus
       state :bank_transfer_form
 
       state :renewal_complete_form
+      state :renewal_received_form
 
       state :cannot_renew_lower_tier_form
       state :cannot_renew_type_change_form
@@ -257,7 +258,7 @@ module CanChangeWorkflowStatus
                     to: :renewal_complete_form
 
         transitions from: :bank_transfer_form,
-                    to: :renewal_complete_form
+                    to: :renewal_received_form
       end
 
       event :back do

--- a/app/models/concerns/can_have_registration_attributes.rb
+++ b/app/models/concerns/can_have_registration_attributes.rb
@@ -62,5 +62,9 @@ module CanHaveRegistrationAttributes
       return [] unless keyPeople.present?
       keyPeople.where(person_type: "relevant")
     end
+
+    def conviction_check_required?
+      declared_convictions == true
+    end
   end
 end

--- a/app/views/renewal_received_forms/new.html.erb
+++ b/app/views/renewal_received_forms/new.html.erb
@@ -1,3 +1,4 @@
+<div class="column-two-thirds">
 <% if @renewal_received_form.errors.any? %>
 
   <h1 class="heading-large"><%= t(".error_heading") %></h1>
@@ -11,9 +12,24 @@
   <%= form_for(@renewal_received_form) do |f| %>
     <%= render("shared/errors", object: @renewal_received_form) %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+    <div class="govuk-box-highlight">
+      <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+      <p class="font-large"><%= t(".highlight_text") %><br><span class="strong"><%= @renewal_received_form.reg_identifier %></span></p>
+    </div>
+
+    <p><%= t(".paragraph_1", email: @renewal_received_form.contact_email) %></p>
+    <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
+    <p><%= t(".paragraph_2") %></p>
+    <p><%= t(".paragraph_3") %></p>
+
+    <div class="panel panel-border-wide">
+      <p><%= t(".paragraph_4") %></p>
+    </div>
+
+    <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_received_form.reg_identifier %>
   <% end %>
 
 <% end %>
+</div>

--- a/app/views/renewal_received_forms/new.html.erb
+++ b/app/views/renewal_received_forms/new.html.erb
@@ -1,0 +1,19 @@
+<% if @renewal_received_form.errors.any? %>
+
+  <h1 class="heading-large"><%= t(".error_heading") %></h1>
+
+  <% @renewal_received_form.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+
+<% else %>
+
+  <%= form_for(@renewal_received_form) do |f| %>
+    <%= render("shared/errors", object: @renewal_received_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= f.hidden_field :reg_identifier, value: @renewal_received_form.reg_identifier %>
+  <% end %>
+
+<% end %>

--- a/app/views/renewal_received_forms/new.html.erb
+++ b/app/views/renewal_received_forms/new.html.erb
@@ -18,12 +18,22 @@
     </div>
 
     <p><%= t(".paragraph_1", email: @renewal_received_form.contact_email) %></p>
-    <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
+
+    <% if @renewal_received_form.pending_payment %>
+    <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
+    <p><%= t(".awaiting_payment_paragraph_1") %></p>
+    <p><%= t(".awaiting_payment_paragraph_2") %></p>
+    <% end %>
+
+    <% if @renewal_received_form.pending_convictions_check %>
+    <h2 class="heading-medium"><%= t(".conviction_check_subheading") %></h2>
+    <p><%= t(".conviction_check_paragraph_1") %></p>
+    <% end %>
+
     <p><%= t(".paragraph_2") %></p>
-    <p><%= t(".paragraph_3") %></p>
 
     <div class="panel panel-border-wide">
-      <p><%= t(".paragraph_4") %></p>
+      <p><%= t(".paragraph_3") %></p>
     </div>
 
     <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -4,11 +4,14 @@ en:
       title: Renewal application received
       heading: Application received
       highlight_text: "Your registration number is still"
-      paragraph_1: "Details of how to pay have been emailed to %{email}."
-      subheading_1: "Next step: pay the renewal charge"
-      paragraph_2: We've sent an email telling you how to pay the charge.
-      paragraph_3: Please allow 5 working days for your payment to reach us.
-      paragraph_4: Call our helpline on 03708 506 506 if you have any questions about your renewal.
+      paragraph_1: "We have sent a confirmation email to to %{email}."
+      awaiting_payment_subheading: "Next step: pay the renewal charge"
+      awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
+      awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.
+      conviction_check_subheading: What happens next
+      conviction_check_paragraph_1: We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.
+      paragraph_2: Your registration will not be renewed until we have received your payment and confirmed your registration.
+      paragraph_3: Call our helpline on 03708 506 506 if you have any questions about your renewal.
       survey_link_text: What do you think of this service?
       survey_link_hint: (takes 30 seconds)
       error_heading: Something is wrong

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -3,7 +3,7 @@ en:
     new:
       title: Renewal application received
       heading: Application received
-      highlight_text: "Please use this reference number if you contact us:"
+      highlight_text: "Your registration number is still"
       paragraph_1: "Details of how to pay have been emailed to %{email}."
       subheading_1: "Next step: pay the renewal charge"
       paragraph_2: We've sent an email telling you how to pay the charge.

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -4,7 +4,7 @@ en:
       title: Renewal application received
       heading: Application received
       highlight_text: "Your registration number is still"
-      paragraph_1: "We have sent a confirmation email to to %{email}."
+      paragraph_1: "We have sent a confirmation email to %{email}."
       awaiting_payment_subheading: "Next step: pay the renewal charge"
       awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
       awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -1,10 +1,18 @@
 en:
   renewal_received_forms:
     new:
-      title: Renewal received
-      heading: Renewal received
+      title: Renewal application received
+      heading: Application received
+      highlight_text: "Please use this reference number if you contact us:"
+      paragraph_1: "Details of how to pay have been emailed to %{email}."
+      subheading_1: "Next step: pay the renewal charge"
+      paragraph_2: We've sent an email telling you how to pay the charge.
+      paragraph_3: Please allow 5 working days for your payment to reach us.
+      paragraph_4: Call our helpline on 03708 506 506 if you have any questions about your renewal.
+      survey_link_text: What do you think of this service?
+      survey_link_hint: (takes 30 seconds)
       error_heading: Something is wrong
-      next_button: Continue
+      next_button: Finished
   activemodel:
     errors:
       models:

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -1,0 +1,16 @@
+en:
+  renewal_received_forms:
+    new:
+      title: Renewal received
+      heading: Renewal received
+      error_heading: Something is wrong
+      next_button: Continue
+  activemodel:
+    errors:
+      models:
+        renewal_received_form:
+          attributes:
+            reg_identifier:
+              invalid_format: "The registration ID is not in a valid format"
+              no_registration: "There is no registration matching this ID"
+              renewal_in_progress: "This renewal is already in progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,6 +373,16 @@ Rails.application.routes.draw do
               on: :collection
             end
 
+  resources :renewal_received_forms,
+            only: [:new, :create],
+            path: "renewal-received",
+            path_names: { new: "/:reg_identifier" } do
+              get "back/:reg_identifier",
+              to: "renewal_received_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :cannot_renew_lower_tier_forms,
             only: [:new, :create],
             path: "cannot-renew-lower-tier",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -366,22 +366,12 @@ Rails.application.routes.draw do
   resources :renewal_complete_forms,
             only: [:new, :create],
             path: "renewal-complete",
-            path_names: { new: "/:reg_identifier" } do
-              get "back/:reg_identifier",
-              to: "renewal_complete_forms#go_back",
-              as: "back",
-              on: :collection
-            end
+            path_names: { new: "/:reg_identifier" }
 
   resources :renewal_received_forms,
             only: [:new, :create],
             path: "renewal-received",
-            path_names: { new: "/:reg_identifier" } do
-              get "back/:reg_identifier",
-              to: "renewal_received_forms#go_back",
-              as: "back",
-              on: :collection
-            end
+            path_names: { new: "/:reg_identifier" }
 
   resources :cannot_renew_lower_tier_forms,
             only: [:new, :create],

--- a/spec/factories/forms/renewal_received_form.rb
+++ b/spec/factories/forms/renewal_received_form.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :renewal_received_form do
+    trait :has_required_data do
+      initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "renewal_received_form")) }
+    end
+  end
+end

--- a/spec/forms/renewal_received_forms_spec.rb
+++ b/spec/forms/renewal_received_forms_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe RenewalReceivedForm, type: :model do
+  describe "#reg_identifier" do
+    context "when a valid transient registration exists" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "renewal_received_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:renewal_received_form) { RenewalReceivedForm.new(transient_registration) }
+
+      context "when a reg_identifier meets the requirements" do
+        before(:each) do
+          renewal_received_form.reg_identifier = transient_registration.reg_identifier
+        end
+
+        it "is valid" do
+          expect(renewal_received_form).to be_valid
+        end
+      end
+
+      context "when a reg_identifier is blank" do
+        before(:each) do
+          renewal_received_form.reg_identifier = ""
+        end
+
+        it "is not valid" do
+          expect(renewal_received_form).to_not be_valid
+        end
+      end
+    end
+  end
+
+  describe "#transient_registration" do
+    context "when the transient registration is invalid" do
+      let(:transient_registration) do
+        build(:transient_registration,
+              workflow_state: "renewal_received_form")
+      end
+      # Don't use FactoryBot for this as we need to make sure it initializes with a specific object
+      let(:renewal_received_form) { RenewalReceivedForm.new(transient_registration) }
+
+      before(:each) do
+        # Make reg_identifier valid for the form, but not the transient object
+        renewal_received_form.reg_identifier = transient_registration.reg_identifier
+        transient_registration.reg_identifier = "foo"
+      end
+
+      it "is not valid" do
+        expect(renewal_received_form).to_not be_valid
+      end
+
+      it "inherits the errors from the transient_registration" do
+        renewal_received_form.valid?
+        expect(renewal_received_form.errors[:base]).to include(I18n.t("mongoid.errors.models.transient_registration.attributes.reg_identifier.invalid_format"))
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_bank_transfer_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_bank_transfer_form_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:bank_transfer_form).to(:payment_summary_form).on_event(:back)
       end
 
-      it "changes to :renewal_complete_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:bank_transfer_form).to(:renewal_complete_form).on_event(:next)
+      it "changes to :renewal_received_form after the 'next' event" do
+        expect(transient_registration).to transition_from(:bank_transfer_form).to(:renewal_received_form).on_event(:next)
       end
     end
   end

--- a/spec/models/workflow_states/transient_registration_renewal_received_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_renewal_received_form_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe TransientRegistration, type: :model do
+  describe "#workflow_state" do
+    context "when a TransientRegistration's state is :renewal_received_form" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               workflow_state: "renewal_received_form")
+      end
+
+      it "does not respond to the 'back' event" do
+        expect(transient_registration).to_not allow_event :back
+      end
+
+      it "does not respond to the 'next' event" do
+        expect(transient_registration).to_not allow_event :next
+      end
+    end
+  end
+end

--- a/spec/models/workflow_states/transient_registration_worldpay_form_spec.rb
+++ b/spec/models/workflow_states/transient_registration_worldpay_form_spec.rb
@@ -13,8 +13,20 @@ RSpec.describe TransientRegistration, type: :model do
         expect(transient_registration).to transition_from(:worldpay_form).to(:payment_summary_form).on_event(:back)
       end
 
-      it "changes to :renewal_complete_form after the 'next' event" do
-        expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_complete_form).on_event(:next)
+      context "when there are no convictions" do
+        before(:each) { transient_registration.declared_convictions = false }
+
+        it "changes to :renewal_complete_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_complete_form).on_event(:next)
+        end
+      end
+
+      context "when there are convictions" do
+        before(:each) { transient_registration.declared_convictions = true }
+
+        it "changes to :renewal_received_form after the 'next' event" do
+          expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_received_form).on_event(:next)
+        end
       end
     end
   end

--- a/spec/requests/bank_transfer_forms_spec.rb
+++ b/spec/requests/bank_transfer_forms_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe "BankTransferForms", type: :request do
             expect(response).to have_http_status(302)
           end
 
-          it "redirects to the renewal_complete form" do
+          it "redirects to the renewal_received form" do
             post bank_transfer_forms_path, bank_transfer_form: valid_params
-            expect(response).to redirect_to(new_renewal_complete_form_path(transient_registration[:reg_identifier]))
+            expect(response).to redirect_to(new_renewal_received_form_path(transient_registration[:reg_identifier]))
           end
         end
 

--- a/spec/requests/renewal_received_forms_spec.rb
+++ b/spec/requests/renewal_received_forms_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "RenewalReceivedForms", type: :request do
+  describe "GET new_renewal_received_path" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when a valid transient registration exists" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_received_form")
+        end
+
+        it "returns a success response" do
+          get new_renewal_received_form_path(transient_registration[:reg_identifier])
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "when a transient registration is in a different state" do
+        let(:transient_registration) do
+          create(:transient_registration,
+                 :has_required_data,
+                 account_email: user.email,
+                 workflow_state: "renewal_start_form")
+        end
+
+        it "redirects to the form for the current state" do
+          get new_renewal_received_form_path(transient_registration[:reg_identifier])
+          expect(response).to redirect_to(new_renewal_start_form_path(transient_registration[:reg_identifier]))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-120

If a user submits their renewal and pays by bank transfer, or submits and has a conviction check pending, they should see a "Renewal received" page.

This story covers setting up that page and adding routing to it depending on the payment type, or if the user has declared convictions. It does not cover other sorts of conviction checks yet.