### PR TITLE
 Make sure can_renew checks are actually applied

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -37,7 +37,8 @@ class FormsController < ApplicationController
 
     return false unless transient_registration_is_valid? &&
                         user_has_permission? &&
-                        state_is_correct?
+                        state_is_correct? &&
+                        can_be_renewed?
 
     # Set an instance variable for the form (eg. @business_type_form) using the provided class (eg. BusinessTypeForm)
     instance_variable_set("@#{form}", form_class.new(@transient_registration))
@@ -86,5 +87,12 @@ class FormsController < ApplicationController
 
   def form_matches_state?
     controller_name == "#{@transient_registration.workflow_state}s"
+  end
+
+  def can_be_renewed?
+    registration = Registration.where(reg_identifier: @transient_registration.reg_identifier).first
+    return true if registration.metaData.may_renew?
+    redirect_to page_path("errors/unrenewable")
+    false
   end
 end

--- a/app/models/concerns/can_change_registration_status.rb
+++ b/app/models/concerns/can_change_registration_status.rb
@@ -9,41 +9,40 @@ module CanChangeRegistrationStatus
     field :status, type: String
 
     aasm column: :status do
-      # States
-      state :pending, initial: true
-      state :active
-      state :revoked
-      state :refused
-      state :expired
+      # States must be capitalised to match what waste-carriers-service adds to the database
+      state :PENDING, initial: true
+      state :ACTIVE
+      state :REVOKED
+      state :REFUSED
+      state :EXPIRED
 
       # Transitions
       after_all_transitions :log_status_change
 
-      # TODO: Confirm what this workflow actually is
       event :activate do
-        transitions from: :pending,
-                    to: :active,
+        transitions from: :PENDING,
+                    to: :ACTIVE,
                     after: :set_expiry_date
       end
 
       event :revoke do
-        transitions from: :active,
-                    to: :revoked
+        transitions from: :ACTIVE,
+                    to: :REVOKED
       end
 
       event :refuse do
-        transitions from: :pending,
-                    to: :refused
+        transitions from: :PENDING,
+                    to: :REFUSED
       end
 
       event :expire do
-        transitions from: :active,
-                    to: :expired
+        transitions from: :ACTIVE,
+                    to: :EXPIRED
       end
 
       event :renew do
-        transitions from: :active,
-                    to: :active,
+        transitions from: :ACTIVE,
+                    to: :ACTIVE,
                     guard: %i[close_to_expiry_date?
                               should_not_be_expired?],
                     after: :extend_expiry_date

--- a/app/views/pages/errors/unrenewable.html.erb
+++ b/app/views/pages/errors/unrenewable.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, I18n.t(".unrenewable_title")  %>
+
+<div class="text">
+  <h1 class="heading-large"><%= I18n.t(".unrenewable_heading") %></h1>
+  <p><%= I18n.t(".unrenewable_text", months: Rails.configuration.renewal_window) %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,3 +56,7 @@ en:
   no_permissions_title: Cannot access registration
   no_permissions_heading: You don't have permission to access that registration
   no_permissions_text: Maybe you should try searching again.
+
+  unrenewable_title: Cannot renew registration
+  unrenewable_heading: This registration cannot be renewed
+  unrenewable_text: You can only renew registrations which are currently active and are due to expire within the next %{months} months.

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -16,10 +16,12 @@ FactoryBot.define do
     end
 
     trait :expires_soon do
+      metaData { build(:metaData, :has_required_data, status: :active) }
       expires_on 2.months.from_now
     end
 
     trait :expires_later do
+      metaData { build(:metaData, :has_required_data, status: :active) }
       expires_on 2.years.from_now
     end
 

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -16,33 +16,33 @@ FactoryBot.define do
     end
 
     trait :expires_soon do
-      metaData { build(:metaData, :has_required_data, status: :active) }
+      metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
       expires_on 2.months.from_now
     end
 
     trait :expires_later do
-      metaData { build(:metaData, :has_required_data, status: :active) }
+      metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
       expires_on 2.years.from_now
     end
 
     trait :is_pending do
-      metaData { build(:metaData, :has_required_data, status: :pending) }
+      metaData { build(:metaData, :has_required_data, status: :PENDING) }
     end
 
     trait :is_active do
-      metaData { build(:metaData, :has_required_data, status: :active) }
+      metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
     end
 
     trait :is_revoked do
-      metaData { build(:metaData, :has_required_data, status: :revoked) }
+      metaData { build(:metaData, :has_required_data, status: :REVOKED) }
     end
 
     trait :is_refused do
-      metaData { build(:metaData, :has_required_data, status: :refused) }
+      metaData { build(:metaData, :has_required_data, status: :REFUSED) }
     end
 
     trait :is_expired do
-      metaData { build(:metaData, :has_required_data, status: :expired) }
+      metaData { build(:metaData, :has_required_data, status: :EXPIRED) }
     end
   end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe Registration, type: :model do
         let(:registration) { build(:registration, :has_required_data, metaData: meta_data) }
 
         it "has 'pending' status" do
-          expect(registration.metaData).to have_state(:pending)
+          expect(registration.metaData).to have_state(:PENDING)
         end
 
         it "is not valid without a status" do
@@ -360,17 +360,17 @@ RSpec.describe Registration, type: :model do
         let(:registration) { build(:registration, :is_pending) }
 
         it "has 'pending' status" do
-          expect(registration.metaData).to have_state(:pending)
+          expect(registration.metaData).to have_state(:PENDING)
         end
 
         it "can be activated" do
           expect(registration.metaData).to allow_event :activate
-          expect(registration.metaData).to transition_from(:pending).to(:active).on_event(:activate)
+          expect(registration.metaData).to transition_from(:PENDING).to(:ACTIVE).on_event(:activate)
         end
 
         it "can be refused" do
           expect(registration.metaData).to allow_event :refuse
-          expect(registration.metaData).to transition_from(:pending).to(:refused).on_event(:refuse)
+          expect(registration.metaData).to transition_from(:PENDING).to(:REFUSED).on_event(:refuse)
         end
 
         it "cannot be revoked" do
@@ -386,9 +386,9 @@ RSpec.describe Registration, type: :model do
         end
 
         it "cannot transition to 'revoked', 'renewed' or 'expired'" do
-          expect(registration.metaData).to_not allow_transition_to(:revoked)
+          expect(registration.metaData).to_not allow_transition_to(:REVOKED)
           expect(registration.metaData).to_not allow_transition_to(:renewed)
-          expect(registration.metaData).to_not allow_transition_to(:expired)
+          expect(registration.metaData).to_not allow_transition_to(:EXPIRED)
         end
       end
 
@@ -407,17 +407,17 @@ RSpec.describe Registration, type: :model do
         let(:registration) { build(:registration, :expires_later, :is_active) }
 
         it "has 'active' status" do
-          expect(registration.metaData).to have_state(:active)
+          expect(registration.metaData).to have_state(:ACTIVE)
         end
 
         it "can be revoked" do
           expect(registration.metaData).to allow_event :revoke
-          expect(registration.metaData).to transition_from(:active).to(:revoked).on_event(:revoke)
+          expect(registration.metaData).to transition_from(:ACTIVE).to(:REVOKED).on_event(:revoke)
         end
 
         it "can expire" do
           expect(registration.metaData).to allow_event :expire
-          expect(registration.metaData).to transition_from(:active).to(:expired).on_event(:expire)
+          expect(registration.metaData).to transition_from(:ACTIVE).to(:EXPIRED).on_event(:expire)
         end
 
         it "cannot be refused" do
@@ -429,8 +429,8 @@ RSpec.describe Registration, type: :model do
         end
 
         it "cannot transition to 'pending' or 'refused'" do
-          expect(registration.metaData).to_not allow_transition_to(:pending)
-          expect(registration.metaData).to_not allow_transition_to(:refused)
+          expect(registration.metaData).to_not allow_transition_to(:PENDING)
+          expect(registration.metaData).to_not allow_transition_to(:REFUSED)
         end
 
         context "when the registration expiration date is more than 6 months away" do
@@ -446,7 +446,7 @@ RSpec.describe Registration, type: :model do
 
           it "can be renewed" do
             expect(registration.metaData).to allow_event :renew
-            expect(registration.metaData).to transition_from(:active).to(:active).on_event(:renew)
+            expect(registration.metaData).to transition_from(:ACTIVE).to(:ACTIVE).on_event(:renew)
           end
         end
 
@@ -547,14 +547,14 @@ RSpec.describe Registration, type: :model do
         let(:registration) { build(:registration, :is_refused) }
 
         it "has 'refused' status" do
-          expect(registration.metaData).to have_state(:refused)
+          expect(registration.metaData).to have_state(:REFUSED)
         end
 
         it "cannot transition to other states" do
-          expect(registration.metaData).to_not allow_transition_to(:pending)
-          expect(registration.metaData).to_not allow_transition_to(:active)
-          expect(registration.metaData).to_not allow_transition_to(:refused)
-          expect(registration.metaData).to_not allow_transition_to(:revoked)
+          expect(registration.metaData).to_not allow_transition_to(:PENDING)
+          expect(registration.metaData).to_not allow_transition_to(:ACTIVE)
+          expect(registration.metaData).to_not allow_transition_to(:REFUSED)
+          expect(registration.metaData).to_not allow_transition_to(:REVOKED)
         end
       end
 
@@ -562,14 +562,14 @@ RSpec.describe Registration, type: :model do
         let(:registration) { build(:registration, :is_revoked) }
 
         it "has 'revoked' status" do
-          expect(registration.metaData).to have_state(:revoked)
+          expect(registration.metaData).to have_state(:REVOKED)
         end
 
         it "cannot transition to other states" do
-          expect(registration.metaData).to_not allow_transition_to(:pending)
-          expect(registration.metaData).to_not allow_transition_to(:active)
-          expect(registration.metaData).to_not allow_transition_to(:refused)
-          expect(registration.metaData).to_not allow_transition_to(:revoked)
+          expect(registration.metaData).to_not allow_transition_to(:PENDING)
+          expect(registration.metaData).to_not allow_transition_to(:ACTIVE)
+          expect(registration.metaData).to_not allow_transition_to(:REFUSED)
+          expect(registration.metaData).to_not allow_transition_to(:REVOKED)
         end
       end
 
@@ -577,7 +577,7 @@ RSpec.describe Registration, type: :model do
         let(:registration) { build(:registration, :is_expired, expires_on: 1.month.ago) }
 
         it "has 'expired' status" do
-          expect(registration.metaData).to have_state(:expired)
+          expect(registration.metaData).to have_state(:EXPIRED)
         end
 
         it "cannot be renewed" do
@@ -597,9 +597,9 @@ RSpec.describe Registration, type: :model do
         end
 
         it "cannot transition to 'pending', 'refused', 'revoked'" do
-          expect(registration.metaData).to_not allow_transition_to(:pending)
-          expect(registration.metaData).to_not allow_transition_to(:refused)
-          expect(registration.metaData).to_not allow_transition_to(:revoked)
+          expect(registration.metaData).to_not allow_transition_to(:PENDING)
+          expect(registration.metaData).to_not allow_transition_to(:REFUSED)
+          expect(registration.metaData).to_not allow_transition_to(:REVOKED)
         end
       end
     end

--- a/spec/requests/renewal_start_forms_spec.rb
+++ b/spec/requests/renewal_start_forms_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe "RenewalStartForms", type: :request do
               get new_renewal_start_form_path(registration[:reg_identifier])
               expect(response).to have_http_status(200)
             end
+
+            context "when the registration cannot be renewed" do
+              before(:each) { registration.metaData.expire! }
+
+              it "redirects to the unrenewable error page" do
+                get new_renewal_start_form_path(registration[:reg_identifier])
+                expect(response).to redirect_to(page_path("errors/unrenewable"))
+              end
+            end
           end
 
           context "when a renewal is in progress" do
@@ -163,6 +172,7 @@ RSpec.describe "RenewalStartForms", type: :request do
             let(:registration) do
               create(:registration,
                      :has_required_data,
+                     :expires_soon,
                      account_email: user.email,
                      company_name: "Correct Name")
             end
@@ -194,6 +204,15 @@ RSpec.describe "RenewalStartForms", type: :request do
               it "redirects to the business type form" do
                 post renewal_start_forms_path, renewal_start_form: valid_params
                 expect(response).to redirect_to(new_location_form_path(valid_params[:reg_identifier]))
+              end
+
+              context "when the registration cannot be renewed" do
+                before(:each) { registration.metaData.expire! }
+
+                it "redirects to the unrenewable error page" do
+                  get new_renewal_start_form_path(registration[:reg_identifier])
+                  expect(response).to redirect_to(page_path("errors/unrenewable"))
+                end
               end
             end
 


### PR DESCRIPTION
Our state machine for registrations has several checks to see if a registration can go through the renew action. However, we don't actually have this implemented anywhere (oops). This change makes sure that we are actually putting those checks into practice, so if a user bypasses the registration search in the frontend and accesses the renewal forms directly, they still can't renew something which should not be renewable.