### PR TITLE
Add helper methods to determine status of transient_registration

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -75,6 +75,19 @@ module WasteCarriersEngine
       old_company_no != company_no
     end
 
+    def renewal_application_submitted?
+      not_in_progress_states = %w[renewal_received_form renewal_complete_form]
+      not_in_progress_states.include?(workflow_state)
+    end
+
+    def pending_payment?
+      renewal_application_submitted? && finance_details.present? && finance_details.balance.positive?
+    end
+
+    def pending_manual_conviction_check?
+      renewal_application_submitted? && conviction_check_required?
+    end
+
     private
 
     def copy_data_from_registration


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-374

In the back office, users need to be able to tell where a renewal is in the process and what actions are required to complete it. We started building in some of these checks in the back office, but actually it makes more sense to attach them directly to the object we are checking the status of.