### PR TITLE
Add missing fields to model

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -41,6 +41,7 @@ module WasteCarriersEngine
       field :declaration,                                                   type: Integer # Unsure of type
       field :regIdentifier, as: :reg_identifier,                            type: String
       field :expires_on,                                                    type: DateTime
+      field :copy_cards,                                                    type: Integer
 
       def contact_address
         return nil unless addresses.present?

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -19,27 +19,28 @@ module WasteCarriersEngine
                                     :conviction_search_result,
                                     :conviction_sign_offs
 
-      field :uuid,                                            type: String
-      field :reg_uuid,                                        type: String # Used by waste-carriers-frontend
-      field :tier,                                            type: String
-      field :registrationType, as: :registration_type,        type: String
-      field :location,                                        type: String
-      field :businessType, as: :business_type,                type: String
-      field :otherBusinesses, as: :other_businesses,          type: Boolean
-      field :isMainService, as: :is_main_service,             type: Boolean
-      field :onlyAMF, as: :only_amf,                          type: Boolean
-      field :constructionWaste, as: :construction_waste,      type: Boolean
-      field :companyName, as: :company_name,                  type: String
-      field :companyNo, as: :company_no,                      type: String # Despite its name, this can include letters
-      field :firstName, as: :first_name,                      type: String
-      field :lastName, as: :last_name,                        type: String
-      field :phoneNumber, as: :phone_number,                  type: String
-      field :contactEmail, as: :contact_email,                type: String
-      field :accountEmail, as: :account_email,                type: String
-      field :declaredConvictions, as: :declared_convictions,  type: Boolean
-      field :declaration,                                     type: Integer # Unsure of type
-      field :regIdentifier, as: :reg_identifier,              type: String
-      field :expires_on,                                      type: DateTime
+      field :uuid,                                                          type: String
+      field :reg_uuid,                                                      type: String # Used by waste-carriers-frontend
+      field :originalRegistrationNumber, as: :original_registration_number, type: String # Used by waste-carriers-frontend
+      field :tier,                                                          type: String
+      field :registrationType, as: :registration_type,                      type: String
+      field :location,                                                      type: String
+      field :businessType, as: :business_type,                              type: String
+      field :otherBusinesses, as: :other_businesses,                        type: Boolean
+      field :isMainService, as: :is_main_service,                           type: Boolean
+      field :onlyAMF, as: :only_amf,                                        type: Boolean
+      field :constructionWaste, as: :construction_waste,                    type: Boolean
+      field :companyName, as: :company_name,                                type: String
+      field :companyNo, as: :company_no,                                    type: String # May include letters, despite name
+      field :firstName, as: :first_name,                                    type: String
+      field :lastName, as: :last_name,                                      type: String
+      field :phoneNumber, as: :phone_number,                                type: String
+      field :contactEmail, as: :contact_email,                              type: String
+      field :accountEmail, as: :account_email,                              type: String
+      field :declaredConvictions, as: :declared_convictions,                type: Boolean
+      field :declaration,                                                   type: Integer # Unsure of type
+      field :regIdentifier, as: :reg_identifier,                            type: String
+      field :expires_on,                                                    type: DateTime
 
       def contact_address
         return nil unless addresses.present?

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -20,6 +20,7 @@ module WasteCarriersEngine
                                     :conviction_sign_offs
 
       field :uuid,                                            type: String
+      field :reg_uuid,                                        type: String # Used by waste-carriers-frontend
       field :tier,                                            type: String
       field :registrationType, as: :registration_type,        type: String
       field :location,                                        type: String

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -97,7 +97,8 @@ module WasteCarriersEngine
                                                   "conviction_search_result",
                                                   "conviction_sign_offs",
                                                   "declaration",
-                                                  "past_registrations")
+                                                  "past_registrations",
+                                                  "copy_cards")
 
       assign_attributes(strip_whitespace(attributes))
       remove_invalid_attributes


### PR DESCRIPTION
There are some attributes which are used in waste-carriers-frontend that were missing from the engine. To keep the two systems in sync, we should allow these on the engine's registration model.