### PR TITLE
Add method to check if person requires conviction check

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -83,10 +83,12 @@ module WasteCarriersEngine
       def key_person_has_matching_or_unknown_conviction?
         return true unless key_people.present?
 
-        conviction_search_results = key_people.map(&:conviction_search_result)
-        match_results = conviction_search_results.map(&:match_result)
+        matches = false
+        key_people.each do |person|
+          matches = true if person.conviction_check_required?
+        end
 
-        match_results.include?("YES") || match_results.include?("UNKNOWN")
+        matches
       end
 
       def update_last_modified

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -82,13 +82,8 @@ module WasteCarriersEngine
 
       def key_person_has_matching_or_unknown_conviction?
         return true unless key_people.present?
-
-        matches = false
-        key_people.each do |person|
-          matches = true if person.conviction_check_required?
-        end
-
-        matches
+        all_requirements = key_people.map(&:conviction_check_required?)
+        all_requirements.include?(true)
       end
 
       def update_last_modified

--- a/app/models/waste_carriers_engine/key_person.rb
+++ b/app/models/waste_carriers_engine/key_person.rb
@@ -19,6 +19,12 @@ module WasteCarriersEngine
     field :dob,         type: DateTime
     field :person_type, type: String
 
+    def conviction_check_required?
+      return false unless conviction_search_result.present?
+      return false if conviction_search_result.match_result == "NO"
+      true
+    end
+
     private
 
     def set_date_of_birth

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -39,5 +39,9 @@ FactoryBot.define do
     trait :unmatched_conviction_search_result do
       conviction_search_result { build(:conviction_search_result, :match_result_no) }
     end
+
+    trait :unknown_conviction_search_result do
+      conviction_search_result { build(:conviction_search_result, :match_result_unknown) }
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/key_person_spec.rb
+++ b/spec/models/waste_carriers_engine/key_person_spec.rb
@@ -23,5 +23,45 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "conviction_check_required?" do
+      context "when there is no conviction_search_result" do
+        let(:key_person) { build(:key_person, :has_required_data) }
+
+        it "returns false" do
+          expect(key_person.conviction_check_required?).to eq(false)
+        end
+      end
+
+      context "when there is a matching conviction_search_result" do
+        let(:key_person) { build(:key_person,
+                                 :has_required_data,
+                                 :matched_conviction_search_result) }
+
+        it "returns true" do
+          expect(key_person.conviction_check_required?).to eq(true)
+        end
+      end
+
+      context "when there is a non-matching conviction_search_result" do
+        let(:key_person) { build(:key_person,
+                                 :has_required_data,
+                                 :unmatched_conviction_search_result) }
+
+        it "returns false" do
+          expect(key_person.conviction_check_required?).to eq(false)
+        end
+      end
+
+      context "when there is an unknwon conviction_search_result" do
+        let(:key_person) { build(:key_person,
+                                 :has_required_data,
+                                 :unknown_conviction_search_result) }
+
+        it "returns true" do
+          expect(key_person.conviction_check_required?).to eq(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is mostly to support https://github.com/DEFRA/waste-carriers-back-office/pull/68, but also allows us to move logic for checking if a person may have a matching result out of the registration concern and into the key person model, which is a better fit.