### PR TITLE
Sync dev and test secret keys across WCR service

### DIFF
--- a/spec/dummy/config/secrets.yml
+++ b/spec/dummy/config/secrets.yml
@@ -11,10 +11,10 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: b87c6f95b5b3b6094c78ba1be6b42b19c856bfbd10171f9a19b3d3a2deee9728c625f3f80a660c2c2b128a35cc025a8f2e025ba8b1ada7db217e5d7e02c7a91d
+  secret_key_base: 71ea996f1ac55f87a94b50feb9fab21ca967c76db775d9fe1c778239574bf9a0ad5138e431837d2eb23ee70e49f0aa2771c03f3b35de3d8d165a4669ac398d09
 
 test:
-  secret_key_base: 1947b95e409cddcf8c31266a76741d7a40ec14fc6913f66dc7fb648e480a4e36991f7cb0ca22750a077a30afdba9579cafd71f8066d6d1284eb42a556e6baa86
+  secret_key_base: d01c13394bdd899925685e0a860cdb68116421e4f53bde1d28ebad428334703d3713982d85c4be68b295e50a7155087ae140b47fc90d6155b69783c156a82800
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
In order for authentication to work across the apps the secret keys used need to be the same.

Currently the dummy testing app in this project is out of sync with the others so this change ensures the DEV and TEST secret keys are the same as in other projects.