### PR TITLE
'Add another user' does not return user to person form

### DIFF
--- a/app/controllers/waste_carriers_engine/person_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/person_forms_controller.rb
@@ -1,7 +1,7 @@
 module WasteCarriersEngine
   class PersonFormsController < FormsController
     def create(form_class, form)
-      if params[:commit] == I18n.t("#{form}s.new.add_person_link")
+      if params[:commit] == I18n.t("waste_carriers_engine.#{form}s.new.add_person_link")
         submit_and_add_another(form_class, form)
       else
         super(form_class, form)

--- a/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -93,7 +93,7 @@ module WasteCarriersEngine
 
             context "when the submit params say to add another" do
               it "redirects to the conviction_details form" do
-                post conviction_details_forms_path, conviction_details_form: valid_params, commit: I18n.t("conviction_details_forms.new.add_person_link")
+                post conviction_details_forms_path, conviction_details_form: valid_params, commit: "Add another person"
                 expect(response).to redirect_to(new_conviction_details_form_path(transient_registration[:reg_identifier]))
               end
             end
@@ -137,7 +137,7 @@ module WasteCarriersEngine
 
             context "when the submit params say to add another" do
               it "returns a 302 response" do
-                post conviction_details_forms_path, conviction_details_form: invalid_params, commit: I18n.t("conviction_details_forms.new.add_person_link")
+                post conviction_details_forms_path, conviction_details_form: invalid_params, commit: "Add another person"
                 expect(response).to have_http_status(302)
               end
             end

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -129,7 +129,7 @@ module WasteCarriersEngine
 
             context "when the submit params say to add another" do
               it "redirects to the main_people form" do
-                post main_people_forms_path, main_people_form: valid_params, commit: I18n.t("main_people_forms.new.add_person_link")
+                post main_people_forms_path, main_people_form: valid_params, commit: "Add another person"
                 expect(response).to redirect_to(new_main_people_form_path(transient_registration[:reg_identifier]))
               end
             end
@@ -173,7 +173,7 @@ module WasteCarriersEngine
 
             context "when the submit params say to add another" do
               it "returns a 302 response" do
-                post main_people_forms_path, main_people_form: invalid_params, commit: I18n.t("main_people_forms.new.add_person_link")
+                post main_people_forms_path, main_people_form: invalid_params, commit: "Add another person"
                 expect(response).to have_http_status(302)
               end
             end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-414

When a user submits a person form with 'Add another user', the PersonController should redirect them back to the same form after saving. This is based on I18n text, which was changed when we namespaced everything for the engine and so broke. This commit fixes that.

The bug wasn't caught because we didn't update the I18n call in the controller and the spec, so both threw matching errors and then everything worked fine. To avoid this happening again, I've made the test more brittle by specifying the text it should expect.