### PR TITLE
Refactor mongoid config to use URI's

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,19 +36,14 @@ WCRS_WORLDPAY_MOTO_USERNAME=
 WCRS_WORLDPAY_MOTO_PASSWORD=
 WCRS_WORLDPAY_MOTO_MACSECRET=
 
-# MongoDB - "Registrations" database
-WCRS_REGSDB_NAME="waste-carriers"
-WCRS_REGSDB_USERNAME="mongoUser"
-WCRS_REGSDB_PASSWORD="password1234"
-WCRS_REGSDB_URL1="localhost:27017"
-WCRS_REGSDB_URL2="localhost:28017"
+# MongoDb config
+# Only required when running the app in production. Defaults are used in
+# development and test, but you can still override them using these env vars
+export WCRS_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers"
+export WCRS_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users"
 
-# MongoDB - "Users" database
-WCRS_USERSDB_NAME="waste-carriers-users"
-WCRS_USERSDB_USERNAME="mongoUser"
-WCRS_USERSDB_PASSWORD="password1234"
-WCRS_USERSDB_URL1="localhost:27017"
-WCRS_USERSDB_URL2="localhost:28017"
+export WCRS_TEST_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test"
+export WCRS_TEST_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test"
 
 # Companies House
 WCRS_COMPANIES_HOUSE_URL=

--- a/spec/dummy/config/mongoid.yml
+++ b/spec/dummy/config/mongoid.yml
@@ -3,52 +3,21 @@ development:
   clients:
     # Config for the registrations database
     default:
-      database: <%= ENV['WCRS_REGSDB_NAME'] || 'waste-carriers' %>
-      hosts:
-        - <%= ENV['WCRS_REGSDB_URL1'] || 'localhost:27017' %>
-      options:
-        user: <%= ENV['WCRS_REGSDB_USERNAME'] || 'mongoUser' %>
-        password: <%= ENV['WCRS_REGSDB_PASSWORD'] || 'password1234' %>
+      uri: <%= ENV['WCRS_REGSDB_URI'] || 'mongodb://mongoUser:password1234@localhost:27017/waste-carriers' %>
     # Config for the users database
     users:
-      database: <%= ENV['WCRS_USERSDB_NAME'] || 'waste-carriers-users' %>
-      hosts:
-        - <%= ENV['WCRS_USERSDB_URL1'] || 'localhost:27017' %>
-      options:
-        user: <%= ENV['WCRS_USERSDB_USERNAME'] || 'mongoUser' %>
-        password: <%= ENV['WCRS_USERSDB_PASSWORD'] || 'password1234' %>
-production:
-  clients:
-    # Config for the registrations database
-    default:
-      uri: <%= ENV['WCRS_REGSDB_URI'] %>
-    # Config for the users database
-    users:
-      uri: <%= ENV['WCRS_USERSDB_URI'] %>
+      uri: <%= ENV['WCRS_USERSDB_URI'] || 'mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users' %>
 test:
   clients:
     default:
-      database: <%= ENV['WCRS_TEST_REGSDB_NAME'] || 'waste-carriers-test' %>
-      hosts:
-        - <%= ENV['WCRS_TEST_REGSDB_URL1'] || 'localhost:27017' %>
-      options:
-        user: <%= ENV['WCRS_TEST_REGSDB_USERNAME'] || 'mongoUser' %>
-        password: <%= ENV['WCRS_TEST_REGSDB_PASSWORD'] || 'password1234' %>
-        # In the test environment we lower the retries and retry interval to
-        # low amounts for fast failures.
-        max_retries: 1
-        retry_interval: 0
+      uri: <%= ENV['WCRS_TEST_REGSDB_URI'] || 'mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test' %>
     users:
-      # Details for the user database
-      database: <%= ENV['WCRS_TEST_USERSDB_NAME'] || 'waste-carriers-users-test' %>
-      hosts:
-        - <%= ENV['WCRS_TEST_REGSDB_URL1'] || 'localhost:27017' %>
-      options:
-        user: <%= ENV['WCRS_TEST_USERSDB_USERNAME'] || 'mongoUser' %>
-        password: <%= ENV['WCRS_TEST_USERSDB_PASSWORD'] || 'password1234' %>
-        # In the test environment we lower the retries and retry interval to
-        # low amounts for fast failures.
-        max_retries: 1
-        retry_interval: 0
+      uri: <%= ENV['WCRS_TEST_USERSDB_URI'] || 'mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test' %>
   options:
     raise_not_found_error: false
+production:
+  clients:
+    default:
+      uri: <%= ENV['WCRS_REGSDB_URI'] %>
+    users:
+      uri: <%= ENV['WCRS_USERSDB_URI'] %>


### PR DESCRIPTION
Previously we had specified each of the parameters that make up a connection to the databases within the `mongoid.yml` file. The documentation for the file is heavily centred on this kind of way of doing it <https://docs.mongodb.com/mongoid/master/tutorials/mongoid-installation/#anatomy-of-a-mongoid-config>.

So database, hosts, user, password etc are all listed out. However commented out is mention of providing a URI which has all the details included. Our web-ops team were pushing for using this format and after some investigation

- it looks like this is how we currently do it for our existing app when running in production
- though not scientific, some investigation online suggests this is the typical way to do it when running in production

So this change is about following conventions and switching the app to follow convention and use the URI. The one decision we have made is rather than maintaining both a URI and bunch of env vars that just duplicate the same info, we will use the URI format in all environments.

N.B. This change also deletes the options `max_retries` and `retry_interval` from the test config. Previous notes indicate this helped speed up tests however we cannot find any reference to these in the  existing Mongoid and MongoDb ruby driver documentation. Hence we believe they are just a left over from when Mongoid used Moped as its driver, and we just copied them across from the Frontend config.