### PR TITLE
Bug: Overseas users fail validation on 'check your details'

### DIFF
--- a/app/models/concerns/can_check_business_type_changes.rb
+++ b/app/models/concerns/can_check_business_type_changes.rb
@@ -4,6 +4,8 @@ module CanCheckBusinessTypeChanges
 
   included do
     def business_type_change_valid?
+      return true if business_type == "overseas"
+
       old_type = Registration.where(reg_identifier: reg_identifier).first.business_type
 
       case old_type

--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 May 2018 13:31:54 GMT
+      - Thu, 07 Jun 2018 14:31:28 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '597'
       X-Ratelimit-Reset:
-      - '1526909813'
+      - '1528382187'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Mon, 21 May 2018 13:31:50 GMT
+  recorded_at: Thu, 07 Jun 2018 14:31:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 21 May 2018 13:31:54 GMT
+      - Thu, 07 Jun 2018 14:31:28 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '598'
       X-Ratelimit-Reset:
-      - '1526909813'
+      - '1528382187'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -60,5 +60,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
     http_version: 
-  recorded_at: Mon, 21 May 2018 13:31:50 GMT
+  recorded_at: Thu, 07 Jun 2018 14:31:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 May 2018 13:31:53 GMT
+      - Thu, 07 Jun 2018 14:31:27 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '599'
       X-Ratelimit-Reset:
-      - '1526909813'
+      - '1528382187'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -61,5 +61,5 @@ http_interactions:
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_made_up_to":"2017-12-31","overdue":false,"next_accounts":{"period_end_on":"2017-12-31","due_on":"2018-09-30","period_start_on":"2017-01-01","overdue":false},"last_accounts":{"made_up_to":"2016-12-31","period_start_on":"2016-01-01","period_end_on":"2016-12-31"},"accounting_reference_date":{"day":"31","month":"12"},"next_due":"2018-09-30"},"undeliverable_registered_office_address":false,"etag":"d1aac62a36df9712e7ef94c383439a6fa001fa84","company_number":"09360070","registered_office_address":{"address_line_1":"21
         Haslam Avenue","postal_code":"SM3 9ND","region":"Surrey","locality":"Sutton"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"last_made_up_to":"2017-12-15","overdue":false,"next_made_up_to":"2018-12-15","next_due":"2018-12-29"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 21 May 2018 13:31:50 GMT
+  recorded_at: Thu, 07 Jun 2018 14:31:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/postcode_no_matches.yml
+++ b/spec/cassettes/postcode_no_matches.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 21 May 2018 13:31:06 GMT
+      - Thu, 07 Jun 2018 14:31:22 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -30,5 +30,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":{"statuscode":400,"message":"Parameters are not valid"}}'
     http_version: 
-  recorded_at: Mon, 21 May 2018 13:31:50 GMT
+  recorded_at: Thu, 07 Jun 2018 14:31:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/postcode_valid.yml
+++ b/spec/cassettes/postcode_valid.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 May 2018 13:31:06 GMT
+      - Thu, 07 Jun 2018 14:31:21 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAOWUUW+bMBDHv4rlZx6gaULWN1NQE42aypBNXdUHJziJNbCRMduqad+9x8JSIN1LlU2T9oDA/7PvfP/7iYfvuNRKfhYGX2HPdd95/sydXbrYwU1l1IlYSCVqfPWAF4TdphFFNyxZ3UEgjAiN2D1iCQnxo4Ot/tqeDtgyzZIYNlS6thudi1ZMPTQlCxAFr61UO9Am07k3aSsobez+oHn+xWzug7bRjbLmCSRY5KISKhfKxnrDC2nHcrY3utntt9yIQ4TnpVSytoZb+UUQI/jgYkWbhjR2rw0kW1U5tyKE53DY6Cde3HJZjAMVN1byAhYDKxyUsWUSJikKCH3voL4vDuqqwsfRgrpZB40scmiZ8rJLvh4q/ZQQba/6q8Vux8B+B2uz49AyNKxVt2M8sGOJplz/nH43o2S7lRsR6G/9AJgL7Zbg7ssdc92sCxG+No0fTh+ryaXrebMXoo7rI0yUZCtGYhTRm5jQ8Dw4XbjTE5x8d/7P4zQyw0GLhC0/JRTeqzQ6E1GDnG9F6nRsfxkqfwSV34cqW7DlhwixiEYfSRBHKbqLr//vP9WrlpyJqLdC9Lsx/VGUHp8B5v82jvgGAAA=
     http_version: 
-  recorded_at: Mon, 21 May 2018 13:31:49 GMT
+  recorded_at: Thu, 07 Jun 2018 14:31:22 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-371

If you selected "Not in the United Kingdom" for your principal place of business, you got this error:

"Because your business type has changed, you cannot renew and must make a new registration instead"

Saying you're based overseas sets the business type to "overseas". However, it's valid for any existing type to change to this type, so this should be valid.