### PR TITLE
Addresses don't allow firstName and lastName attributes

### DIFF
--- a/app/models/waste_carriers_engine/address.rb
+++ b/app/models/waste_carriers_engine/address.rb
@@ -28,6 +28,8 @@ module WasteCarriersEngine
     field :northing,                                                    type: Integer
     field :firstOrOnlyEasting, as: :first_or_only_easting,              type: Integer
     field :firstOrOnlyNorthing, as: :first_or_only_northing,            type: Integer
+    field :firstName, as: :first_name,                                  type: String
+    field :lastName, as: :last_name,                                    type: String
 
     def self.create_from_manual_entry(params, overseas)
       address = Address.new

--- a/app/services/waste_carriers_engine/renewal_completion_service.rb
+++ b/app/services/waste_carriers_engine/renewal_completion_service.rb
@@ -7,6 +7,7 @@ module WasteCarriersEngine
 
     def complete_renewal
       return :error unless valid_renewal?
+      copy_names_to_contact_address
       create_past_registration
       update_registration
       delete_transient_registration
@@ -20,6 +21,11 @@ module WasteCarriersEngine
 
     def valid_renewal?
       @registration.metaData.may_renew?
+    end
+
+    def copy_names_to_contact_address
+      @transient_registration.contact_address.first_name = @transient_registration.first_name
+      @transient_registration.contact_address.last_name = @transient_registration.last_name
     end
 
     def create_past_registration

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -96,6 +96,18 @@ module WasteCarriersEngine
           expect(registration.reload.metaData.last_modified).to_not eq(old_last_modified)
         end
 
+        it "copies the first_name to the contact address" do
+          first_name = transient_registration.first_name
+          renewal_completion_service.complete_renewal
+          expect(registration.reload.contact_address.first_name).to eq(first_name)
+        end
+
+        it "copies the last_name to the contact address" do
+          last_name = transient_registration.last_name
+          renewal_completion_service.complete_renewal
+          expect(registration.reload.contact_address.last_name).to eq(last_name)
+        end
+
         context "when the metadata_route is set" do
           before do
             allow(Rails.configuration).to receive(:metadata_route).and_return("ASSISTED_DIGITAL")


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-433

In waste-carriers-frontend, the firstName and lastName attributes are stored against the registration - however we also store them against the postal address. The engine doesn't allow this, which means it runs into issues when attempting to use addresses from the old system (for example, when updating a newly renewed registration).

We should allow these attributes to unblock renewals, but also make sure that we copy the firstName and lastName fields onto the postal address before renewing, so that we don't break any systems that rely on them (like mail merges).
