### PR TITLE
Upcase person_type to match existing schema

### DIFF
--- a/app/forms/waste_carriers_engine/person_form.rb
+++ b/app/forms/waste_carriers_engine/person_form.rb
@@ -57,7 +57,7 @@ module WasteCarriersEngine
                              dob_day: dob_day,
                              dob_month: dob_month,
                              dob_year: dob_year,
-                             person_type: person_type)
+                             person_type: person_type.upcase)
       person.position = position if position?
 
       person

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -61,12 +61,12 @@ module WasteCarriersEngine
 
       def main_people
         return [] unless key_people.present?
-        key_people.where(person_type: "key")
+        key_people.where(person_type: "KEY")
       end
 
       def relevant_people
         return [] unless key_people.present?
-        key_people.where(person_type: "relevant")
+        key_people.where(person_type: "RELEVANT")
       end
 
       def conviction_check_required?

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -13,11 +13,11 @@ FactoryBot.define do
     end
 
     trait :main do
-      person_type "key"
+      person_type "KEY"
     end
 
     trait :relevant do
-      person_type "relevant"
+      person_type "RELEVANT"
     end
 
     trait :has_matching_conviction do

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -20,9 +20,9 @@ module WasteCarriersEngine
           expect(conviction_details_form.submit(valid_params)).to eq(true)
         end
 
-        it "should set a person_type of 'relevant'" do
+        it "should set a person_type of 'RELEVANT'" do
           conviction_details_form.submit(valid_params)
-          expect(conviction_details_form.new_person.person_type).to eq("relevant")
+          expect(conviction_details_form.new_person.person_type).to eq("RELEVANT")
         end
       end
 

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -19,9 +19,9 @@ module WasteCarriersEngine
           expect(main_people_form.submit(valid_params)).to eq(true)
         end
 
-        it "should set a person_type of 'key'" do
+        it "should set a person_type of 'KEY'" do
           main_people_form.submit(valid_params)
-          expect(main_people_form.new_person.person_type).to eq("key")
+          expect(main_people_form.new_person.person_type).to eq("KEY")
         end
       end
 


### PR DESCRIPTION
We were storing a key_person's person_type in lowercase. However, the Java service expects it to be in uppercase, and is case-sensitive. This commit fixes the person_type so it should now be compatible.