### PR TITLE
 Renewal Complete page for renewals with no pending checks or payment

### DIFF
--- a/app/forms/renewal_complete_form.rb
+++ b/app/forms/renewal_complete_form.rb
@@ -1,11 +1,12 @@
 class RenewalCompleteForm < BaseForm
-  attr_accessor :contact_email, :registration_type, :certificate_link
+  attr_accessor :certificate_link, :contact_email, :projected_renewal_end_date, :registration_type
 
   def initialize(transient_registration)
     super
-    self.contact_email = @transient_registration.contact_email
-    self.registration_type = @transient_registration.registration_type
     self.certificate_link = build_certificate_link
+    self.contact_email = @transient_registration.contact_email
+    self.projected_renewal_end_date = @transient_registration.projected_renewal_end_date
+    self.registration_type = @transient_registration.registration_type
   end
 
   # Override BaseForm method as users shouldn't be able to submit this form

--- a/app/forms/renewal_complete_form.rb
+++ b/app/forms/renewal_complete_form.rb
@@ -1,8 +1,23 @@
 class RenewalCompleteForm < BaseForm
+  attr_accessor :contact_email, :registration_type, :certificate_link
+
   def initialize(transient_registration)
     super
+    self.contact_email = @transient_registration.contact_email
+    self.registration_type = @transient_registration.registration_type
+    self.certificate_link = build_certificate_link
   end
 
   # Override BaseForm method as users shouldn't be able to submit this form
   def submit; end
+
+  private
+
+  def build_certificate_link
+    registration = Registration.where(reg_identifier: reg_identifier).first
+    return unless registration.present?
+    id = registration.id
+    root = Rails.configuration.wcrs_frontend_url
+    "#{root}/registrations/#{id}/view?locale=en"
+  end
 end

--- a/app/views/renewal_complete_forms/new.html.erb
+++ b/app/views/renewal_complete_forms/new.html.erb
@@ -1,3 +1,4 @@
+<div class="column-two-thirds">
 <% if @renewal_complete_form.errors.any? %>
 
   <h1 class="heading-large"><%= t(".error_heading") %></h1>
@@ -11,9 +12,47 @@
   <%= form_for(@renewal_complete_form) do |f| %>
     <%= render("shared/errors", object: @renewal_complete_form) %>
 
-    <h1 class="heading-large"><%= t(".heading") %></h1>
+    <div class="govuk-box-highlight">
+      <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+      <p class="font-large"><%= t(".highlight_text") %><br><span class="strong"><%= @renewal_complete_form.reg_identifier %></span></p>
+    </div>
+
+    <p><%= t(".paragraph_1", email: @renewal_complete_form.contact_email) %></p>
+
+    <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
+    <p><%= link_to(t(".paragraph_2"), @renewal_complete_form.certificate_link,
+    target: "_blank") %></p>
+
+    <h2 class="heading-medium"><%= t(".subheading_2") %></h2>
+    <p><%= t(".paragraph_3.#{@renewal_complete_form.registration_type}") %></p>
+    <p><%= t(".paragraph_4.#{@renewal_complete_form.registration_type}") %></p>
+
+    <ul class="list list-bullet">
+      <% t(".list_1").each do |list_item| %>
+      <li><%= list_item %></li>
+      <% end %>
+    </ul>
+
+    <p><%= t(".paragraph_5") %></p>
+
+    <ul class="list list-bullet">
+      <% t(".list_2").each do |list_item| %>
+      <li><%= list_item %></li>
+      <% end %>
+    </ul>
+
+    <h2 class="heading-medium"><%= t(".subheading_3") %></h2>
+    <p><%= t(".paragraph_6") %></p>
+    <p><%= t(".paragraph_7") %></p>
+
+    <div class="panel panel-border-wide">
+      <p><%= t(".paragraph_8") %></p>
+    </div>
+
+    <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_complete_form.reg_identifier %>
   <% end %>
 
 <% end %>
+</div>

--- a/app/views/renewal_complete_forms/new.html.erb
+++ b/app/views/renewal_complete_forms/new.html.erb
@@ -17,10 +17,11 @@
       <p class="font-large"><%= t(".highlight_text") %><br><span class="strong"><%= @renewal_complete_form.reg_identifier %></span></p>
     </div>
 
-    <p><%= t(".paragraph_1", email: @renewal_complete_form.contact_email) %></p>
+    <p><%= t(".paragraph_1", date: @renewal_complete_form.projected_renewal_end_date) %></p>
+    <p><%= t(".paragraph_2", email: @renewal_complete_form.contact_email) %></p>
 
     <h2 class="heading-medium"><%= t(".subheading_1") %></h2>
-    <p><%= link_to(t(".paragraph_2"), @renewal_complete_form.certificate_link,
+    <p><%= link_to(t(".certificate_link_text"), @renewal_complete_form.certificate_link,
     target: "_blank") %></p>
 
     <h2 class="heading-medium"><%= t(".subheading_2") %></h2>

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -3,8 +3,36 @@ en:
     new:
       title: Renewal complete
       heading: Renewal complete
+      highlight_text: "Your registration number is still"
+      paragraph_1: "We have sent a confirmation email to %{email}."
+      subheading_1: Your registration certificate
+      paragraph_2: Download and print your certificate
+      subheading_2: What happens next
+      paragraph_3:
+        carrier_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste carrier and dealer.
+        broker_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste broker and dealer.
+        carrier_broker_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste carrier, broker and dealer.
+      paragraph_4:
+        carrier_dealer: "Being an upper tier waste carrier and dealer means that:"
+        broker_dealer: "Being an upper tier waste broker and dealer means that:"
+        carrier_broker_dealer: "Being an upper tier waste carrier, broker and dealer means that:"
+      list_1:
+        - You need to renew your registrations every 3 years (we’ll send you a reminder)
+        - You’ll need to pay a registration charge each time you renew
+      paragraph_5: "There are some simple rules you must follow:"
+      list_2:
+        - If you give your waste to another person or business, you must check they are properly authorised to accept it, e.g. as a permitted site or a registered waste carrier
+        - Make sure the correct documentation is completed for each transfer of waste and that it correctly describes the waste
+        - Make sure any waste is safely handled and stored
+        - Minimise the environmental impact of waste by prioritising waste prevention, reuse, recycling and recovery over disposal
+      subheading_3: Updating your details
+      paragraph_6: If any of your details change you must update your registration within 28 days.
+      paragraph_7: You can sign in to view your certificate or make a change to your registration.
+      paragraph_8: Call our helpline on 03708 506 506 if you have any questions about your renewal.
+      survey_link_text: What do you think of this service?
+      survey_link_hint: (takes 30 seconds)
       error_heading: Something is wrong
-      next_button: Continue
+      next_button: Finished
   activemodel:
     errors:
       models:

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -4,9 +4,10 @@ en:
       title: Renewal complete
       heading: Renewal complete
       highlight_text: "Your registration number is still"
-      paragraph_1: "We have sent a confirmation email to %{email}."
+      paragraph_1: "Your registration has been renewed until %{date}."
+      paragraph_2: "We have sent a confirmation email to %{email}."
       subheading_1: Your registration certificate
-      paragraph_2: Download and print your certificate
+      certificate_link_text: Download and print your certificate
       subheading_2: What happens next
       paragraph_3:
         carrier_dealer: Based on what you told us about your organisation and what it does, we have renewed your registration as an upper tier waste carrier and dealer.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-119

If a user submits their renewal, pays by card, and doesn't require any further checks, they should see a "Renewal complete" page.

This does not cover the actual renewing of the registration, which is a separate story (WC-303).