### PR TITLE
Update last_modified before saving, not validation

### DIFF
--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -10,7 +10,7 @@ module WasteCarriersEngine
     accepts_nested_attributes_for :past_registrations
 
     before_validation :generate_reg_identifier, on: :create
-    before_validation :update_last_modified
+    before_save :update_last_modified
 
     validates :reg_identifier,
               :addresses,

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -13,7 +13,7 @@ module WasteCarriersEngine
     validate :no_renewal_in_progress?, on: :create
 
     after_initialize :copy_data_from_registration
-    before_validation :update_last_modified
+    before_save :update_last_modified
 
     # Attributes specific to the transient object - all others are in CanHaveRegistrationAttributes
     field :temp_cards, type: Integer


### PR DESCRIPTION
Came across this issue while working on ordering in-progress renewals for WC-374. We call validations on registrations and transient_registrations on some occasions other than saving, which means that the last_modified field was being updated too often. Those changes weren't always saved, but they did cause problems when it came to ordering transient_registrations. So we should only update this field when we are actually modifying the object in the DB.