### PR TITLE
Assign address lines in a more sensible way

### DIFF
--- a/app/forms/check_your_answers_form.rb
+++ b/app/forms/check_your_answers_form.rb
@@ -64,8 +64,7 @@ class CheckYourAnswersForm < BaseForm
   def displayable_address(address)
     return [] unless address.present?
     # Get all the possible address lines, then remove the blank ones
-    [address.house_number,
-     address.address_line_1,
+    [address.address_line_1,
      address.address_line_2,
      address.address_line_3,
      address.address_line_4,

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -67,11 +67,16 @@ class Address
   end
 
   def assign_address_lines(data)
-    lines = data["lines"]
+    lines = []
+    lines << data["organisationName"]
+    lines << data["subBuildingName"]
+    lines << data["buildingName"]
+    lines << [data["buildingNumber"], data["thoroughfareName"]].join(" ")
     address_attributes = %i[address_line_1
                             address_line_2
                             address_line_3
                             address_line_4]
+    lines.reject!(&:empty?)
 
     # Assign lines one at a time until we run out of lines to assign
     write_attribute(address_attributes.shift, lines.shift) until lines.empty?

--- a/spec/models/address.rb
+++ b/spec/models/address.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Address, type: :model do
+  let(:address) { build(:address) }
+
+  describe "assign_address_lines" do
+    context "when it is given address data" do
+      let(:data) do
+        {
+          "organisationName" => "Foo Industries",
+          "subBuildingName" => "Suite 5",
+          "buildingName" => "The Bar Building",
+          "buildingNumber" => "5",
+          "thoroughfareName" => "Baz Street"
+        }
+      end
+
+      it "should assign the correct address lines" do
+        address.assign_address_lines(data)
+        expect(address[:address_line_1]).to eq("Foo Industries")
+        expect(address[:address_line_2]).to eq("Suite 5")
+        expect(address[:address_line_3]).to eq("The Bar Building")
+        expect(address[:address_line_4]).to eq("5 Baz Street")
+      end
+
+      context "when not all address fields are used" do
+        before { data["buildingName"] = "" }
+
+        it "should skip blank fields when assigning lines" do
+          address.assign_address_lines(data)
+          expect(address[:address_line_1]).to eq("Foo Industries")
+          expect(address[:address_line_2]).to eq("Suite 5")
+          expect(address[:address_line_3]).to eq("5 Baz Street")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We noticed that addresses found from OS Places which had building numbers were displaying strangely. This change puts a bit more thought into how we assign the lines of the address so we get a more readable result.