### PR TITLE
Review and fix aliased attributes after Java upgrade

### DIFF
--- a/app/controllers/waste_carriers_engine/person_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/person_forms_controller.rb
@@ -27,7 +27,7 @@ module WasteCarriersEngine
 
       respond_to do |format|
         # Check if there are any matches first, to avoid a Mongoid error
-        people_with_id = @transient_registration.keyPeople.where(id: params[:id])
+        people_with_id = @transient_registration.key_people.where(id: params[:id])
         people_with_id.first.delete if people_with_id.any?
 
         format.html { redirect_to_correct_form }

--- a/app/forms/waste_carriers_engine/conviction_details_form.rb
+++ b/app/forms/waste_carriers_engine/conviction_details_form.rb
@@ -15,12 +15,12 @@ module WasteCarriersEngine
 
     private
 
-    # Adding the new person directly to @transient_registration.keyPeople immediately updates the object,
+    # Adding the new person directly to @transient_registration.key_people immediately updates the object,
     # regardless of validation. So instead we copy all existing people into a new array and modify that.
     def list_of_people_to_keep
       people = []
 
-      @transient_registration.keyPeople.each do |person|
+      @transient_registration.key_people.each do |person|
         # We need to copy the person before adding to the array to avoid a 'conflicting modifications' Mongo error (10151)
         people << person.clone
       end

--- a/app/forms/waste_carriers_engine/main_people_form.rb
+++ b/app/forms/waste_carriers_engine/main_people_form.rb
@@ -30,17 +30,17 @@ module WasteCarriersEngine
       self.dob_year = @transient_registration.main_people.first.dob_year
     end
 
-    # Adding the new main person directly to @transient_registration.keyPeople immediately updates the object,
+    # Adding the new main person directly to @transient_registration.key_people immediately updates the object,
     # regardless of validation. So instead we copy all existing people into a new array and modify that.
     def list_of_people_to_keep
       people = []
 
       # If there's only one main person allowed, we want to discard any existing main people, but keep people with
-      # relevant convictions. Otherwise, we copy all the keyPeople, regardless of type.
+      # relevant convictions. Otherwise, we copy all the key_people, regardless of type.
       existing_people = if can_only_have_one_main_person?
                           @transient_registration.relevant_people
                         else
-                          @transient_registration.keyPeople
+                          @transient_registration.key_people
                         end
 
       existing_people.each do |person|

--- a/app/forms/waste_carriers_engine/person_form.rb
+++ b/app/forms/waste_carriers_engine/person_form.rb
@@ -18,7 +18,7 @@ module WasteCarriersEngine
       self.dob = new_person.dob
 
       attributes = if fields_have_content?
-                     { keyPeople: all_people }
+                     { key_people: all_people }
                    else
                      {}
                    end

--- a/app/forms/waste_carriers_engine/person_form.rb
+++ b/app/forms/waste_carriers_engine/person_form.rb
@@ -1,6 +1,6 @@
 module WasteCarriersEngine
   class PersonForm < BaseForm
-    attr_accessor :first_name, :last_name, :position, :dob_day, :dob_month, :dob_year, :date_of_birth
+    attr_accessor :first_name, :last_name, :position, :dob_day, :dob_month, :dob_year, :dob
     attr_accessor :new_person
 
     def initialize(transient_registration)
@@ -15,7 +15,7 @@ module WasteCarriersEngine
       process_date_fields(params)
 
       self.new_person = set_up_new_person
-      self.date_of_birth = new_person.date_of_birth
+      self.dob = new_person.dob
 
       attributes = if fields_have_content?
                      { keyPeople: all_people }
@@ -82,11 +82,11 @@ module WasteCarriersEngine
     end
 
     def old_enough?
-      return false unless date_of_birth.present?
+      return false unless dob.present?
 
-      return true if date_of_birth < age_cutoff_date
+      return true if dob < age_cutoff_date
 
-      errors.add(:date_of_birth, age_limit_error_message)
+      errors.add(:dob, age_limit_error_message)
       false
     end
 

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -5,18 +5,18 @@ module WasteCarriersEngine
     include Mongoid::Document
 
     included do
-      embeds_one :metaData,               class_name: "WasteCarriersEngine::MetaData"
-      embeds_many :addresses,             class_name: "WasteCarriersEngine::Address"
-      embeds_many :key_people,            class_name: "WasteCarriersEngine::KeyPerson"
-      embeds_one :finance_details,        class_name: "WasteCarriersEngine::FinanceDetails", store_as: "financeDetails"
-      embeds_one :convictionSearchResult, class_name: "WasteCarriersEngine::ConvictionSearchResult"
-      embeds_many :conviction_sign_offs,  class_name: "WasteCarriersEngine::ConvictionSignOff"
+      embeds_one :metaData,                 class_name: "WasteCarriersEngine::MetaData"
+      embeds_many :addresses,               class_name: "WasteCarriersEngine::Address"
+      embeds_many :key_people,              class_name: "WasteCarriersEngine::KeyPerson"
+      embeds_one :finance_details,          class_name: "WasteCarriersEngine::FinanceDetails", store_as: "financeDetails"
+      embeds_one :conviction_search_result, class_name: "WasteCarriersEngine::ConvictionSearchResult"
+      embeds_many :conviction_sign_offs,    class_name: "WasteCarriersEngine::ConvictionSignOff"
 
       accepts_nested_attributes_for :metaData,
                                     :addresses,
                                     :key_people,
                                     :finance_details,
-                                    :convictionSearchResult,
+                                    :conviction_search_result,
                                     :conviction_sign_offs
 
       field :uuid,                                            type: String
@@ -70,15 +70,15 @@ module WasteCarriersEngine
       end
 
       def business_has_matching_or_unknown_conviction?
-        return true unless convictionSearchResult.present?
-        return false if convictionSearchResult.match_result == "NO"
+        return true unless conviction_search_result.present?
+        return false if conviction_search_result.match_result == "NO"
         true
       end
 
       def key_person_has_matching_or_unknown_conviction?
         return true unless key_people.present?
 
-        conviction_search_results = key_people.map(&:convictionSearchResult)
+        conviction_search_results = key_people.map(&:conviction_search_result)
         match_results = conviction_search_results.map(&:match_result)
 
         match_results.include?("YES") || match_results.include?("UNKNOWN")

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -7,14 +7,14 @@ module WasteCarriersEngine
     included do
       embeds_one :metaData,               class_name: "WasteCarriersEngine::MetaData"
       embeds_many :addresses,             class_name: "WasteCarriersEngine::Address"
-      embeds_many :keyPeople,             class_name: "WasteCarriersEngine::KeyPerson"
+      embeds_many :key_people,            class_name: "WasteCarriersEngine::KeyPerson"
       embeds_one :finance_details,        class_name: "WasteCarriersEngine::FinanceDetails", store_as: "financeDetails"
       embeds_one :convictionSearchResult, class_name: "WasteCarriersEngine::ConvictionSearchResult"
       embeds_many :conviction_sign_offs,  class_name: "WasteCarriersEngine::ConvictionSignOff"
 
       accepts_nested_attributes_for :metaData,
                                     :addresses,
-                                    :keyPeople,
+                                    :key_people,
                                     :finance_details,
                                     :convictionSearchResult,
                                     :conviction_sign_offs
@@ -55,13 +55,13 @@ module WasteCarriersEngine
       end
 
       def main_people
-        return [] unless keyPeople.present?
-        keyPeople.where(person_type: "key")
+        return [] unless key_people.present?
+        key_people.where(person_type: "key")
       end
 
       def relevant_people
-        return [] unless keyPeople.present?
-        keyPeople.where(person_type: "relevant")
+        return [] unless key_people.present?
+        key_people.where(person_type: "relevant")
       end
 
       def conviction_check_required?
@@ -76,9 +76,9 @@ module WasteCarriersEngine
       end
 
       def key_person_has_matching_or_unknown_conviction?
-        return true unless keyPeople.present?
+        return true unless key_people.present?
 
-        conviction_search_results = keyPeople.map(&:convictionSearchResult)
+        conviction_search_results = key_people.map(&:convictionSearchResult)
         match_results = conviction_search_results.map(&:match_result)
 
         match_results.include?("YES") || match_results.include?("UNKNOWN")

--- a/app/models/waste_carriers_engine/conviction_search_result.rb
+++ b/app/models/waste_carriers_engine/conviction_search_result.rb
@@ -4,16 +4,16 @@ module WasteCarriersEngine
 
     embedded_in :registration,      class_name: "WasteCarriersEngine::Registration"
     embedded_in :past_registration, class_name: "WasteCarriersEngine::PastRegistration"
-    embedded_in :keyPerson,         class_name: "WasteCarriersEngine::KeyPerson"
+    embedded_in :key_person,         class_name: "WasteCarriersEngine::KeyPerson"
 
-    field :matchResult, as: :match_result,        type: String
-    field :matchingSystem, as: :matching_system,  type: String
-    field :reference,                             type: String
-    field :matchedName, as: :matched_name,        type: String
-    field :searchedAt, as: :searched_at,          type: DateTime
-    field :confirmed,                             type: String
-    field :confirmedAt, as: :confirmed_at,        type: DateTime
-    field :confirmedBy, as: :confirmed_by,        type: String
+    field :match_result,    type: String
+    field :matching_system, type: String
+    field :reference,       type: String
+    field :matched_name,    type: String
+    field :searched_at,     type: DateTime
+    field :confirmed,       type: String
+    field :confirmed_at,    type: DateTime
+    field :confirmed_by,    type: String
 
     def self.new_from_entity_matching_service(data)
       result = ConvictionSearchResult.new

--- a/app/models/waste_carriers_engine/key_person.rb
+++ b/app/models/waste_carriers_engine/key_person.rb
@@ -10,26 +10,26 @@ module WasteCarriersEngine
 
     after_initialize :set_date_of_birth
 
-    field :firstName, as: :first_name,       type: String
-    field :lastName, as: :last_name,         type: String
-    field :position,                         type: String
-    field :dob_day,                          type: Integer
-    field :dob_month,                        type: Integer
-    field :dob_year,                         type: Integer
-    field :dateOfBirth, as: :date_of_birth,  type: DateTime
-    field :personType, as: :person_type,     type: String
+    field :first_name,  type: String
+    field :last_name,   type: String
+    field :position,    type: String
+    field :dob_day,     type: Integer
+    field :dob_month,   type: Integer
+    field :dob_year,    type: Integer
+    field :dob,         type: DateTime
+    field :person_type, type: String
 
     private
 
     def set_date_of_birth
       begin
-        self.date_of_birth = Date.new(dob_year, dob_month, dob_day)
+        self.dob = Date.new(dob_year, dob_month, dob_day)
       rescue NoMethodError
-        errors.add(:date_of_birth, :invalid_date)
+        errors.add(:dob, :invalid_date)
       rescue ArgumentError
-        errors.add(:date_of_birth, :invalid_date)
+        errors.add(:dob, :invalid_date)
       rescue TypeError
-        errors.add(:date_of_birth, :invalid_date)
+        errors.add(:dob, :invalid_date)
       end
     end
   end

--- a/app/models/waste_carriers_engine/key_person.rb
+++ b/app/models/waste_carriers_engine/key_person.rb
@@ -2,11 +2,11 @@ module WasteCarriersEngine
   class KeyPerson
     include Mongoid::Document
 
-    embedded_in :registration,          class_name: "WasteCarriersEngine::Registration"
-    embedded_in :past_registration,     class_name: "WasteCarriersEngine::PastRegistration"
-    embeds_one :convictionSearchResult, class_name: "WasteCarriersEngine::ConvictionSearchResult"
+    embedded_in :registration,            class_name: "WasteCarriersEngine::Registration"
+    embedded_in :past_registration,       class_name: "WasteCarriersEngine::PastRegistration"
+    embeds_one :conviction_search_result, class_name: "WasteCarriersEngine::ConvictionSearchResult"
 
-    accepts_nested_attributes_for :convictionSearchResult
+    accepts_nested_attributes_for :conviction_search_result
 
     after_initialize :set_date_of_birth
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -94,7 +94,7 @@ module WasteCarriersEngine
                                                   "key_people",
                                                   "financeDetails",
                                                   "declaredConvictions",
-                                                  "convictionSearchResult",
+                                                  "conviction_search_result",
                                                   "conviction_sign_offs",
                                                   "declaration",
                                                   "past_registrations")

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -91,7 +91,7 @@ module WasteCarriersEngine
                                                   "constructionWaste",
                                                   "onlyAMF",
                                                   "addresses",
-                                                  "keyPeople",
+                                                  "key_people",
                                                   "financeDetails",
                                                   "declaredConvictions",
                                                   "convictionSearchResult",

--- a/app/services/waste_carriers_engine/entity_matching_service.rb
+++ b/app/services/waste_carriers_engine/entity_matching_service.rb
@@ -76,7 +76,7 @@ module WasteCarriersEngine
     def person_url(person)
       first_name = person.first_name
       last_name = person.last_name
-      date_of_birth = person.date_of_birth.to_s(:entity_matching)
+      date_of_birth = person.dob.to_s(:entity_matching)
       "#{base_url}person?firstname=#{first_name}&lastname=#{last_name}&dateofbirth=#{date_of_birth}"
     end
   end

--- a/app/services/waste_carriers_engine/entity_matching_service.rb
+++ b/app/services/waste_carriers_engine/entity_matching_service.rb
@@ -50,7 +50,7 @@ module WasteCarriersEngine
     end
 
     def store_match_result(entity, data)
-      entity.convictionSearchResult = ConvictionSearchResult.new_from_entity_matching_service(data)
+      entity.conviction_search_result = ConvictionSearchResult.new_from_entity_matching_service(data)
       entity.save!
     end
 

--- a/app/services/waste_carriers_engine/entity_matching_service.rb
+++ b/app/services/waste_carriers_engine/entity_matching_service.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
     end
 
     def check_people_for_matches
-      @transient_registration.keyPeople.each do |person|
+      @transient_registration.key_people.each do |person|
         url = person_url(person)
         data = query_service(url)
         store_match_result(person, data)

--- a/app/validators/waste_carriers_engine/date_of_birth_validator.rb
+++ b/app/validators/waste_carriers_engine/date_of_birth_validator.rb
@@ -16,7 +16,7 @@ module WasteCarriersEngine
     def all_fields_empty?(record)
       fields = [record.dob_day, record.dob_month, record.dob_year].compact
       return false if fields.any?
-      record.errors.add(:date_of_birth, :not_a_date)
+      record.errors.add(:dob, :not_a_date)
       true
     end
 
@@ -41,14 +41,14 @@ module WasteCarriersEngine
     def field_present?(record, type, field)
       return true unless field.blank?
       error_message = "#{type}_blank".to_sym
-      record.errors.add(:date_of_birth, error_message)
+      record.errors.add(:dob, error_message)
       false
     end
 
     def field_is_integer?(record, type, field)
       return true if field.is_a? Integer
       error_message = "#{type}_integer".to_sym
-      record.errors.add(:date_of_birth, error_message)
+      record.errors.add(:dob, error_message)
       false
     end
 
@@ -61,13 +61,13 @@ module WasteCarriersEngine
 
       return true if ranges[type].include?(field)
       error_message = "#{type}_range".to_sym
-      record.errors.add(:date_of_birth, error_message)
+      record.errors.add(:dob, error_message)
       false
     end
 
     def dob_is_a_date?(record)
-      return true if record.date_of_birth.is_a? Date
-      record.errors.add(:date_of_birth, :not_a_date)
+      return true if record.dob.is_a? Date
+      record.errors.add(:dob, :not_a_date)
       false
     end
   end

--- a/app/views/waste_carriers_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/check_your_answers_forms/new.html.erb
@@ -79,7 +79,7 @@
       <% @check_your_answers_form.main_people.each do |person| %>
         <ul class="list">
           <li><%= person.first_name %> <%= person.last_name %></li>
-          <li><%= person.date_of_birth.to_date %></li>
+          <li><%= person.dob.to_date %></li>
         </ul>
       <% end %>
 
@@ -94,7 +94,7 @@
           <ul class="list">
             <li><%= person.first_name %> <%= person.last_name %></li>
             <li><%= person.position %></li>
-            <li><%= person.date_of_birth.to_date %></li>
+            <li><%= person.dob.to_date %></li>
           </ul>
         <% end %>
       <% end %>

--- a/app/views/waste_carriers_engine/conviction_details_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/conviction_details_forms/new.html.erb
@@ -24,7 +24,7 @@
       </fieldset>
     </div>
 
-    <%= render("waste_carriers_engine/shared/date_of_birth", form: @conviction_details_form, f: f) %>
+    <%= render("waste_carriers_engine/shared/dob", form: @conviction_details_form, f: f) %>
 
     <%= f.hidden_field :reg_identifier, value: @conviction_details_form.reg_identifier %>
 

--- a/app/views/waste_carriers_engine/main_people_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/main_people_forms/new.html.erb
@@ -15,7 +15,7 @@
 
     <%= render("waste_carriers_engine/shared/person_name", form: @main_people_form, f: f) %>
 
-    <%= render("waste_carriers_engine/shared/date_of_birth", form: @main_people_form, f: f) %>
+    <%= render("waste_carriers_engine/shared/dob", form: @main_people_form, f: f) %>
 
     <%= f.hidden_field :reg_identifier, value: @main_people_form.reg_identifier %>
 

--- a/app/views/waste_carriers_engine/shared/_dob.html.erb
+++ b/app/views/waste_carriers_engine/shared/_dob.html.erb
@@ -1,16 +1,16 @@
-<% if form.errors[:date_of_birth].any? %>
+<% if form.errors[:dob].any? %>
 <div class="form-group form-group-error">
 <% else %>
 <div class="form-group">
 <% end %>
-  <fieldset id="date_of_birth">
-    <% if form.errors[:date_of_birth].any? %>
-      <span class="error-message"><%= form.errors[:date_of_birth].join(". ") %></span>
+  <fieldset id="dob">
+    <% if form.errors[:dob].any? %>
+      <span class="error-message"><%= form.errors[:dob].join(". ") %></span>
     <% end %>
 
     <legend>
-      <%= t(".date_of_birth") %>
-      <span class="form-hint"><%= t(".date_of_birth_hint") %></span>
+      <%= t(".dob") %>
+      <span class="form-hint"><%= t(".dob_hint") %></span>
     </legend>
 
     <fieldset id="dob_day" class="inline-date">

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,6 +18,6 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular("finance_details", "finance_details")
   inflect.singular("financeDetails", "financeDetails")
-  inflect.plural("keyPerson", "keyPeople")
+  inflect.plural("key_person", "key_people")
   inflect.singular("metaData", "metaData")
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,9 +10,9 @@ en:
     shared:
       back:
         back_link: Back
-      date_of_birth:
-        date_of_birth: Date of birth
-        date_of_birth_hint: For example, 26 5 1976
+      dob:
+        dob: Date of birth
+        dob_hint: For example, 26 5 1976
         dob_year: Year
         dob_month: Month
         dob_day: Day

--- a/config/locales/forms/conviction_details_forms/en.yml
+++ b/config/locales/forms/conviction_details_forms/en.yml
@@ -26,7 +26,7 @@ en:
             position:
               blank: "You must enter a position"
               too_long: "The position must be no longer than 35 characters"
-            date_of_birth:
+            dob:
               age_limit: "You must be 16 or older to use this service"
               not_a_date: "You must enter a valid date"
               day_blank: "You must enter a day"

--- a/config/locales/forms/main_people_forms/en.yml
+++ b/config/locales/forms/main_people_forms/en.yml
@@ -36,7 +36,7 @@ en:
             last_name:
               blank: "You must enter a last name"
               too_long: "The last name must be no longer than 35 characters"
-            date_of_birth:
+            dob:
               age_limit_localAuthority: "Chief executives must be 17 or older"
               age_limit_limitedCompany: "Directors must be 16 or older to be a director of a private limited company in the UK"
               age_limit_limitedLiabilityPartnership: "Partners must be 17 or older"

--- a/spec/factories/conviction_search_result.rb
+++ b/spec/factories/conviction_search_result.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :convictionSearchResult, class: WasteCarriersEngine::ConvictionSearchResult do
+  factory :conviction_search_result, class: WasteCarriersEngine::ConvictionSearchResult do
     trait :match_result_yes do
       match_result "YES"
     end

--- a/spec/factories/forms/conviction_details_form.rb
+++ b/spec/factories/forms/conviction_details_form.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       dob_year 2000
       dob_month 1
       dob_day 1
-      date_of_birth Date.new(2000, 1, 1)
+      dob Date.new(2000, 1, 1)
 
       initialize_with { new(create(:transient_registration, :has_required_data, :declared_convictions, workflow_state: "conviction_details_form")) }
     end

--- a/spec/factories/forms/main_people_form.rb
+++ b/spec/factories/forms/main_people_form.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       dob_year 2000
       dob_month 1
       dob_day 1
-      date_of_birth Date.new(2000, 1, 1)
+      dob Date.new(2000, 1, 1)
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "main_people_form")) }
     end

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -33,11 +33,11 @@ FactoryBot.define do
     end
 
     trait :matched_conviction_search_result do
-      convictionSearchResult { build(:convictionSearchResult, :match_result_yes) }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
     end
 
     trait :unmatched_conviction_search_result do
-      convictionSearchResult { build(:convictionSearchResult, :match_result_no) }
+      conviction_search_result { build(:conviction_search_result, :match_result_no) }
     end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
          build(:address, :has_required_data, :registered, :from_os_places)]
       end
 
-      keyPeople do
+      key_people do
         [build(:key_person, :has_required_data, :main),
          build(:key_person, :has_required_data, :relevant)]
       end
@@ -43,7 +43,7 @@ FactoryBot.define do
          build(:address, :has_required_data, :registered, :manual_foreign)]
       end
 
-      keyPeople do
+      key_people do
         [build(:key_person, :has_required_data, :main),
          build(:key_person, :has_required_data, :relevant)]
       end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
     end
 
     trait :has_conviction_search_result do
-      convictionSearchResult { build(:convictionSearchResult, :match_result_no) }
+      conviction_search_result { build(:conviction_search_result, :match_result_no) }
     end
 
     # Overseas registrations

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
 
     trait :has_key_people do
-      keyPeople do
+      key_people do
         [build(:key_person, :has_required_data, :unmatched_conviction_search_result, :main),
          build(:key_person, :has_required_data, :unmatched_conviction_search_result, :relevant)]
       end
@@ -61,7 +61,7 @@ FactoryBot.define do
       company_name "Test Waste Services"
       company_no "12345678"
 
-      keyPeople do
+      key_people do
         [build(:key_person, :has_matching_conviction, :main)]
       end
     end

--- a/spec/forms/waste_carriers_engine/base_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/base_forms_spec.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
       end
 
       it "should strip excess whitespace from attributes within an array" do
-        attributes = { keyPeople: [build(:key_person, :main, first_name: " test ")] }
+        attributes = { key_people: [build(:key_person, :main, first_name: " test ")] }
 
         base_form.submit(attributes, base_form.reg_identifier)
         expect(base_form.transient_registration.main_people.first.first_name).to eq("test")

--- a/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -205,7 +205,7 @@ module WasteCarriersEngine
       describe "#main_people" do
         context "when there are no main_people" do
           before do
-            check_your_answers_form.transient_registration.keyPeople = nil
+            check_your_answers_form.transient_registration.key_people = nil
             check_your_answers_form.main_people = nil
           end
 
@@ -218,7 +218,7 @@ module WasteCarriersEngine
           before do
             main_person = build(:key_person, :main)
 
-            check_your_answers_form.transient_registration.keyPeople = [main_person]
+            check_your_answers_form.transient_registration.key_people = [main_person]
             check_your_answers_form.main_people = [main_person]
           end
 
@@ -231,7 +231,7 @@ module WasteCarriersEngine
           before do
             main_person = build(:key_person, :has_required_data, :main)
 
-            check_your_answers_form.transient_registration.keyPeople = [main_person]
+            check_your_answers_form.transient_registration.key_people = [main_person]
             check_your_answers_form.main_people = [main_person]
           end
 
@@ -257,7 +257,7 @@ module WasteCarriersEngine
             main_person_a = build(:key_person, :has_required_data, :main)
             main_person_b = build(:key_person, :has_required_data, :main)
 
-            check_your_answers_form.transient_registration.keyPeople = [main_person_a, main_person_b]
+            check_your_answers_form.transient_registration.key_people = [main_person_a, main_person_b]
             check_your_answers_form.main_people = [main_person_a, main_person_b]
           end
 
@@ -284,7 +284,7 @@ module WasteCarriersEngine
 
         context "when there are no relevant_people" do
           before do
-            check_your_answers_form.transient_registration.keyPeople = [main_person]
+            check_your_answers_form.transient_registration.key_people = [main_person]
             check_your_answers_form.relevant_people = nil
           end
 
@@ -315,7 +315,7 @@ module WasteCarriersEngine
           before do
             relevant_person = build(:key_person, :has_required_data, :relevant)
 
-            check_your_answers_form.transient_registration.keyPeople = [main_person, relevant_person]
+            check_your_answers_form.transient_registration.key_people = [main_person, relevant_person]
             check_your_answers_form.relevant_people = [relevant_person]
           end
 
@@ -328,7 +328,7 @@ module WasteCarriersEngine
           before do
             relevant_person = build(:key_person, :relevant)
 
-            check_your_answers_form.transient_registration.keyPeople = [main_person, relevant_person]
+            check_your_answers_form.transient_registration.key_people = [main_person, relevant_person]
             check_your_answers_form.relevant_people = [relevant_person]
           end
 

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -47,7 +47,7 @@ module WasteCarriersEngine
 
         context "when the transient registration already has enough people with convictions" do
           before(:each) do
-            conviction_details_form.transient_registration.update_attributes(keyPeople: [build(:key_person, :has_required_data, :relevant)])
+            conviction_details_form.transient_registration.update_attributes(key_people: [build(:key_person, :has_required_data, :relevant)])
           end
 
           it "should submit" do
@@ -57,7 +57,7 @@ module WasteCarriersEngine
 
         context "when the transient registration does not have enough people with convictions" do
           before(:each) do
-            conviction_details_form.transient_registration.update_attributes(keyPeople: [build(:key_person, :has_required_data, :main)])
+            conviction_details_form.transient_registration.update_attributes(key_people: [build(:key_person, :has_required_data, :main)])
           end
 
           it "should not submit" do

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -268,14 +268,14 @@ module WasteCarriersEngine
         end
       end
 
-      describe "#date_of_birth" do
-        context "when a date_of_birth meets the requirements" do
+      describe "#dob" do
+        context "when a dob meets the requirements" do
           it "is valid" do
             expect(conviction_details_form).to be_valid
           end
         end
 
-        context "when all the date of birth fields are empty" do
+        context "when all the dob fields are empty" do
           before(:each) do
             conviction_details_form.dob_day = ""
             conviction_details_form.dob_month = ""
@@ -287,9 +287,9 @@ module WasteCarriersEngine
           end
         end
 
-        context "when a date of birth is not a valid date" do
+        context "when a dob is not a valid date" do
           before(:each) do
-            conviction_details_form.date_of_birth = nil
+            conviction_details_form.dob = nil
           end
 
           it "is not valid" do
@@ -297,9 +297,9 @@ module WasteCarriersEngine
           end
         end
 
-        context "when the date of birth is below the age limit" do
+        context "when the dob is below the age limit" do
           before(:each) do
-            conviction_details_form.date_of_birth = Date.today
+            conviction_details_form.dob = Date.today
           end
 
           it "should not be valid" do

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -277,14 +277,14 @@ module WasteCarriersEngine
         end
       end
 
-      describe "#date_of_birth" do
-        context "when a date_of_birth meets the requirements" do
+      describe "#dob" do
+        context "when a dob meets the requirements" do
           it "is valid" do
             expect(main_people_form).to be_valid
           end
         end
 
-        context "when all the date of birth fields are empty" do
+        context "when all the dob fields are empty" do
           before(:each) do
             main_people_form.dob_day = ""
             main_people_form.dob_month = ""
@@ -296,9 +296,9 @@ module WasteCarriersEngine
           end
         end
 
-        context "when a date of birth is not a valid date" do
+        context "when a dob is not a valid date" do
           before(:each) do
-            main_people_form.date_of_birth = nil
+            main_people_form.dob = nil
           end
 
           it "is not valid" do
@@ -312,12 +312,12 @@ module WasteCarriersEngine
           end
 
           it "should be valid when at the age limit" do
-            main_people_form.date_of_birth = Date.today - age_limit.years
+            main_people_form.dob = Date.today - age_limit.years
             expect(main_people_form).to be_valid
           end
 
           it "should not be valid when under the age limit" do
-            main_people_form.date_of_birth = Date.today - (age_limit.years - 1.year)
+            main_people_form.dob = Date.today - (age_limit.years - 1.year)
             expect(main_people_form).to_not be_valid
           end
         end

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -45,7 +45,7 @@ module WasteCarriersEngine
 
         context "when the transient registration already has enough main people" do
           before(:each) do
-            main_people_form.transient_registration.update_attributes(keyPeople: [build(:key_person, :has_required_data, :main)])
+            main_people_form.transient_registration.update_attributes(key_people: [build(:key_person, :has_required_data, :main)])
             main_people_form.business_type = "overseas"
           end
 
@@ -56,7 +56,7 @@ module WasteCarriersEngine
 
         context "when the transient registration does not have enough main people" do
           before(:each) do
-            main_people_form.transient_registration.update_attributes(keyPeople: [build(:key_person, :has_required_data, :main)])
+            main_people_form.transient_registration.update_attributes(key_people: [build(:key_person, :has_required_data, :main)])
             main_people_form.business_type = "partnership"
           end
 
@@ -73,32 +73,32 @@ module WasteCarriersEngine
           create(:transient_registration,
                  :has_required_data,
                  business_type: "soleTrader",
-                 keyPeople: [build(:key_person, :has_required_data, :main)])
+                 key_people: [build(:key_person, :has_required_data, :main)])
         end
         let(:main_people_form) { MainPeopleForm.new(transient_registration) }
 
         it "should prefill the first_name" do
-          first_name = transient_registration.keyPeople.first.first_name
+          first_name = transient_registration.key_people.first.first_name
           expect(main_people_form.first_name).to eq(first_name)
         end
 
         it "should prefill the last_name" do
-          last_name = transient_registration.keyPeople.first.last_name
+          last_name = transient_registration.key_people.first.last_name
           expect(main_people_form.last_name).to eq(last_name)
         end
 
         it "should prefill the dob_day" do
-          dob_day = transient_registration.keyPeople.first.dob_day
+          dob_day = transient_registration.key_people.first.dob_day
           expect(main_people_form.dob_day).to eq(dob_day)
         end
 
         it "should prefill the dob_month" do
-          dob_month = transient_registration.keyPeople.first.dob_month
+          dob_month = transient_registration.key_people.first.dob_month
           expect(main_people_form.dob_month).to eq(dob_month)
         end
 
         it "should prefill the dob_year" do
-          dob_year = transient_registration.keyPeople.first.dob_year
+          dob_year = transient_registration.key_people.first.dob_year
           expect(main_people_form.dob_year).to eq(dob_year)
         end
       end

--- a/spec/models/waste_carriers_engine/key_person_spec.rb
+++ b/spec/models/waste_carriers_engine/key_person_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 module WasteCarriersEngine
   RSpec.describe KeyPerson, type: :model do
-    describe "#date_of_birth" do
+    describe "#dob" do
       context "when the provided fields make a valid date" do
         # Can't use factories as we have to trigger the after_initialize method at correct time
         let(:key_person) { KeyPerson.new(dob_day: 1, dob_month: 2, dob_year: 2000) }
 
         it "should return the date when setting date of birth" do
-          expect(key_person.date_of_birth).to eq(Date.new(key_person.dob_year,
-                                                          key_person.dob_month,
-                                                          key_person.dob_day))
+          expect(key_person.dob).to eq(Date.new(key_person.dob_year,
+                                                key_person.dob_month,
+                                                key_person.dob_day))
         end
       end
 
@@ -19,7 +19,7 @@ module WasteCarriersEngine
         let(:key_person) { KeyPerson.new(dob_day: 31, dob_month: 2, dob_year: 2000) }
 
         it "should return nil when setting date of birth" do
-          expect(key_person.date_of_birth).to eq(nil)
+          expect(key_person.dob).to eq(nil)
         end
       end
     end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -287,13 +287,13 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#keyPeople" do
+    describe "#key_people" do
       context "when a registration has one key person" do
         let(:key_person) { build(:key_person, :has_required_data) }
         let(:registration) do
           build(:registration,
                 :has_required_data,
-                keyPeople: [key_person])
+                key_people: [key_person])
         end
 
         it "is valid" do
@@ -307,7 +307,7 @@ module WasteCarriersEngine
         let(:registration) do
           build(:registration,
                 :has_required_data,
-                keyPeople: [key_person_a,
+                key_people: [key_person_a,
                             key_person_b])
         end
 
@@ -323,7 +323,7 @@ module WasteCarriersEngine
           let(:registration) do
             build(:registration,
                   :has_required_data,
-                  keyPeople: [key_person])
+                  key_people: [key_person])
           end
 
           it "is valid" do

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -132,13 +132,13 @@ module WasteCarriersEngine
       end
     end
 
-    describe "#convictionSearchResult" do
-      context "when a registration has a convictionSearchResult" do
-        let(:conviction_search_result) { build(:convictionSearchResult) }
+    describe "#conviction_search_result" do
+      context "when a registration has a conviction_search_result" do
+        let(:conviction_search_result) { build(:conviction_search_result) }
         let(:registration) do
           build(:registration,
                 :has_required_data,
-                convictionSearchResult: conviction_search_result)
+                conviction_search_result: conviction_search_result)
         end
 
         it "is valid" do
@@ -316,10 +316,10 @@ module WasteCarriersEngine
         end
       end
 
-      describe "#convictionSearchResult" do
-        context "when a registration's key person has a convictionSearchResult" do
-          let(:conviction_search_result) { build(:convictionSearchResult) }
-          let(:key_person) { build(:key_person, :has_required_data, convictionSearchResult: conviction_search_result) }
+      describe "#conviction_search_result" do
+        context "when a registration's key person has a conviction_search_result" do
+          let(:conviction_search_result) { build(:conviction_search_result) }
+          let(:key_person) { build(:key_person, :has_required_data, conviction_search_result: conviction_search_result) }
           let(:registration) do
             build(:registration,
                   :has_required_data,

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
@@ -34,7 +34,7 @@ module WasteCarriersEngine
           end
 
           context "when a keyPerson's convictionSearchResult has a match" do
-            before(:each) { transient_registration.keyPeople << build(:key_person, :main, :matched_conviction_search_result) }
+            before(:each) { transient_registration.key_people << build(:key_person, :main, :matched_conviction_search_result) }
 
             it "changes to :renewal_received_form after the 'next' event" do
               expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_received_form).on_event(:next)

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
@@ -19,21 +19,21 @@ module WasteCarriersEngine
         context "when there are no convictions" do
           before(:each) { transient_registration.declared_convictions = false }
 
-          context "when the convictionSearchResults have no matches" do
+          context "when the conviction_search_results have no matches" do
             it "changes to :renewal_complete_form after the 'next' event" do
               expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_complete_form).on_event(:next)
             end
           end
 
-          context "when the convictionSearchResult has a match" do
-            before(:each) { transient_registration.convictionSearchResult = build(:convictionSearchResult, :match_result_yes) }
+          context "when the conviction_search_result has a match" do
+            before(:each) { transient_registration.conviction_search_result = build(:conviction_search_result, :match_result_yes) }
 
             it "changes to :renewal_received_form after the 'next' event" do
               expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_received_form).on_event(:next)
             end
           end
 
-          context "when a keyPerson's convictionSearchResult has a match" do
+          context "when a keyPerson's conviction_search_result has a match" do
             before(:each) { transient_registration.key_people << build(:key_person, :main, :matched_conviction_search_result) }
 
             it "changes to :renewal_received_form after the 'next' event" do

--- a/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -33,14 +33,14 @@ module WasteCarriersEngine
             }
 
             it "increases the total number of people" do
-              total_people_count = transient_registration.keyPeople.count
+              total_people_count = transient_registration.key_people.count
               post conviction_details_forms_path, conviction_details_form: valid_params
-              expect(transient_registration.reload.keyPeople.count).to eq(total_people_count + 1)
+              expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
             end
 
             it "updates the transient registration" do
               post conviction_details_forms_path, conviction_details_form: valid_params
-              expect(transient_registration.reload.keyPeople.last.position).to eq(valid_params[:position])
+              expect(transient_registration.reload.key_people.last.position).to eq(valid_params[:position])
             end
 
             it "returns a 302 response" do
@@ -57,18 +57,18 @@ module WasteCarriersEngine
               let(:relevant_conviction_person) { build(:key_person, :has_required_data, :relevant) }
 
               before(:each) do
-                transient_registration.update_attributes(keyPeople: [relevant_conviction_person])
+                transient_registration.update_attributes(key_people: [relevant_conviction_person])
               end
 
               it "increases the total number of people" do
-                total_people_count = transient_registration.keyPeople.count
+                total_people_count = transient_registration.key_people.count
                 post conviction_details_forms_path, conviction_details_form: valid_params
-                expect(transient_registration.reload.keyPeople.count).to eq(total_people_count + 1)
+                expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
               end
 
               it "does not replace the existing relevant conviction person" do
                 post conviction_details_forms_path, conviction_details_form: valid_params
-                expect(transient_registration.reload.keyPeople.first.first_name).to eq(relevant_conviction_person.first_name)
+                expect(transient_registration.reload.key_people.first.first_name).to eq(relevant_conviction_person.first_name)
               end
             end
 
@@ -76,18 +76,18 @@ module WasteCarriersEngine
               let(:main_person) { build(:key_person, :has_required_data, :main) }
 
               before(:each) do
-                transient_registration.update_attributes(keyPeople: [main_person])
+                transient_registration.update_attributes(key_people: [main_person])
               end
 
               it "increases the total number of people" do
-                total_people_count = transient_registration.keyPeople.count
+                total_people_count = transient_registration.key_people.count
                 post conviction_details_forms_path, conviction_details_form: valid_params
-                expect(transient_registration.reload.keyPeople.count).to eq(total_people_count + 1)
+                expect(transient_registration.reload.key_people.count).to eq(total_people_count + 1)
               end
 
               it "does not replace the existing main person" do
                 post conviction_details_forms_path, conviction_details_form: valid_params
-                expect(transient_registration.reload.keyPeople.first.first_name).to eq(main_person.first_name)
+                expect(transient_registration.reload.key_people.first.first_name).to eq(main_person.first_name)
               end
             end
 
@@ -117,21 +117,21 @@ module WasteCarriersEngine
             end
 
             it "does not increase the total number of people" do
-              total_people_count = transient_registration.keyPeople.count
+              total_people_count = transient_registration.key_people.count
               post conviction_details_forms_path, conviction_details_form: invalid_params
-              expect(transient_registration.reload.keyPeople.count).to eq(total_people_count)
+              expect(transient_registration.reload.key_people.count).to eq(total_people_count)
             end
 
             context "when there is already a main person" do
               let(:existing_main_person) { build(:key_person, :has_required_data, :main) }
 
               before(:each) do
-                transient_registration.update_attributes(keyPeople: [existing_main_person])
+                transient_registration.update_attributes(key_people: [existing_main_person])
               end
 
               it "does not replace the existing main person" do
                 post conviction_details_forms_path, conviction_details_form: invalid_params
-                expect(transient_registration.reload.keyPeople.first.first_name).to eq(existing_main_person.first_name)
+                expect(transient_registration.reload.key_people.first.first_name).to eq(existing_main_person.first_name)
               end
             end
 
@@ -157,9 +157,9 @@ module WasteCarriersEngine
             }
 
             it "does not increase the total number of people" do
-              total_people_count = transient_registration.keyPeople.count
+              total_people_count = transient_registration.key_people.count
               post conviction_details_forms_path, conviction_details_form: blank_params
-              expect(transient_registration.reload.keyPeople.count).to eq(total_people_count)
+              expect(transient_registration.reload.key_people.count).to eq(total_people_count)
             end
           end
         end
@@ -186,7 +186,7 @@ module WasteCarriersEngine
 
           it "does not update the transient registration" do
             post conviction_details_forms_path, conviction_details_form: valid_params
-            expect(transient_registration.reload.keyPeople).to_not exist
+            expect(transient_registration.reload.key_people).to_not exist
           end
 
           it "returns a 302 response" do
@@ -273,7 +273,7 @@ module WasteCarriersEngine
             let(:relevant_person_b) { build(:key_person, :has_required_data, :relevant) }
 
             before(:each) do
-              transient_registration.update_attributes(keyPeople: [relevant_person_a, relevant_person_b])
+              transient_registration.update_attributes(key_people: [relevant_person_a, relevant_person_b])
             end
 
             context "when the delete person action is triggered" do
@@ -288,19 +288,19 @@ module WasteCarriersEngine
               end
 
               it "reduces the total number of people" do
-                total_people_count = transient_registration.keyPeople.count
+                total_people_count = transient_registration.key_people.count
                 delete delete_person_conviction_details_forms_path(relevant_person_a[:id]), reg_identifier: transient_registration.reg_identifier
-                expect(transient_registration.reload.keyPeople.count).to eq(total_people_count - 1)
+                expect(transient_registration.reload.key_people.count).to eq(total_people_count - 1)
               end
 
               it "removes the person" do
                 delete delete_person_conviction_details_forms_path(relevant_person_a[:id]), reg_identifier: transient_registration.reg_identifier
-                expect(transient_registration.reload.keyPeople.where(id: relevant_person_a[:id]).count).to eq(0)
+                expect(transient_registration.reload.key_people.where(id: relevant_person_a[:id]).count).to eq(0)
               end
 
               it "does not modify the other people" do
                 delete delete_person_conviction_details_forms_path(relevant_person_a[:id]), reg_identifier: transient_registration.reg_identifier
-                expect(transient_registration.reload.keyPeople.where(id: relevant_person_b[:id]).count).to eq(1)
+                expect(transient_registration.reload.key_people.where(id: relevant_person_b[:id]).count).to eq(1)
               end
             end
           end

--- a/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
@@ -37,14 +37,14 @@ module WasteCarriersEngine
             }
           end
 
-          it "creates a new convictionSearchResult for the registration" do
+          it "creates a new conviction_search_result for the registration" do
             post declaration_forms_path, declaration_form: params
-            expect(transient_registration.reload.convictionSearchResult).to_not eq(nil)
+            expect(transient_registration.reload.conviction_search_result).to_not eq(nil)
           end
 
-          it "creates a new convictionSearchResult for the key people" do
+          it "creates a new conviction_search_result for the key people" do
             post declaration_forms_path, declaration_form: params
-            expect(transient_registration.reload.key_people.first.convictionSearchResult).to_not eq(nil)
+            expect(transient_registration.reload.key_people.first.conviction_search_result).to_not eq(nil)
           end
         end
       end

--- a/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
@@ -44,7 +44,7 @@ module WasteCarriersEngine
 
           it "creates a new convictionSearchResult for the key people" do
             post declaration_forms_path, declaration_form: params
-            expect(transient_registration.reload.keyPeople.first.convictionSearchResult).to_not eq(nil)
+            expect(transient_registration.reload.key_people.first.convictionSearchResult).to_not eq(nil)
           end
         end
       end

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -31,15 +31,15 @@ module WasteCarriersEngine
               }
             }
 
-            it "increases the number of keyPeople" do
-              key_people_count = transient_registration.keyPeople.count
+            it "increases the number of key_people" do
+              key_people_count = transient_registration.key_people.count
               post main_people_forms_path, main_people_form: valid_params
-              expect(transient_registration.reload.keyPeople.count).to eq(key_people_count + 1)
+              expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
             end
 
             it "updates the transient registration" do
               post main_people_forms_path, main_people_form: valid_params
-              expect(transient_registration.reload.keyPeople.last.first_name).to eq(valid_params[:first_name])
+              expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
             end
 
             it "returns a 302 response" do
@@ -56,13 +56,13 @@ module WasteCarriersEngine
               let(:existing_main_person) { build(:key_person, :has_required_data, :main) }
 
               before(:each) do
-                transient_registration.update_attributes(keyPeople: [existing_main_person])
+                transient_registration.update_attributes(key_people: [existing_main_person])
               end
 
               context "when there can be multiple main people" do
                 it "does not replace the existing main person" do
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.first.first_name).to eq(existing_main_person.first_name)
+                  expect(transient_registration.reload.key_people.first.first_name).to eq(existing_main_person.first_name)
                 end
               end
 
@@ -71,15 +71,15 @@ module WasteCarriersEngine
                   transient_registration.update_attributes(business_type: "soleTrader")
                 end
 
-                it "does not increase the number of keyPeople" do
-                  key_people_count = transient_registration.keyPeople.count
+                it "does not increase the number of key_people" do
+                  key_people_count = transient_registration.key_people.count
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.count).to eq(key_people_count)
+                  expect(transient_registration.reload.key_people.count).to eq(key_people_count)
                 end
 
                 it "replaces the existing main person" do
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.first.first_name).to_not eq(existing_main_person.first_name)
+                  expect(transient_registration.reload.key_people.first.first_name).to_not eq(existing_main_person.first_name)
                 end
               end
             end
@@ -88,19 +88,19 @@ module WasteCarriersEngine
               let(:relevant_conviction_person) { build(:key_person, :has_required_data, :relevant) }
 
               before(:each) do
-                transient_registration.update_attributes(keyPeople: [relevant_conviction_person])
+                transient_registration.update_attributes(key_people: [relevant_conviction_person])
               end
 
               context "when there can be multiple key people" do
                 it "increases the number of key people" do
-                  key_people_count = transient_registration.keyPeople.count
+                  key_people_count = transient_registration.key_people.count
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.count).to eq(key_people_count + 1)
+                  expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
                 end
 
                 it "does not replace the relevant conviction person" do
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.first.first_name).to eq(relevant_conviction_person.first_name)
+                  expect(transient_registration.reload.key_people.first.first_name).to eq(relevant_conviction_person.first_name)
                 end
               end
 
@@ -109,20 +109,20 @@ module WasteCarriersEngine
                   transient_registration.update_attributes(business_type: "soleTrader")
                 end
 
-                it "increases the number of keyPeople" do
-                  key_people_count = transient_registration.keyPeople.count
+                it "increases the number of key_people" do
+                  key_people_count = transient_registration.key_people.count
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.count).to eq(key_people_count + 1)
+                  expect(transient_registration.reload.key_people.count).to eq(key_people_count + 1)
                 end
 
                 it "adds the new main person" do
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.last.first_name).to eq(valid_params[:first_name])
+                  expect(transient_registration.reload.key_people.last.first_name).to eq(valid_params[:first_name])
                 end
 
                 it "does not replace the relevant conviction person" do
                   post main_people_forms_path, main_people_form: valid_params
-                  expect(transient_registration.reload.keyPeople.first.first_name).to eq(relevant_conviction_person.first_name)
+                  expect(transient_registration.reload.key_people.first.first_name).to eq(relevant_conviction_person.first_name)
                 end
               end
             end
@@ -152,22 +152,22 @@ module WasteCarriersEngine
               expect(response).to have_http_status(302)
             end
 
-            it "does not increase the number of keyPeople" do
-              key_people_count = transient_registration.keyPeople.count
+            it "does not increase the number of key_people" do
+              key_people_count = transient_registration.key_people.count
               post main_people_forms_path, main_people_form: invalid_params
-              expect(transient_registration.reload.keyPeople.count).to eq(key_people_count)
+              expect(transient_registration.reload.key_people.count).to eq(key_people_count)
             end
 
             context "when there is already a main person" do
               let(:existing_main_person) { build(:key_person, :has_required_data, :main) }
 
               before(:each) do
-                transient_registration.update_attributes(keyPeople: [existing_main_person])
+                transient_registration.update_attributes(key_people: [existing_main_person])
               end
 
               it "does not replace the existing main person" do
                 post main_people_forms_path, main_people_form: invalid_params
-                expect(transient_registration.reload.keyPeople.first.first_name).to eq(existing_main_person.first_name)
+                expect(transient_registration.reload.key_people.first.first_name).to eq(existing_main_person.first_name)
               end
             end
 
@@ -192,9 +192,9 @@ module WasteCarriersEngine
             }
 
             it "does not increase the number of key people" do
-              key_people_count = transient_registration.keyPeople.count
+              key_people_count = transient_registration.key_people.count
               post main_people_forms_path, main_people_form: blank_params
-              expect(transient_registration.reload.keyPeople.count).to eq(key_people_count)
+              expect(transient_registration.reload.key_people.count).to eq(key_people_count)
             end
           end
         end
@@ -220,7 +220,7 @@ module WasteCarriersEngine
 
           it "does not update the transient registration" do
             post main_people_forms_path, main_people_form: valid_params
-            expect(transient_registration.reload.keyPeople).to_not exist
+            expect(transient_registration.reload.key_people).to_not exist
           end
 
           it "returns a 302 response" do
@@ -320,7 +320,7 @@ module WasteCarriersEngine
             let(:main_person_b) { build(:key_person, :has_required_data, :main) }
 
             before(:each) do
-              transient_registration.update_attributes(keyPeople: [main_person_a, main_person_b])
+              transient_registration.update_attributes(key_people: [main_person_a, main_person_b])
             end
 
             context "when the delete person action is triggered" do
@@ -334,20 +334,20 @@ module WasteCarriersEngine
                 expect(response).to redirect_to(new_main_people_form_path(transient_registration[:reg_identifier]))
               end
 
-              it "reduces the number of keyPeople" do
-                key_people_count = transient_registration.keyPeople.count
+              it "reduces the number of key_people" do
+                key_people_count = transient_registration.key_people.count
                 delete delete_person_main_people_forms_path(main_person_a[:id]), reg_identifier: transient_registration.reg_identifier
-                expect(transient_registration.reload.keyPeople.count).to eq(key_people_count - 1)
+                expect(transient_registration.reload.key_people.count).to eq(key_people_count - 1)
               end
 
               it "removes the main person" do
                 delete delete_person_main_people_forms_path(main_person_a[:id]), reg_identifier: transient_registration.reg_identifier
-                expect(transient_registration.reload.keyPeople.where(id: main_person_a[:id]).count).to eq(0)
+                expect(transient_registration.reload.key_people.where(id: main_person_a[:id]).count).to eq(0)
               end
 
-              it "does not modify the other keyPeople" do
+              it "does not modify the other key_people" do
                 delete delete_person_main_people_forms_path(main_person_a[:id]), reg_identifier: transient_registration.reg_identifier
-                expect(transient_registration.reload.keyPeople.where(id: main_person_b[:id]).count).to eq(1)
+                expect(transient_registration.reload.key_people.where(id: main_person_b[:id]).count).to eq(1)
               end
             end
           end

--- a/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
+++ b/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
@@ -12,10 +12,10 @@ module WasteCarriersEngine
 
     describe "check_business_for_matches" do
       context "when there is a match" do
-        it "creates a valid convictionSearchResult for the business" do
+        it "creates a valid conviction_search_result for the business" do
           VCR.use_cassette("entity_matching_business_has_matches") do
             entity_matching_service.check_business_for_matches
-            expect(transient_registration.reload.convictionSearchResult.match_result).to eq("YES")
+            expect(transient_registration.reload.conviction_search_result.match_result).to eq("YES")
           end
         end
       end
@@ -27,10 +27,10 @@ module WasteCarriersEngine
                  :has_key_people)
         end
 
-        it "creates a valid convictionSearchResult for the business" do
+        it "creates a valid conviction_search_result for the business" do
           VCR.use_cassette("entity_matching_business_no_matches") do
             entity_matching_service.check_business_for_matches
-            expect(transient_registration.reload.convictionSearchResult.match_result).to eq("NO")
+            expect(transient_registration.reload.conviction_search_result.match_result).to eq("NO")
           end
         end
       end
@@ -38,10 +38,10 @@ module WasteCarriersEngine
 
     describe "check_people_for_matches" do
       context "when there is a match" do
-        it "creates a valid convictionSearchResult for the person" do
+        it "creates a valid conviction_search_result for the person" do
           VCR.use_cassette("entity_matching_person_has_matches") do
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("YES")
+            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("YES")
           end
         end
       end
@@ -53,10 +53,10 @@ module WasteCarriersEngine
                  :has_key_people)
         end
 
-        it "creates a valid convictionSearchResult for the person" do
+        it "creates a valid conviction_search_result for the person" do
           VCR.use_cassette("entity_matching_person_no_matches") do
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("NO")
+            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("NO")
           end
         end
       end
@@ -66,44 +66,44 @@ module WasteCarriersEngine
           allow_any_instance_of(RestClient::Request).to receive(:execute).and_return("foo")
         end
 
-        it "creates a new convictionSearchResult" do
+        it "creates a new conviction_search_result" do
           entity_matching_service.check_people_for_matches
-          expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+          expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("UNKNOWN")
         end
       end
 
       context "when the request times out" do
-        it "creates a new convictionSearchResult" do
+        it "creates a new conviction_search_result" do
           VCR.turned_off do
             host = Rails.configuration.wcrs_services_url
             stub_request(:any, /.*#{host}.*/).to_timeout
 
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("UNKNOWN")
           end
         end
       end
 
       context "when the request returns a connection refused error" do
-        it "creates a new convictionSearchResult" do
+        it "creates a new conviction_search_result" do
           VCR.turned_off do
             host = Rails.configuration.wcrs_services_url
             stub_request(:any, /.*#{host}.*/).to_raise(Errno::ECONNREFUSED)
 
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("UNKNOWN")
           end
         end
       end
 
       context "when the request returns a socket error" do
-        it "creates a new convictionSearchResult" do
+        it "creates a new conviction_search_result" do
           VCR.turned_off do
             host = Rails.configuration.wcrs_services_url
             stub_request(:any, /.*#{host}.*/).to_raise(SocketError)
 
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("UNKNOWN")
           end
         end
       end

--- a/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
+++ b/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
@@ -41,7 +41,7 @@ module WasteCarriersEngine
         it "creates a valid convictionSearchResult for the person" do
           VCR.use_cassette("entity_matching_person_has_matches") do
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.keyPeople.first.convictionSearchResult.match_result).to eq("YES")
+            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("YES")
           end
         end
       end
@@ -56,7 +56,7 @@ module WasteCarriersEngine
         it "creates a valid convictionSearchResult for the person" do
           VCR.use_cassette("entity_matching_person_no_matches") do
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.keyPeople.first.convictionSearchResult.match_result).to eq("NO")
+            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("NO")
           end
         end
       end
@@ -68,7 +68,7 @@ module WasteCarriersEngine
 
         it "creates a new convictionSearchResult" do
           entity_matching_service.check_people_for_matches
-          expect(transient_registration.reload.keyPeople.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+          expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
         end
       end
 
@@ -79,7 +79,7 @@ module WasteCarriersEngine
             stub_request(:any, /.*#{host}.*/).to_timeout
 
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.keyPeople.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
           end
         end
       end
@@ -91,7 +91,7 @@ module WasteCarriersEngine
             stub_request(:any, /.*#{host}.*/).to_raise(Errno::ECONNREFUSED)
 
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.keyPeople.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
           end
         end
       end
@@ -103,7 +103,7 @@ module WasteCarriersEngine
             stub_request(:any, /.*#{host}.*/).to_raise(SocketError)
 
             entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.keyPeople.first.convictionSearchResult.match_result).to eq("UNKNOWN")
+            expect(transient_registration.reload.key_people.first.convictionSearchResult.match_result).to eq("UNKNOWN")
           end
         end
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-420

Information saved by the waste-carriers-service Java app used to always save it in camelCase - for example, keyPeople.

However, following the upgrade, some fields and objects have been changed to snake_case.

We need to compare the data, identify what has changed and update the renewals engine to match it.