### PR TITLE
Fix missing error messages for postcode validation

### DIFF
--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -37,6 +37,6 @@ class PostcodeValidator < ActiveModel::EachValidator
 
   def error_message(record, attribute, error)
     class_name = record.class.to_s.underscore
-    I18n.t("activemodel.errors.models.#{class_name}.attribute.#{attribute}.#{error}")
+    I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
   end
 end


### PR DESCRIPTION
There was a missing 's'.