### PR TITLE
Set metaData.route value in application config

### DIFF
--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -29,7 +29,7 @@ module WasteCarriersEngine
     def update_registration
       copy_data_from_transient_registration
       merge_finance_details
-      @registration.metaData.route = "DIGITAL"
+      @registration.metaData.route = Rails.configuration.metadata_route
       @registration.metaData.renew
       @registration.save!
     end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -77,6 +77,9 @@ module Dummy
     config.worldpay_password = ENV["WCRS_WORLDPAY_ECOM_PASSWORD"]
     config.worldpay_macsecret =  ENV["WCRS_WORLDPAY_ECOM_MACSECRET"]
 
+    # Digital or assisted digital metadata.Route value
+    config.metadata_route = "DIGITAL"
+
     # Version info
     config.application_version = "0.0.1".freeze
     config.application_name = "waste-carriers-renewals"

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -95,12 +95,7 @@ module WasteCarriersEngine
           expect(registration.reload.metaData.last_modified).to_not eq(old_last_modified)
         end
 
-        it "updates the registration's route" do
-          renewal_completion_service.complete_renewal
-          expect(registration.reload.metaData.route).to eq("DIGITAL")
-        end
-
-        context "when the meta_data route is set" do
+        context "when the metadata_route is set" do
           before do
             allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
           end

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -100,6 +100,17 @@ module WasteCarriersEngine
           expect(registration.reload.metaData.route).to eq("DIGITAL")
         end
 
+        context "when the meta_data route is set" do
+          before do
+            allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")
+          end
+
+          it "updates the registration's route to the correct value" do
+            renewal_completion_service.complete_renewal
+            expect(registration.reload.metaData.route).to eq("ASSISTED_DIGITAL")
+          end
+        end
+
         it "deletes the transient registration" do
           renewal_completion_service.complete_renewal
           expect(TransientRegistration.where(reg_identifier: transient_registration.reg_identifier).count).to eq(0)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-123

This is used to state whether the renewal was completed through the DIGITAL or ASSISTED_DIGITAL route. So we need to set that value in the host applications.