### PR TITLE
All boolean attributes should be "yes" or "no"

### DIFF
--- a/app/forms/waste_carriers_engine/base_form.rb
+++ b/app/forms/waste_carriers_engine/base_form.rb
@@ -31,14 +31,6 @@ module WasteCarriersEngine
 
     private
 
-    def convert_to_boolean(value)
-      if value == "true"
-        true
-      elsif value == "false"
-        false
-      end
-    end
-
     def transient_registration_valid?
       return if @transient_registration.valid?
       @transient_registration.errors.each do |_attribute, message|

--- a/app/forms/waste_carriers_engine/check_your_answers_form.rb
+++ b/app/forms/waste_carriers_engine/check_your_answers_form.rb
@@ -50,7 +50,7 @@ module WasteCarriersEngine
     validates :company_no, "waste_carriers_engine/company_no": true
     validates :contact_address, "waste_carriers_engine/address": true
     validates :contact_email, "waste_carriers_engine/email": true
-    validates :declared_convictions, "waste_carriers_engine/boolean": true
+    validates :declared_convictions, "waste_carriers_engine/yes_no": true
     validates :first_name, :last_name, "waste_carriers_engine/person_name": true
     validates :location, "waste_carriers_engine/location": true
     validates :phone_number, "waste_carriers_engine/phone_number": true

--- a/app/forms/waste_carriers_engine/construction_demolition_form.rb
+++ b/app/forms/waste_carriers_engine/construction_demolition_form.rb
@@ -17,6 +17,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    validates :construction_waste, "waste_carriers_engine/boolean": true
+    validates :construction_waste, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/construction_demolition_form.rb
+++ b/app/forms/waste_carriers_engine/construction_demolition_form.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.construction_waste = convert_to_boolean(params[:construction_waste])
+      self.construction_waste = params[:construction_waste]
       attributes = { construction_waste: construction_waste }
 
       super(attributes, params[:reg_identifier])

--- a/app/forms/waste_carriers_engine/declare_convictions_form.rb
+++ b/app/forms/waste_carriers_engine/declare_convictions_form.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.declared_convictions = convert_to_boolean(params[:declared_convictions])
+      self.declared_convictions = params[:declared_convictions]
       attributes = { declared_convictions: declared_convictions }
 
       super(attributes, params[:reg_identifier])

--- a/app/forms/waste_carriers_engine/declare_convictions_form.rb
+++ b/app/forms/waste_carriers_engine/declare_convictions_form.rb
@@ -17,6 +17,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    validates :declared_convictions, "waste_carriers_engine/boolean": true
+    validates :declared_convictions, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/other_businesses_form.rb
+++ b/app/forms/waste_carriers_engine/other_businesses_form.rb
@@ -17,6 +17,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    validates :other_businesses, "waste_carriers_engine/boolean": true
+    validates :other_businesses, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/other_businesses_form.rb
+++ b/app/forms/waste_carriers_engine/other_businesses_form.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.other_businesses = convert_to_boolean(params[:other_businesses])
+      self.other_businesses = params[:other_businesses]
       attributes = { other_businesses: other_businesses }
 
       super(attributes, params[:reg_identifier])

--- a/app/forms/waste_carriers_engine/service_provided_form.rb
+++ b/app/forms/waste_carriers_engine/service_provided_form.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.is_main_service = convert_to_boolean(params[:is_main_service])
+      self.is_main_service = params[:is_main_service]
       attributes = { is_main_service: is_main_service }
 
       super(attributes, params[:reg_identifier])

--- a/app/forms/waste_carriers_engine/service_provided_form.rb
+++ b/app/forms/waste_carriers_engine/service_provided_form.rb
@@ -17,6 +17,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    validates :is_main_service, "waste_carriers_engine/boolean": true
+    validates :is_main_service, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/tier_check_form.rb
+++ b/app/forms/waste_carriers_engine/tier_check_form.rb
@@ -17,6 +17,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    validates :temp_tier_check, "waste_carriers_engine/boolean": true
+    validates :temp_tier_check, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/tier_check_form.rb
+++ b/app/forms/waste_carriers_engine/tier_check_form.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.temp_tier_check = convert_to_boolean(params[:temp_tier_check])
+      self.temp_tier_check = params[:temp_tier_check]
       attributes = { temp_tier_check: temp_tier_check }
 
       super(attributes, params[:reg_identifier])

--- a/app/forms/waste_carriers_engine/waste_types_form.rb
+++ b/app/forms/waste_carriers_engine/waste_types_form.rb
@@ -17,6 +17,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    validates :only_amf, "waste_carriers_engine/boolean": true
+    validates :only_amf, "waste_carriers_engine/yes_no": true
   end
 end

--- a/app/forms/waste_carriers_engine/waste_types_form.rb
+++ b/app/forms/waste_carriers_engine/waste_types_form.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.only_amf = convert_to_boolean(params[:only_amf])
+      self.only_amf = params[:only_amf]
       attributes = { only_amf: only_amf }
 
       super(attributes, params[:reg_identifier])

--- a/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
@@ -487,9 +487,9 @@ module WasteCarriersEngine
     end
 
     def switch_to_lower_tier_based_on_smart_answers?
-      return true if other_businesses == false && construction_waste == false
-      return true if other_businesses == true && is_main_service == false && construction_waste == false
-      return true if other_businesses == true && is_main_service == true && only_amf == true
+      return true if other_businesses == "no" && construction_waste == "no"
+      return true if other_businesses == "yes" && is_main_service == "no" && construction_waste == "no"
+      return true if other_businesses == "yes" && is_main_service == "yes" && only_amf == "yes"
       false
     end
 
@@ -498,15 +498,15 @@ module WasteCarriersEngine
     end
 
     def skip_tier_check?
-      temp_tier_check == false
+      temp_tier_check == "no"
     end
 
     def only_carries_own_waste?
-      other_businesses == false
+      other_businesses == "no"
     end
 
     def waste_is_main_service?
-      is_main_service == true
+      is_main_service == "yes"
     end
 
     def based_overseas?
@@ -540,7 +540,7 @@ module WasteCarriersEngine
     end
 
     def declared_convictions?
-      declared_convictions == true
+      declared_convictions == "yes"
     end
 
     def paying_by_card?

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -24,10 +24,10 @@ module WasteCarriersEngine
       field :registrationType, as: :registration_type,        type: String
       field :location,                                        type: String
       field :businessType, as: :business_type,                type: String
-      field :otherBusinesses, as: :other_businesses,          type: Boolean
-      field :isMainService, as: :is_main_service,             type: Boolean
-      field :onlyAMF, as: :only_amf,                          type: Boolean
-      field :constructionWaste, as: :construction_waste,      type: Boolean
+      field :otherBusinesses, as: :other_businesses,          type: String # 'yes' or 'no' - should refactor to boolean
+      field :isMainService, as: :is_main_service,             type: String # 'yes' or 'no' - should refactor to boolean
+      field :onlyAMF, as: :only_amf,                          type: String # 'yes' or 'no' - should refactor to boolean
+      field :constructionWaste, as: :construction_waste,      type: String # 'yes' or 'no' - should refactor to boolean
       field :companyName, as: :company_name,                  type: String
       field :companyNo, as: :company_no,                      type: String # Despite its name, this can include letters
       field :firstName, as: :first_name,                      type: String
@@ -35,8 +35,8 @@ module WasteCarriersEngine
       field :phoneNumber, as: :phone_number,                  type: String
       field :contactEmail, as: :contact_email,                type: String
       field :accountEmail, as: :account_email,                type: String
-      field :declaredConvictions, as: :declared_convictions,  type: Boolean
-      field :declaration,                                     type: Integer # Unsure of type
+      field :declaredConvictions, as: :declared_convictions,  type: String # 'yes' or 'no' - should refactor to boolean
+      field :declaration,                                     type: Integer
       field :regIdentifier, as: :reg_identifier,              type: String
       field :expires_on,                                      type: DateTime
 
@@ -65,7 +65,7 @@ module WasteCarriersEngine
       end
 
       def conviction_check_required?
-        return true if declared_convictions == true
+        return true if declared_convictions == "yes"
         business_has_matching_or_unknown_conviction? || key_person_has_matching_or_unknown_conviction?
       end
 

--- a/app/models/concerns/waste_carriers_engine/can_limit_number_of_relevant_people.rb
+++ b/app/models/concerns/waste_carriers_engine/can_limit_number_of_relevant_people.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
     end
 
     def minimum_relevant_people
-      return 1 if @transient_registration.declared_convictions
+      return 1 if @transient_registration.declared_convictions == "yes"
       0
     end
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -19,9 +19,9 @@ module WasteCarriersEngine
     field :temp_cards, type: Integer
     field :temp_company_postcode, type: String
     field :temp_contact_postcode, type: String
-    field :temp_os_places_error, type: Boolean
+    field :temp_os_places_error, type: String # 'yes' or 'no' - should refactor to boolean
     field :temp_payment_method, type: String
-    field :temp_tier_check, type: Boolean
+    field :temp_tier_check, type: String # 'yes' or 'no' - should refactor to boolean
 
     # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
     def registration_type_changed?

--- a/app/validators/waste_carriers_engine/boolean_validator.rb
+++ b/app/validators/waste_carriers_engine/boolean_validator.rb
@@ -1,7 +1,7 @@
 module WasteCarriersEngine
   class BooleanValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
-      valid_values = [true, false]
+      valid_values = %w[yes no]
       return true if valid_values.include?(value)
       record.errors[attribute] << error_message(record, attribute, "inclusion")
       false

--- a/app/validators/waste_carriers_engine/yes_no_validator.rb
+++ b/app/validators/waste_carriers_engine/yes_no_validator.rb
@@ -1,5 +1,5 @@
 module WasteCarriersEngine
-  class BooleanValidator < ActiveModel::EachValidator
+  class YesNoValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       valid_values = %w[yes no]
       return true if valid_values.include?(value)

--- a/app/views/waste_carriers_engine/construction_demolition_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/construction_demolition_forms/new.html.erb
@@ -21,12 +21,12 @@
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :construction_waste, "true" %>
-          <%= f.label :construction_waste, t(".option_true"), value: "true" %>
+          <%= f.radio_button :construction_waste, "yes" %>
+          <%= f.label :construction_waste, t(".options.yes"), value: "yes" %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :construction_waste, "false" %>
-          <%= f.label :construction_waste, t(".option_false"), value: "false" %>
+          <%= f.radio_button :construction_waste, "no" %>
+          <%= f.label :construction_waste, t(".options.no"), value: "no" %>
         </div>
       </fieldset>
     </div>

--- a/app/views/waste_carriers_engine/declare_convictions_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/declare_convictions_forms/new.html.erb
@@ -22,12 +22,12 @@
         <p class="strong"><%= t(".paragraph_1") %></p>
 
         <div class="multiple-choice">
-          <%= f.radio_button :declared_convictions, "true" %>
-          <%= f.label :declared_convictions, t(".options.true"), value: "true" %>
+          <%= f.radio_button :declared_convictions, "yes" %>
+          <%= f.label :declared_convictions, t(".options.yes"), value: "yes" %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :declared_convictions, "false" %>
-          <%= f.label :declared_convictions, t(".options.false"), value: "false" %>
+          <%= f.radio_button :declared_convictions, "no" %>
+          <%= f.label :declared_convictions, t(".options.no"), value: "no" %>
         </div>
       </fieldset>
     </div>

--- a/app/views/waste_carriers_engine/other_businesses_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/other_businesses_forms/new.html.erb
@@ -21,12 +21,12 @@
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :other_businesses, "true" %>
-          <%= f.label :other_businesses, t(".option_true"), value: "true" %>
+          <%= f.radio_button :other_businesses, "yes" %>
+          <%= f.label :other_businesses, t(".options.yes"), value: "yes" %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :other_businesses, "false" %>
-          <%= f.label :other_businesses, t(".option_false"), value: "false" %>
+          <%= f.radio_button :other_businesses, "no" %>
+          <%= f.label :other_businesses, t(".options.no"), value: "no" %>
         </div>
       </fieldset>
     </div>

--- a/app/views/waste_carriers_engine/service_provided_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/service_provided_forms/new.html.erb
@@ -21,12 +21,12 @@
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :is_main_service, "false" %>
-          <%= f.label :is_main_service, t(".option_false"), value: "false" %>
+          <%= f.radio_button :is_main_service, "no" %>
+          <%= f.label :is_main_service, t(".options.no"), value: "no" %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :is_main_service, "true" %>
-          <%= f.label :is_main_service, t(".option_true"), value: "true" %>
+          <%= f.radio_button :is_main_service, "yes" %>
+          <%= f.label :is_main_service, t(".options.yes"), value: "yes" %>
         </div>
       </fieldset>
     </div>

--- a/app/views/waste_carriers_engine/tier_check_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/tier_check_forms/new.html.erb
@@ -48,12 +48,12 @@
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :temp_tier_check, "false" %>
-          <%= f.label :temp_tier_check, t(".options.false"), value: "false" %>
+          <%= f.radio_button :temp_tier_check, "no" %>
+          <%= f.label :temp_tier_check, t(".options.no"), value: "no" %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :temp_tier_check, "true" %>
-          <%= f.label :temp_tier_check, t(".options.true"), value: "true" %>
+          <%= f.radio_button :temp_tier_check, "yes" %>
+          <%= f.label :temp_tier_check, t(".options.yes"), value: "yes" %>
         </div>
       </fieldset>
     </div>

--- a/app/views/waste_carriers_engine/waste_types_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/waste_types_forms/new.html.erb
@@ -27,12 +27,12 @@
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :only_amf, "true" %>
-          <%= f.label :only_amf, t(".option_true_html"), value: "true" %>
+          <%= f.radio_button :only_amf, "yes" %>
+          <%= f.label :only_amf, t(".options.yes"), value: "yes" %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :only_amf, "false" %>
-          <%= f.label :only_amf, t(".option_false"), value: "false" %>
+          <%= f.radio_button :only_amf, "no" %>
+          <%= f.label :only_amf, t(".options.no"), value: "no" %>
         </div>
       </fieldset>
     </div>

--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -66,8 +66,8 @@ en:
             other: Business or organisation owners
         subheading_7: Relevant convictions
         declared_convictions:
-          "true": You told us you have relevant people with convictions in your business or organisation.
-          "false": You told us there are no relevant people with convictions in your business or organisation.
+          "yes": You told us you have relevant people with convictions in your business or organisation.
+          "no": You told us there are no relevant people with convictions in your business or organisation.
         subheading_8: Contact details
         next_button: Continue
   activemodel:

--- a/config/locales/forms/construction_demolition_forms/en.yml
+++ b/config/locales/forms/construction_demolition_forms/en.yml
@@ -4,8 +4,9 @@ en:
       new:
         title: Building, construction and demolition waste
         heading: Do you ever deal with building, construction or demolition waste?
-        option_true: "Yes"
-        option_false: "No"
+        options:
+          "yes": "Yes"
+          "no": "No"
         waste_detail_subheading: What is building, construction and demolition waste?
         waste_detail_paragraph_1: This waste is generated through building or renovation work, including soil, concrete, bricks, glass, wood, plasterboard, asbestos, metal and plastic.
         waste_detail_paragraph_2: It can be produced as part of a large construction project or a smaller business activity (e.g. a builder replacing a bathroom, or a gardener replacing fence panels).

--- a/config/locales/forms/declare_convictions_forms/en.yml
+++ b/config/locales/forms/declare_convictions_forms/en.yml
@@ -6,8 +6,8 @@ en:
         heading: Has anyone in the organisation's management been convicted of an environmental offence in the last 12 months?
         paragraph_1: If you don’t tell us about any unspent environmental offences, you may not be able to register.
         options:
-          "true": "Yes"
-          "false": "No"
+          "yes": "Yes"
+          "no": "No"
         conviction_types_subheading: Offences you must tell us about
         conviction_types_paragraph_1: If anyone involved in managing the business has been convicted of an environmental offence, it might affect this registration.
         conviction_types_paragraph_2: "You only need to tell us about unspent convictions for offences under these areas of law:"

--- a/config/locales/forms/other_businesses_forms/en.yml
+++ b/config/locales/forms/other_businesses_forms/en.yml
@@ -4,8 +4,9 @@ en:
       new:
         title: Waste from other people
         heading: Do you ever deal with waste from other businesses or households?
-        option_true: "Yes"
-        option_false: "No"
+        options:
+          "yes": "Yes"
+          "no": "No"
         error_heading: Something is wrong
         next_button: Continue
   activemodel:

--- a/config/locales/forms/service_provided_forms/en.yml
+++ b/config/locales/forms/service_provided_forms/en.yml
@@ -5,8 +5,9 @@ en:
         title: Who creates the waste?
         heading: Who creates the waste that you deal with?
         error_heading: Something is wrong
-        option_true: Our customers create the waste, we just collect or move it for them
-        option_false: We create the waste as part of a service we provide to our customers, for example a gardener taking away grass cuttings
+        options:
+          "yes": Our customers create the waste, we just collect or move it for them
+          "no": We create the waste as part of a service we provide to our customers, for example a gardener taking away grass cuttings
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/tier_check_forms/en.yml
+++ b/config/locales/forms/tier_check_forms/en.yml
@@ -19,8 +19,8 @@ en:
           - item: "You ONLY deal with waste you produce in the course of carrying out your business – for example, a hairdresser dealing with hair clippings. This does not include construction or demolition waste"
           - item: "You ONLY deal with waste from mines or quarries, from agricultural premises, or animal by-products"
         options:
-          "false": I know I need an upper tier registration (continue)
-          "true": I want to check my tier is correct before renewing
+          "no": I know I need an upper tier registration (continue)
+          "yes": I want to check my tier is correct before renewing
         error_heading: Something is wrong
         next_button: Continue
   activemodel:

--- a/config/locales/forms/waste_types_forms/en.yml
+++ b/config/locales/forms/waste_types_forms/en.yml
@@ -8,8 +8,9 @@ en:
           - Farm or agricultural waste
           - Animal by-products
           - Waste from mines or quarries
-        option_true_html: "We only deal with these types of waste"
-        option_false: "We deal with more than just the waste listed above"
+        options:
+          "yes": "We only deal with these types of waste"
+          "no": "We deal with more than just the waste listed above"
         error_heading: Something is wrong
         next_button: Continue
   activemodel:

--- a/spec/factories/forms/construction_demolition_form.rb
+++ b/spec/factories/forms/construction_demolition_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :construction_demolition_form, class: WasteCarriersEngine::ConstructionDemolitionForm do
     trait :has_required_data do
-      construction_waste "true"
+      construction_waste "yes"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "construction_demolition_form")) }
     end

--- a/spec/factories/forms/declare_convictions_form.rb
+++ b/spec/factories/forms/declare_convictions_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :declare_convictions_form, class: WasteCarriersEngine::DeclareConvictionsForm do
     trait :has_required_data do
-      declared_convictions false
+      declared_convictions "no"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "declare_convictions_form")) }
     end

--- a/spec/factories/forms/other_businesses_form.rb
+++ b/spec/factories/forms/other_businesses_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :other_businesses_form, class: WasteCarriersEngine::OtherBusinessesForm do
     trait :has_required_data do
-      other_businesses "true"
+      other_businesses "yes"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "other_businesses_form")) }
     end

--- a/spec/factories/forms/service_provided_form.rb
+++ b/spec/factories/forms/service_provided_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :service_provided_form, class: WasteCarriersEngine::ServiceProvidedForm do
     trait :has_required_data do
-      is_main_service "true"
+      is_main_service "yes"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "service_provided_form")) }
     end

--- a/spec/factories/forms/tier_check_form.rb
+++ b/spec/factories/forms/tier_check_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :tier_check_form, class: WasteCarriersEngine::TierCheckForm do
     trait :has_required_data do
-      temp_tier_check false
+      temp_tier_check "no"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "tier_check_form")) }
     end

--- a/spec/factories/forms/waste_types_form.rb
+++ b/spec/factories/forms/waste_types_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :waste_types_form, class: WasteCarriersEngine::WasteTypesForm do
     trait :has_required_data do
-      only_amf "true"
+      only_amf "yes"
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "waste_types_form")) }
     end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :transient_registration, class: WasteCarriersEngine::TransientRegistration do
     trait :has_required_data do
       location "england"
-      declared_convictions "false"
+      declared_convictions "no"
       temp_cards 1
 
       # Create a new registration when initializing so we can copy its data
@@ -26,7 +26,7 @@ FactoryBot.define do
     end
 
     trait :declared_convictions do
-      declared_convictions "true"
+      declared_convictions "yes"
     end
 
     trait :has_finance_details do
@@ -43,7 +43,7 @@ FactoryBot.define do
 
     trait :has_required_overseas_data do
       location "overseas"
-      declared_convictions "false"
+      declared_convictions "no"
       temp_cards 1
 
       # Create a new registration when initializing so we can copy its data

--- a/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -26,7 +26,7 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :check_your_answers_form, field = :declared_convictions
+    include_examples "validate yes no", form = :check_your_answers_form, field = :declared_convictions
     include_examples "validate business_type", form = :check_your_answers_form
     include_examples "validate company_name", form = :check_your_answers_form
     include_examples "validate company_no", form = :check_your_answers_form

--- a/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -290,8 +290,8 @@ module WasteCarriersEngine
 
           context "when declared_convictions does not expect there to be people" do
             before(:each) do
-              check_your_answers_form.transient_registration.declared_convictions = false
-              check_your_answers_form.declared_convictions = false
+              check_your_answers_form.transient_registration.declared_convictions = "no"
+              check_your_answers_form.declared_convictions = "no"
             end
 
             it "is valid" do
@@ -301,8 +301,8 @@ module WasteCarriersEngine
 
           context "when declared_convictions expects there to be people" do
             before(:each) do
-              check_your_answers_form.transient_registration.declared_convictions = true
-              check_your_answers_form.declared_convictions = true
+              check_your_answers_form.transient_registration.declared_convictions = "yes"
+              check_your_answers_form.declared_convictions = "yes"
             end
 
             it "is not valid" do

--- a/spec/forms/waste_carriers_engine/construction_demolition_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/construction_demolition_forms_spec.rb
@@ -27,6 +27,6 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :construction_demolition_form, field = :construction_waste
+    include_examples "validate yes no", form = :construction_demolition_form, field = :construction_waste
   end
 end

--- a/spec/forms/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -32,6 +32,6 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :declare_convictions_form, field = :declared_convictions
+    include_examples "validate yes no", form = :declare_convictions_form, field = :declared_convictions
   end
 end

--- a/spec/forms/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
         let(:valid_params) do
           {
             reg_identifier: declare_convictions_form.reg_identifier,
-            declared_convictions: "false"
+            declared_convictions: declare_convictions_form.declared_convictions
           }
         end
 

--- a/spec/forms/waste_carriers_engine/other_businesses_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/other_businesses_forms_spec.rb
@@ -27,6 +27,6 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :other_businesses_form, field = :other_businesses
+    include_examples "validate yes no", form = :other_businesses_form, field = :other_businesses
   end
 end

--- a/spec/forms/waste_carriers_engine/service_provided_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/service_provided_forms_spec.rb
@@ -27,6 +27,6 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :service_provided_form, field = :is_main_service
+    include_examples "validate yes no", form = :service_provided_form, field = :is_main_service
   end
 end

--- a/spec/forms/waste_carriers_engine/tier_check_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/tier_check_forms_spec.rb
@@ -27,6 +27,6 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :tier_check_form, field = :temp_tier_check
+    include_examples "validate yes no", form = :tier_check_form, field = :temp_tier_check
   end
 end

--- a/spec/forms/waste_carriers_engine/tier_check_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/tier_check_forms_spec.rb
@@ -8,7 +8,7 @@ module WasteCarriersEngine
         let(:valid_params) do
           {
             reg_identifier: tier_check_form.reg_identifier,
-            temp_tier_check: "false"
+            temp_tier_check: tier_check_form.temp_tier_check
           }
         end
 

--- a/spec/forms/waste_carriers_engine/waste_types_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/waste_types_forms_spec.rb
@@ -27,6 +27,6 @@ module WasteCarriersEngine
       end
     end
 
-    include_examples "validate boolean", form = :waste_types_form, field = :only_amf
+    include_examples "validate yes no", form = :waste_types_form, field = :only_amf
   end
 end

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_cannot_renew_lower_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_cannot_renew_lower_tier_form_spec.rb
@@ -20,9 +20,9 @@ module WasteCarriersEngine
 
         context "when the tier change is because the business only deals with certain waste types" do
           before(:each) do
-            transient_registration.other_businesses = true
-            transient_registration.is_main_service = true
-            transient_registration.only_amf = true
+            transient_registration.other_businesses = "yes"
+            transient_registration.is_main_service = "yes"
+            transient_registration.only_amf = "yes"
           end
 
           it "changes to :waste_types_form after the 'back' event" do
@@ -32,8 +32,8 @@ module WasteCarriersEngine
 
         context "when the tier change is because the business doesn't deal with construction waste" do
           before(:each) do
-            transient_registration.other_businesses = false
-            transient_registration.construction_waste = false
+            transient_registration.other_businesses = "no"
+            transient_registration.construction_waste = "no"
           end
 
           it "changes to :construction_demolition_form after the 'back' event" do

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_cbd_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_cbd_type_form_spec.rb
@@ -10,19 +10,19 @@ module WasteCarriersEngine
                  workflow_state: "cbd_type_form")
         end
 
-        context "when temp_tier_check is false" do
-          before(:each) { transient_registration.temp_tier_check = false }
+        context "when temp_tier_check is no" do
+          before(:each) { transient_registration.temp_tier_check = "no" }
 
           it "transitions to :tier_check_form after the 'back' event" do
             expect(transient_registration).to transition_from(:cbd_type_form).to(:tier_check_form).on_event(:back)
           end
         end
 
-        context "when temp_tier_check is true" do
-          before(:each) { transient_registration.temp_tier_check = true }
+        context "when temp_tier_check is yes" do
+          before(:each) { transient_registration.temp_tier_check = "yes" }
 
           context "when the business doesn't carry waste for other businesses or households" do
-            before(:each) { transient_registration.other_businesses = false }
+            before(:each) { transient_registration.other_businesses = "no" }
 
             it "changes to :construction_demolition_form after the 'back' event" do
               expect(transient_registration).to transition_from(:cbd_type_form).to(:construction_demolition_form).on_event(:back)
@@ -30,7 +30,7 @@ module WasteCarriersEngine
           end
 
           context "when the business carries waste produced by its customers" do
-            before(:each) { transient_registration.is_main_service = true }
+            before(:each) { transient_registration.is_main_service = "yes" }
 
             it "changes to :waste_types_form after the 'back' event" do
               expect(transient_registration).to transition_from(:cbd_type_form).to(:waste_types_form).on_event(:back)
@@ -39,8 +39,8 @@ module WasteCarriersEngine
 
           context "when the business carries carries waste for other businesses but produces that waste" do
             before(:each) do
-              transient_registration.other_businesses = true
-              transient_registration.is_main_service = false
+              transient_registration.other_businesses = "yes"
+              transient_registration.is_main_service = "no"
             end
 
             it "changes to :construction_demolition_form after the 'back' event" do

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_construction_demolition_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_construction_demolition_form_spec.rb
@@ -11,7 +11,7 @@ module WasteCarriersEngine
         end
 
         context "when the business does not carry waste for other businesses or households" do
-          before(:each) { transient_registration.other_businesses = false }
+          before(:each) { transient_registration.other_businesses = "no" }
 
           it "transitions to :service_provided_form after the 'back' event" do
             expect(transient_registration).to transition_from(:construction_demolition_form).to(:other_businesses_form).on_event(:back)
@@ -19,7 +19,7 @@ module WasteCarriersEngine
         end
 
         context "when the business does carry waste for other businesses or households" do
-          before(:each) { transient_registration.other_businesses = true }
+          before(:each) { transient_registration.other_businesses = "yes" }
 
           it "transitions to :service_provided_form after the 'back' event" do
             expect(transient_registration).to transition_from(:construction_demolition_form).to(:service_provided_form).on_event(:back)
@@ -28,9 +28,9 @@ module WasteCarriersEngine
 
         context "when the registration should change to lower tier" do
           before(:each) do
-            transient_registration.other_businesses = true
-            transient_registration.is_main_service = true
-            transient_registration.only_amf = true
+            transient_registration.other_businesses = "yes"
+            transient_registration.is_main_service = "yes"
+            transient_registration.only_amf = "yes"
           end
 
           it "transitions to :cannot_renew_lower_tier_form after the 'next' event" do
@@ -40,9 +40,9 @@ module WasteCarriersEngine
 
         context "when the registration should stay upper tier" do
           before(:each) do
-            transient_registration.other_businesses = true
-            transient_registration.is_main_service = true
-            transient_registration.only_amf = false
+            transient_registration.other_businesses = "yes"
+            transient_registration.is_main_service = "yes"
+            transient_registration.only_amf = "no"
           end
 
           it "transitions to :cbd_type_form after the 'next' event" do

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_name_form_spec.rb
@@ -10,9 +10,9 @@ module WasteCarriersEngine
                  workflow_state: "contact_name_form")
         end
 
-        context "when declared_convictions is false" do
+        context "when declared_convictions is no" do
           before(:each) do
-            transient_registration.declared_convictions = false
+            transient_registration.declared_convictions = "no"
           end
 
           it "changes to :declare_convictions_form after the 'back' event" do
@@ -20,9 +20,9 @@ module WasteCarriersEngine
           end
         end
 
-        context "when declared_convictions is true" do
+        context "when declared_convictions is yes" do
           before(:each) do
-            transient_registration.declared_convictions = true
+            transient_registration.declared_convictions = "yes"
           end
 
           it "changes to :conviction_details_form after the 'back' event" do

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_declare_convictions_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_declare_convictions_form_spec.rb
@@ -14,9 +14,9 @@ module WasteCarriersEngine
           expect(transient_registration).to transition_from(:declare_convictions_form).to(:main_people_form).on_event(:back)
         end
 
-        context "when declared_convictions is true" do
+        context "when declared_convictions is yes" do
           before(:each) do
-            transient_registration.declared_convictions = true
+            transient_registration.declared_convictions = "yes"
           end
 
           it "changes to :conviction_details_form after the 'next' event" do
@@ -24,9 +24,9 @@ module WasteCarriersEngine
           end
         end
 
-        context "when declared_convictions is false" do
+        context "when declared_convictions is no" do
           before(:each) do
-            transient_registration.declared_convictions = false
+            transient_registration.declared_convictions = "no"
           end
 
           it "changes to :contact_name_form after the 'next' event" do

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_other_businesses_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_other_businesses_form_spec.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
         end
 
         context "when the business does not carry waste for other businesses or households" do
-          before(:each) { transient_registration.other_businesses = false }
+          before(:each) { transient_registration.other_businesses = "no" }
 
           it "transitions to :construction_demolition_form after the 'next' event" do
             expect(transient_registration).to transition_from(:other_businesses_form).to(:construction_demolition_form).on_event(:next)
@@ -23,7 +23,7 @@ module WasteCarriersEngine
         end
 
         context "when the business does carry waste for other businesses or households" do
-          before(:each) { transient_registration.other_businesses = true }
+          before(:each) { transient_registration.other_businesses = "yes" }
 
           it "transitions to :service_provided_form after the 'next' event" do
             expect(transient_registration).to transition_from(:other_businesses_form).to(:service_provided_form).on_event(:next)

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_service_provided_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_service_provided_form_spec.rb
@@ -15,7 +15,7 @@ module WasteCarriersEngine
         end
 
         context "when the business only carries waste it produces" do
-          before(:each) { transient_registration.is_main_service = false }
+          before(:each) { transient_registration.is_main_service = "no" }
 
           it "transitions to :construction_demolition_form after the 'next' event" do
             expect(transient_registration).to transition_from(:service_provided_form).to(:construction_demolition_form).on_event(:next)
@@ -23,7 +23,7 @@ module WasteCarriersEngine
         end
 
         context "when the business carries waste produced by others" do
-          before(:each) { transient_registration.is_main_service = true }
+          before(:each) { transient_registration.is_main_service = "yes" }
 
           it "transitions to :waste_types_form after the 'next' event" do
             expect(transient_registration).to transition_from(:service_provided_form).to(:waste_types_form).on_event(:next)

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_tier_check_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_tier_check_form_spec.rb
@@ -22,16 +22,16 @@ module WasteCarriersEngine
           end
         end
 
-        context "when temp_tier_check is true" do
-          before(:each) { transient_registration.temp_tier_check = true }
+        context "when temp_tier_check is yes" do
+          before(:each) { transient_registration.temp_tier_check = "yes" }
 
           it "transitions to :other_businesses_form after the 'next' event" do
             expect(transient_registration).to transition_from(:tier_check_form).to(:other_businesses_form).on_event(:next)
           end
         end
 
-        context "when temp_tier_check is false" do
-          before(:each) { transient_registration.temp_tier_check = false }
+        context "when temp_tier_check is no" do
+          before(:each) { transient_registration.temp_tier_check = "no" }
 
           it "transitions to :cbd_type_form after the 'next' event" do
             expect(transient_registration).to transition_from(:tier_check_form).to(:cbd_type_form).on_event(:next)

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
         end
 
         context "when there are no convictions" do
-          before(:each) { transient_registration.declared_convictions = false }
+          before(:each) { transient_registration.declared_convictions = "no" }
 
           context "when the convictionSearchResults have no matches" do
             it "changes to :renewal_complete_form after the 'next' event" do
@@ -43,7 +43,7 @@ module WasteCarriersEngine
         end
 
         context "when there are convictions" do
-          before(:each) { transient_registration.declared_convictions = true }
+          before(:each) { transient_registration.declared_convictions = "yes" }
 
           it "changes to :renewal_received_form after the 'next' event" do
             expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_received_form).on_event(:next)

--- a/spec/requests/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
@@ -36,9 +36,9 @@ module WasteCarriersEngine
 
             context "when the tier change is because the business only deals with certain waste types" do
               before(:each) do
-                transient_registration.update_attributes(other_businesses: true,
-                                                         is_main_service: true,
-                                                         only_amf: true)
+                transient_registration.update_attributes(other_businesses: "yes",
+                                                         is_main_service: "yes",
+                                                         only_amf: "yes")
               end
 
               it "redirects to the waste_types form" do
@@ -49,8 +49,8 @@ module WasteCarriersEngine
 
             context "when the tier change is because the business doesn't deal with construction waste" do
               before(:each) do
-                transient_registration.update_attributes(other_businesses: false,
-                                                         construction_waste: false)
+                transient_registration.update_attributes(other_businesses: "no",
+                                                         construction_waste: "no")
               end
 
               it "redirects to the construction_demolition form" do

--- a/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
@@ -32,7 +32,7 @@ module WasteCarriersEngine
             end
 
             context "when the business doesn't carry waste for other businesses or households" do
-              before(:each) { transient_registration.update_attributes(other_businesses: false) }
+              before(:each) { transient_registration.update_attributes(other_businesses: "no") }
 
               it "redirects to the construction_demolition form" do
                 get back_cbd_type_forms_path(transient_registration[:reg_identifier])
@@ -42,8 +42,8 @@ module WasteCarriersEngine
 
             context "when the business carries waste produced by its customers" do
               before(:each) do
-                transient_registration.update_attributes(other_businesses: true,
-                                                         is_main_service: true)
+                transient_registration.update_attributes(other_businesses: "yes",
+                                                         is_main_service: "yes")
               end
 
               it "redirects to the waste_types form" do
@@ -54,8 +54,8 @@ module WasteCarriersEngine
 
             context "when the business carries waste for other businesses but produces that waste" do
               before(:each) do
-                transient_registration.update_attributes(other_businesses: true,
-                                                         is_main_service: false)
+                transient_registration.update_attributes(other_businesses: "yes",
+                                                         is_main_service: "no")
               end
 
               it "redirects to the construction_demolition form" do

--- a/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
@@ -6,10 +6,9 @@ module WasteCarriersEngine
 
     include_examples "POST form",
                      form = "construction_demolition_form",
-                     valid_params = { construction_waste: "true" },
+                     valid_params = { construction_waste: "yes" },
                      invalid_params = { construction_waste: "foo" },
-                     test_attribute = :construction_waste,
-                     expected_value = true
+                     test_attribute = :construction_waste
 
     describe "GET back_construction_demolition_forms_path" do
       context "when a valid user is signed in" do
@@ -33,7 +32,7 @@ module WasteCarriersEngine
             end
 
             context "when the business does not carry waste for other businesses or households" do
-              before(:each) { transient_registration.update_attributes(other_businesses: false) }
+              before(:each) { transient_registration.update_attributes(other_businesses: "no") }
 
               it "redirects to the other_businesses form" do
                 get back_construction_demolition_forms_path(transient_registration[:reg_identifier])
@@ -42,7 +41,7 @@ module WasteCarriersEngine
             end
 
             context "when the business does carry waste for other businesses or households" do
-              before(:each) { transient_registration.update_attributes(other_businesses: true) }
+              before(:each) { transient_registration.update_attributes(other_businesses: "yes") }
 
               it "redirects to the service_provided form" do
                 get back_construction_demolition_forms_path(transient_registration[:reg_identifier])

--- a/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -6,10 +6,9 @@ module WasteCarriersEngine
 
     include_examples "POST form",
                      form = "declare_convictions_form",
-                     valid_params = { declared_convictions: "true" },
+                     valid_params = { declared_convictions: "yes" },
                      invalid_params = { declared_convictions: "foo" },
-                     test_attribute = :declared_convictions,
-                     expected_value = true
+                     test_attribute = :declared_convictions
 
     describe "GET back_declare_convictions_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
@@ -6,10 +6,9 @@ module WasteCarriersEngine
 
     include_examples "POST form",
                      form = "other_businesses_form",
-                     valid_params = { other_businesses: "true" },
+                     valid_params = { other_businesses: "yes" },
                      invalid_params = { other_businesses: "foo" },
-                     test_attribute = :other_businesses,
-                     expected_value = true
+                     test_attribute = :other_businesses
 
     describe "GET back_other_businesses_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
@@ -6,10 +6,9 @@ module WasteCarriersEngine
 
     include_examples "POST form",
                      form = "service_provided_form",
-                     valid_params = { is_main_service: "true" },
+                     valid_params = { is_main_service: "yes" },
                      invalid_params = { is_main_service: "foo" },
-                     test_attribute = :is_main_service,
-                     expected_value = true
+                     test_attribute = :is_main_service
 
     describe "GET back_service_provided_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/tier_check_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/tier_check_forms_spec.rb
@@ -6,10 +6,9 @@ module WasteCarriersEngine
 
     include_examples "POST form",
                      form = "tier_check_form",
-                     valid_params = { temp_tier_check: "true" },
+                     valid_params = { temp_tier_check: "yes" },
                      invalid_params = { temp_tier_check: "foo" },
-                     test_attribute = :temp_tier_check,
-                     expected_value = true
+                     test_attribute = :temp_tier_check
 
     describe "GET back_tier_check_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
@@ -6,10 +6,9 @@ module WasteCarriersEngine
 
     include_examples "POST form",
                      form = "waste_types_form",
-                     valid_params = { only_amf: "true" },
+                     valid_params = { only_amf: "yes" },
                      invalid_params = { only_amf: "foo" },
-                     test_attribute = :only_amf,
-                     expected_value = true
+                     test_attribute = :only_amf
 
     describe "GET back_waste_types_forms_path" do
       context "when a valid user is signed in" do

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -75,7 +75,7 @@ module WasteCarriersEngine
 
             context "when it has been flagged for conviction checks" do
               before do
-                transient_registration.update_attributes(declared_convictions: true)
+                transient_registration.update_attributes(declared_convictions: "yes")
               end
 
               it "redirects to renewal_received_form" do

--- a/spec/support/shared_examples/validate_boolean.rb
+++ b/spec/support/shared_examples/validate_boolean.rb
@@ -3,10 +3,10 @@ RSpec.shared_examples "validate boolean" do |form_factory, field|
   context "when a valid transient registration exists" do
     let(:form) { build(form_factory, :has_required_data) }
 
-    context "when a value is true" do
+    context "when a value is yes" do
       before(:each) do
         # Using 'send' because we have to pass in a field name (for example, instead of form.value = ?)
-        form.send("#{field}=", true)
+        form.send("#{field}=", "yes")
       end
 
       it "is valid" do
@@ -14,10 +14,10 @@ RSpec.shared_examples "validate boolean" do |form_factory, field|
       end
     end
 
-    context "when a value is false" do
+    context "when a value is no" do
       before(:each) do
         # Using 'send' because we have to pass in a field name (for example, instead of form.value = ?)
-        form.send("#{field}=", false)
+        form.send("#{field}=", "no")
       end
 
       it "is valid" do
@@ -25,7 +25,7 @@ RSpec.shared_examples "validate boolean" do |form_factory, field|
       end
     end
 
-    context "when a value is not a boolean" do
+    context "when a value is not a valid string" do
       before(:each) do
         # Using 'send' because we have to pass in a field name (for example, instead of form.value = ?)
         form.send("#{field}=", "foo")

--- a/spec/support/shared_examples/validate_yes_no.rb
+++ b/spec/support/shared_examples/validate_yes_no.rb
@@ -1,5 +1,5 @@
-# Tests for fields using the BooleanValidator
-RSpec.shared_examples "validate boolean" do |form_factory, field|
+# Tests for fields using the YesNoValidator
+RSpec.shared_examples "validate yes no" do |form_factory, field|
   context "when a valid transient registration exists" do
     let(:form) { build(form_factory, :has_required_data) }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-419

If there are questions where there is a yes or no answer, like smart answers or "Do you have any declared convictions?" we've been saving the answer as a boolean value.

However, the old system saves them as a string - "yes" or "no".

So we have to update the renewals engine to save and validate these answers as strings instead (at least until we can fix our technical debt).