### PR TITLE
Add link to dashboard from renewal end pages

### DIFF
--- a/app/forms/renewal_complete_form.rb
+++ b/app/forms/renewal_complete_form.rb
@@ -12,6 +12,13 @@ class RenewalCompleteForm < BaseForm
   # Override BaseForm method as users shouldn't be able to submit this form
   def submit; end
 
+  def dashboard_link(current_user)
+    return unless current_user.present?
+    id = current_user.id
+    root = Rails.configuration.wcrs_frontend_url
+    "#{root}/user/#{id}/registrations?locale=en"
+  end
+
   private
 
   def build_certificate_link

--- a/app/forms/renewal_complete_form.rb
+++ b/app/forms/renewal_complete_form.rb
@@ -16,7 +16,7 @@ class RenewalCompleteForm < BaseForm
     return unless current_user.present?
     id = current_user.id
     root = Rails.configuration.wcrs_frontend_url
-    "#{root}/user/#{id}/registrations?locale=en"
+    "#{root}/user/#{id}/registrations"
   end
 
   private
@@ -26,6 +26,6 @@ class RenewalCompleteForm < BaseForm
     return unless registration.present?
     id = registration.id
     root = Rails.configuration.wcrs_frontend_url
-    "#{root}/registrations/#{id}/view?locale=en"
+    "#{root}/registrations/#{id}/view"
   end
 end

--- a/app/forms/renewal_received_form.rb
+++ b/app/forms/renewal_received_form.rb
@@ -10,4 +10,11 @@ class RenewalReceivedForm < BaseForm
 
   # Override BaseForm method as users shouldn't be able to submit this form
   def submit; end
+
+  def dashboard_link(current_user)
+    return unless current_user.present?
+    id = current_user.id
+    root = Rails.configuration.wcrs_frontend_url
+    "#{root}/user/#{id}/registrations?locale=en"
+  end
 end

--- a/app/forms/renewal_received_form.rb
+++ b/app/forms/renewal_received_form.rb
@@ -15,6 +15,6 @@ class RenewalReceivedForm < BaseForm
     return unless current_user.present?
     id = current_user.id
     root = Rails.configuration.wcrs_frontend_url
-    "#{root}/user/#{id}/registrations?locale=en"
+    "#{root}/user/#{id}/registrations"
   end
 end

--- a/app/views/renewal_complete_forms/new.html.erb
+++ b/app/views/renewal_complete_forms/new.html.erb
@@ -53,6 +53,7 @@
     <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_complete_form.reg_identifier %>
+    <%= link_to t(".next_button"), @renewal_complete_form.dashboard_link(current_user), class: 'button' %>
   <% end %>
 
 <% end %>

--- a/app/views/renewal_received_forms/new.html.erb
+++ b/app/views/renewal_received_forms/new.html.erb
@@ -39,6 +39,7 @@
     <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_received_form.reg_identifier %>
+    <%= link_to t(".next_button"), @renewal_received_form.dashboard_link(current_user), class: 'button' %>
   <% end %>
 
 <% end %>


### PR DESCRIPTION
The pages for completed renewals and received renewal applications should link back to the dashboard with a 'Finished' button.