### PR TITLE
Set payment.updated_by_user to current_user

### DIFF
--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -47,7 +47,7 @@ module WasteCarriersEngine
     def prepare_for_payment
       FinanceDetails.new_finance_details(@transient_registration, :worldpay, current_user)
       order = @transient_registration.finance_details.orders.first
-      worldpay_service = WorldpayService.new(@transient_registration, order)
+      worldpay_service = WorldpayService.new(@transient_registration, order, current_user)
       worldpay_service.prepare_for_payment
     end
 
@@ -71,12 +71,12 @@ module WasteCarriersEngine
     end
 
     def valid_worldpay_success_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, params)
+      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
       worldpay_service.valid_success?
     end
 
     def valid_worldpay_failure_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, params)
+      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
       worldpay_service.valid_failure?
     end
   end

--- a/app/models/waste_carriers_engine/payment.rb
+++ b/app/models/waste_carriers_engine/payment.rb
@@ -20,7 +20,7 @@ module WasteCarriersEngine
     field :paymentType, as: :payment_type,                        type: String
     field :manualPayment, as: :manual_payment,                    type: String
 
-    def self.new_from_worldpay(order)
+    def self.new_from_worldpay(order, current_user)
       payment = Payment.new
 
       payment[:order_key] = order[:order_code]
@@ -29,7 +29,7 @@ module WasteCarriersEngine
       payment[:payment_type] = "WORLDPAY"
       payment[:registration_reference] = "Worldpay"
       payment[:comment] = "Paid via Worldpay"
-      payment[:updated_by_user] = order.finance_details.transient_registration.account_email
+      payment[:updated_by_user] = current_user.email
       payment.finance_details = order.finance_details
 
       payment

--- a/app/services/waste_carriers_engine/worldpay_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_service.rb
@@ -2,13 +2,14 @@ require "rest-client"
 
 module WasteCarriersEngine
   class WorldpayService
-    def initialize(transient_registration, order, params = nil)
+    def initialize(transient_registration, order, current_user, params = nil)
       @transient_registration = transient_registration
       @order = order
       @url = Rails.configuration.worldpay_url
       @username = Rails.configuration.worldpay_username
       @password = Rails.configuration.worldpay_password
       @params = prepare_params(params)
+      @current_user = current_user
     end
 
     def prepare_for_payment
@@ -94,11 +95,11 @@ module WasteCarriersEngine
     end
 
     def new_payment_object(order)
-      Payment.new_from_worldpay(order)
+      Payment.new_from_worldpay(order, @current_user)
     end
 
     def update_saved_data
-      payment = Payment.new_from_worldpay(@order)
+      payment = Payment.new_from_worldpay(@order, @current_user)
       payment.update_after_worldpay(@params)
       @order.update_after_worldpay(@params[:paymentStatus])
 

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
       end
 
       let(:order) { transient_registration.finance_details.orders.first }
-      let(:payment) { Payment.new_from_worldpay(order) }
+      let(:payment) { Payment.new_from_worldpay(order, current_user) }
 
       it "should set the correct order_key" do
         expect(payment.order_key).to eq("1514764800")
@@ -36,7 +36,7 @@ module WasteCarriersEngine
       end
 
       it "should have the correct updated_by_user" do
-        expect(payment.updated_by_user).to eq("foo@example.com")
+        expect(payment.updated_by_user).to eq(current_user.email)
       end
 
       it "should set the correct comment" do
@@ -46,7 +46,7 @@ module WasteCarriersEngine
 
     describe "update_after_worldpay" do
       let(:order) { transient_registration.finance_details.orders.first }
-      let(:payment) { Payment.new_from_worldpay(order) }
+      let(:payment) { Payment.new_from_worldpay(order, current_user) }
 
       before do
         Timecop.freeze(Time.new(2018, 3, 4)) do

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -17,7 +17,7 @@ module WasteCarriersEngine
     before do
       current_user = build(:user)
       FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
-      Payment.new_from_worldpay(transient_registration.finance_details.orders.first)
+      Payment.new_from_worldpay(transient_registration.finance_details.orders.first, current_user)
       registration.update_attributes(finance_details: build(:finance_details,
                                                             :has_required_data,
                                                             :has_order_and_payment))

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -9,18 +9,18 @@ module WasteCarriersEngine
              :has_finance_details,
              temp_cards: 0)
     end
+    let(:current_user) { build(:user) }
 
     before do
       allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
 
-      user = build(:user)
-      WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+      WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
     end
 
     let(:order) { transient_registration.finance_details.orders.first }
     let(:params) {}
 
-    let(:worldpay_service) { WorldpayService.new(transient_registration, order, params) }
+    let(:worldpay_service) { WorldpayService.new(transient_registration, order, current_user, params) }
 
     describe "prepare_params" do
       context "when the params are nil" do


### PR DESCRIPTION
This previously just used the account email for the registration, but if the renewal is done through an assisted digital route, that won't be accurate. So we should use the current_user's email instead.

We fixed this issue for orders in https://github.com/DEFRA/waste-carriers-renewals/pull/237, but it turns out to affect payments as well.