### PR TITLE
Rename session cookie to match frontend service

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_waste-carriers-renewals_session'
+Rails.application.config.session_store :cookie_store, key: '_registrations_session'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-306

In order to allow users to move between the existing frontend service and this one, without needing to sign in again we need to ensure they have access to the same session cookie.

This change renames the session cookie to match the existing service, which also brings it inline with what we have on our cookies page.

Because of the need to handle existing users, and the renewals service has not yet been launched, we chose to rename the session here rather than the old service.