### PR TITLE
Set order.updated_by_user to current_user

### DIFF
--- a/app/controllers/waste_carriers_engine/bank_transfer_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/bank_transfer_forms_controller.rb
@@ -12,7 +12,7 @@ module WasteCarriersEngine
     private
 
     def set_up_finance_details
-      FinanceDetails.new_finance_details(@transient_registration, :bank_transfer)
+      FinanceDetails.new_finance_details(@transient_registration, :bank_transfer, current_user)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -45,7 +45,7 @@ module WasteCarriersEngine
     private
 
     def prepare_for_payment
-      FinanceDetails.new_finance_details(@transient_registration, :worldpay)
+      FinanceDetails.new_finance_details(@transient_registration, :worldpay, current_user)
       order = @transient_registration.finance_details.orders.first
       worldpay_service = WorldpayService.new(@transient_registration, order)
       worldpay_service.prepare_for_payment

--- a/app/models/waste_carriers_engine/finance_details.rb
+++ b/app/models/waste_carriers_engine/finance_details.rb
@@ -15,10 +15,10 @@ module WasteCarriersEngine
     validates :balance,
               presence: true
 
-    def self.new_finance_details(transient_registration, method)
+    def self.new_finance_details(transient_registration, method, current_user)
       finance_details = FinanceDetails.new
       finance_details.transient_registration = transient_registration
-      finance_details[:orders] = [Order.new_order(transient_registration, method)]
+      finance_details[:orders] = [Order.new_order(transient_registration, method, current_user)]
       finance_details.update_balance
       finance_details.save!
       finance_details

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -23,7 +23,7 @@ module WasteCarriersEngine
     field :manualOrder, as: :manual_order,           type: String
     field :order_item_reference,                     type: String
 
-    def self.new_order(transient_registration, method)
+    def self.new_order(transient_registration, method, current_user)
       order = Order.new
 
       card_count = transient_registration.temp_cards
@@ -34,7 +34,7 @@ module WasteCarriersEngine
 
       order[:date_created] = Time.current
       order[:date_last_updated] = order[:date_created]
-      order[:updated_by_user] = transient_registration.account_email
+      order[:updated_by_user] = current_user.email
 
       order[:order_items] = [OrderItem.new_renewal_item]
       order[:order_items] << OrderItem.new_type_change_item if transient_registration.registration_type_changed?

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     trait :has_finance_details do
       after(:build, :create) do |transient_registration|
-        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay)
+        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, build(:user))
       end
     end
 

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -9,9 +9,10 @@ module WasteCarriersEngine
     end
 
     let(:transient_registration) { build(:transient_registration, :has_required_data, temp_cards: 0) }
+    let(:current_user) { build(:user) }
 
     describe "new_finance_details" do
-      let(:finance_details) { FinanceDetails.new_finance_details(transient_registration, :worldpay) }
+      let(:finance_details) { FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user) }
 
       it "should include 1 order" do
         order_count = finance_details.orders.length
@@ -37,7 +38,7 @@ module WasteCarriersEngine
 
       context "when there is an order" do
         before do
-          finance_details.orders = [Order.new_order(transient_registration, :worldpay)]
+          finance_details.orders = [Order.new_order(transient_registration, :worldpay, current_user)]
         end
 
         it "should have the correct balance" do

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -10,9 +10,10 @@ module WasteCarriersEngine
     end
 
     let(:transient_registration) { create(:transient_registration, :has_required_data, temp_cards: 0) }
+    let(:current_user) { build(:user) }
 
     describe "new_order" do
-      let(:order) { Order.new_order(transient_registration, :worldpay) }
+      let(:order) { Order.new_order(transient_registration, :worldpay, current_user) }
 
       it "should have a valid order_id" do
         Timecop.freeze(Time.new(2018, 1, 1)) do
@@ -34,7 +35,7 @@ module WasteCarriersEngine
       end
 
       it "should have the correct updated_by_user" do
-        expect(order.updated_by_user).to eq("foo@example.com")
+        expect(order.updated_by_user).to eq(current_user.email)
       end
 
       it "updates the date_created" do
@@ -120,7 +121,7 @@ module WasteCarriersEngine
       end
 
       context "when it is a bank transfer order" do
-        let(:order) { Order.new_order(transient_registration, :bank_transfer) }
+        let(:order) { Order.new_order(transient_registration, :bank_transfer, current_user) }
 
         it "should have the correct payment_method" do
           expect(order.payment_method).to eq("OFFLINE")
@@ -137,7 +138,7 @@ module WasteCarriersEngine
     end
 
     describe "update_after_worldpay" do
-      let(:finance_details) { FinanceDetails.new_finance_details(transient_registration, :worldpay) }
+      let(:finance_details) { FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user) }
       let(:order) { finance_details.orders.first }
 
       it "copies the worldpay status to the order" do

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe Payment, type: :model do
     let(:transient_registration) { build(:transient_registration, :has_required_data) }
+    let(:current_user) { build(:user) }
 
     describe "new_from_worldpay" do
       before do
         Timecop.freeze(Time.new(2018, 1, 1)) do
-          FinanceDetails.new_finance_details(transient_registration, :worldpay)
+          FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
         end
       end
 
@@ -49,7 +50,7 @@ module WasteCarriersEngine
 
       before do
         Timecop.freeze(Time.new(2018, 3, 4)) do
-          FinanceDetails.new_finance_details(transient_registration, :worldpay)
+          FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
           payment.update_after_worldpay(paymentStatus: "AUTHORISED", mac: "foo")
         end
       end

--- a/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
@@ -26,7 +26,7 @@ module WasteCarriersEngine
 
           context "when a worldpay order already exists" do
             before do
-              FinanceDetails.new_finance_details(transient_registration, :worldpay)
+              FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
               transient_registration.finance_details.orders.first.world_pay_status = "CANCELLED"
             end
 

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -49,7 +49,7 @@ module WasteCarriersEngine
 
         describe "#success" do
           before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay)
+            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
           end
 
           let(:order) do
@@ -116,7 +116,7 @@ module WasteCarriersEngine
 
         describe "#failure" do
           before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay)
+            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
           end
 
           let(:order) do

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -15,7 +15,8 @@ module WasteCarriersEngine
     let(:renewal_completion_service) { RenewalCompletionService.new(transient_registration) }
 
     before do
-      FinanceDetails.new_finance_details(transient_registration, :worldpay)
+      current_user = build(:user)
+      FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
       Payment.new_from_worldpay(transient_registration.finance_details.orders.first)
       registration.update_attributes(finance_details: build(:finance_details,
                                                             :has_required_data,

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -13,7 +13,8 @@ module WasteCarriersEngine
     before do
       allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
 
-      WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay)
+      user = build(:user)
+      WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
     end
 
     let(:order) { transient_registration.finance_details.orders.first }

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -16,9 +16,10 @@ module WasteCarriersEngine
       allow(Rails.configuration).to receive(:worldpay_macsecret).and_return("5r2zsonhn2t69s1q9jsub90l0ljrs59r")
       allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
 
+      current_user = build(:user)
       # We need to set a specific time so we know what order code to expect
       Timecop.freeze(Time.new(2018, 1, 1)) do
-        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay)
+        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-123

Currently this just reuses the account_email for the registration. However, in AD, the current_user would be a different user than the one who owns the registration, so we should correctly record who has modified it.