### PR TITLE
Only display user's registrations in temp listing page

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,7 +4,7 @@ class RegistrationsController < ApplicationController
   # GET /registrations
   # GET /registrations.json
   def index
-    # Only loading 50 for now
-    @registrations = Registration.all.limit(50)
+    # Only load the first 50 accessible by the current user
+    @registrations = Registration.accessible_by(current_ability).limit(50)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,6 +2,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    can :read, Registration, account_email: user.email
     can :manage, TransientRegistration, account_email: user.email
   end
 end

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -1,15 +1,16 @@
 <p id="notice"><%= notice %></p>
 
-<h1 class="heading-large">Listing Registrations</h1>
+<h1 class="heading-large">Your registrations</h1>
 
-<p>This page is for testing purposes only. Click the reg_identifier to enter the renewals process.</p>
+<p>This is a temporary page for testing purposes only.</p>
 
 <table>
   <thead>
     <tr>
-      <th scope="col">Reg identifier</th>
+      <th scope="col">Registration</th>
       <th scope="col">Company name</th>
       <th scope="col">Status</th>
+      <th scope="col">Actions</th>
     </tr>
   </thead>
 
@@ -19,6 +20,7 @@
         <td scope="row"><%= link_to registration.regIdentifier, new_renewal_start_form_path(registration[:reg_identifier]) %></td>
         <td><%= registration.companyName %></td>
         <td><%= registration.metaData.status %></td>
+        <td><%= link_to "Renew", new_renewal_start_form_path(registration[:reg_identifier]), class: 'button' %></td>
       </tr>
     <% end %>
   </tbody>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,16 +32,22 @@ def parse_dates(seed, date)
   end
 end
 
-# Only seed if not running in production or we specifically require it, eg. for Heroku
-if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
-  User.find_or_create_by(
-    email: "user@waste-exemplar.gov.uk",
-    password: ENV["WCR_TEST_USER_PASSWORD"] || "Secret123",
-    confirmed_at: DateTime.new(2015, 1, 1)
-  )
+def seed_users
+  seeds = JSON.parse(File.read("#{Rails.root}/db/seeds/users.json"))
+  users = seeds["users"]
 
+  users.each do |user|
+    User.find_or_create_by(
+      email: user["email"],
+      password: ENV["WCR_TEST_USER_PASSWORD"] || "Secret123",
+      confirmed_at: DateTime.new(2015, 1, 1)
+    )
+  end
+end
+
+def seed_registrations
   seeds = []
-  Dir.glob("#{Rails.root}/db/seeds/*.json").each do |file|
+  Dir.glob("#{Rails.root}/db/seeds/CBD*.json").each do |file|
     seeds << JSON.parse(File.read(file))
   end
 
@@ -57,4 +63,10 @@ if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
   sorted_seeds.each do |seed|
     Registration.find_or_create_by(seed.except("_id"))
   end
+end
+
+# Only seed if not running in production or we specifically require it, eg. for Heroku
+if !Rails.env.production? || ENV["WCR_ALLOW_SEED"]
+  seed_users
+  seed_registrations
 end

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -1,0 +1,10 @@
+{
+  "users": [
+    {
+      "email": "user@waste-exemplar.gov.uk"
+    },
+    {
+      "email": "another-user@waste-exemplar.gov.uk"
+    }
+  ]
+}

--- a/spec/controllers/registrations_spec.rb
+++ b/spec/controllers/registrations_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe RegistrationsController, type: :controller do
+  describe "index" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      describe "@registrations" do
+        it "contains registrations belonging to the user" do
+          registration = create(:registration, :has_required_data, account_email: user.email)
+          get :index
+          expect(assigns(:registrations)).to include(registration)
+        end
+
+        it "does not contain registrations belonging to other users" do
+          registration = create(:registration, :has_required_data, account_email: "not-this-user@example.com")
+          get :index
+          expect(assigns(:registrations)).to_not include(registration)
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.include RequestSpecHelper, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-278

For testing purposes only, we have a page which lists all registrations in the database and lets users start the renewal process. We should limit this to just showing registrations belonging to the logged-in user account.