### PR TITLE
Alias administrative_area field on addresses

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -19,7 +19,7 @@ class Address
   field :postcode,                                                    type: String
   field :country,                                                     type: String
   field :dependentLocality, as: :dependent_locality,                  type: String
-  field :administrativeArea,                                          type: String
+  field :administrativeArea, as: :administrative_area,                type: String
   field :localAuthorityUpdateDate, as: :local_authority_update_date,  type: String
   field :easting,                                                     type: Integer
   field :northing,                                                    type: Integer


### PR DESCRIPTION
The database stores the field as administrativeArea, but we were assigning administrative_area without aliasing the field name properly. This led to an error when we updated a renewed registration. This commit fixes that error.