### PR TITLE
Update deprecated static attributes in factories

### DIFF
--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,32 +1,32 @@
 FactoryBot.define do
   factory :address, class: WasteCarriersEngine::Address do
     trait :has_required_data do
-      house_number "42"
-      address_line_1 "Foo Gardens"
-      town_city "Baz City"
-      postcode "FA1 1KE"
-      uprn "340116"
+      house_number { "42" }
+      address_line_1 { "Foo Gardens" }
+      town_city { "Baz City" }
+      postcode { "FA1 1KE" }
+      uprn { "340116" }
     end
 
     trait :contact do
-      address_type "POSTAL"
+      address_type { "POSTAL" }
     end
 
     trait :registered do
-      address_type "REGISTERED"
+      address_type { "REGISTERED" }
     end
 
     trait :from_os_places do
-      address_mode "address-results"
+      address_mode { "address-results" }
     end
 
     trait :manual_uk do
-      address_mode "manual-uk"
+      address_mode { "manual-uk" }
     end
 
     trait :manual_foreign do
-      address_mode "manual-foreign"
-      country "Slovakia"
+      address_mode { "manual-foreign" }
+      country { "Slovakia" }
     end
   end
 end

--- a/spec/factories/conviction_search_result.rb
+++ b/spec/factories/conviction_search_result.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :conviction_search_result, class: WasteCarriersEngine::ConvictionSearchResult do
     trait :match_result_yes do
-      match_result "YES"
+      match_result { "YES" }
     end
 
     trait :match_result_no do
-      match_result "NO"
+      match_result { "NO" }
     end
 
     trait :match_result_unknown do
-      match_result "UNKNOWN"
+      match_result { "UNKNOWN" }
     end
   end
 end

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :finance_details, class: WasteCarriersEngine::FinanceDetails do
     trait :has_required_data do
-      balance 10_000
+      balance { 10_000 }
       orders {[]}
       payments {[]}
     end

--- a/spec/factories/forms/cards_form.rb
+++ b/spec/factories/forms/cards_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :cards_form, class: WasteCarriersEngine::CardsForm do
     trait :has_required_data do
-      temp_cards 1
+      temp_cards { 1 }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "cards_form")) }
     end

--- a/spec/factories/forms/company_address_form.rb
+++ b/spec/factories/forms/company_address_form.rb
@@ -1,31 +1,33 @@
 FactoryBot.define do
   factory :company_address_form, class: WasteCarriersEngine::CompanyAddressForm do
     trait :has_required_data do
-      temp_address "340116"
-      temp_addresses [{
-        "moniker" => "340116",
-        "uprn" => "340116",
-        "lines" => ["NATURAL ENGLAND", "DEANERY ROAD"],
-        "town" => "BRISTOL",
-        "postcode" => "BS1 5AH",
-        "easting" => "358205",
-        "northing" => "172708",
-        "country" => "",
-        "dependentLocality" => "",
-        "dependentThroughfare" => "",
-        "administrativeArea" => "BRISTOL",
-        "localAuthorityUpdateDate" => "",
-        "royalMailUpdateDate" => "",
-        "partial" => "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
-        "subBuildingName" => "",
-        "buildingName" => "HORIZON HOUSE",
-        "thoroughfareName" => "DEANERY ROAD",
-        "organisationName" => "NATURAL ENGLAND",
-        "buildingNumber" => "",
-        "postOfficeBoxNumber" => "",
-        "departmentName" => "",
-        "doubleDependentLocality" => ""
-      }]
+      temp_address { "340116" }
+      temp_addresses do
+        [{
+          "moniker" => "340116",
+          "uprn" => "340116",
+          "lines" => ["NATURAL ENGLAND", "DEANERY ROAD"],
+          "town" => "BRISTOL",
+          "postcode" => "BS1 5AH",
+          "easting" => "358205",
+          "northing" => "172708",
+          "country" => "",
+          "dependentLocality" => "",
+          "dependentThroughfare" => "",
+          "administrativeArea" => "BRISTOL",
+          "localAuthorityUpdateDate" => "",
+          "royalMailUpdateDate" => "",
+          "partial" => "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
+          "subBuildingName" => "",
+          "buildingName" => "HORIZON HOUSE",
+          "thoroughfareName" => "DEANERY ROAD",
+          "organisationName" => "NATURAL ENGLAND",
+          "buildingNumber" => "",
+          "postOfficeBoxNumber" => "",
+          "departmentName" => "",
+          "doubleDependentLocality" => ""
+        }]
+      end
 
       addresses { [build(:address, :has_required_data, :registered)] }
 

--- a/spec/factories/forms/company_address_manual_form.rb
+++ b/spec/factories/forms/company_address_manual_form.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :company_address_manual_form, class: WasteCarriersEngine::CompanyAddressManualForm do
     trait :has_required_data do
-      house_number "Business Building"
-      address_line_1 "Foo Terrace"
-      address_line_2 "Bar Street"
-      town_city "Bazville"
-      postcode "12345"
-      country "FooBarBaz"
+      house_number { "Business Building" }
+      address_line_1 { "Foo Terrace" }
+      address_line_2 { "Bar Street" }
+      town_city { "Bazville" }
+      postcode { "12345" }
+      country { "FooBarBaz" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "company_address_manual_form")) }
     end

--- a/spec/factories/forms/company_postcode_form.rb
+++ b/spec/factories/forms/company_postcode_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :company_postcode_form, class: WasteCarriersEngine::CompanyPostcodeForm do
     trait :has_required_data do
-      temp_company_postcode "BS1 5AH"
+      temp_company_postcode { "BS1 5AH" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "company_postcode_form")) }
     end

--- a/spec/factories/forms/construction_demolition_form.rb
+++ b/spec/factories/forms/construction_demolition_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :construction_demolition_form, class: WasteCarriersEngine::ConstructionDemolitionForm do
     trait :has_required_data do
-      construction_waste "yes"
+      construction_waste { "yes" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "construction_demolition_form")) }
     end

--- a/spec/factories/forms/contact_address_form.rb
+++ b/spec/factories/forms/contact_address_form.rb
@@ -1,31 +1,33 @@
 FactoryBot.define do
   factory :contact_address_form, class: WasteCarriersEngine::ContactAddressForm do
     trait :has_required_data do
-      temp_address "340116"
-      temp_addresses [{
-        "moniker" => "340116",
-        "uprn" => "340116",
-        "lines" => ["NATURAL ENGLAND", "DEANERY ROAD"],
-        "town" => "BRISTOL",
-        "postcode" => "BS1 5AH",
-        "easting" => "358205",
-        "northing" => "172708",
-        "country" => "",
-        "dependentLocality" => "",
-        "dependentThroughfare" => "",
-        "administrativeArea" => "BRISTOL",
-        "localAuthorityUpdateDate" => "",
-        "royalMailUpdateDate" => "",
-        "partial" => "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
-        "subBuildingName" => "",
-        "buildingName" => "HORIZON HOUSE",
-        "thoroughfareName" => "DEANERY ROAD",
-        "organisationName" => "NATURAL ENGLAND",
-        "buildingNumber" => "",
-        "postOfficeBoxNumber" => "",
-        "departmentName" => "",
-        "doubleDependentLocality" => ""
-      }]
+      temp_address { "340116" }
+      temp_addresses do
+        [{
+          "moniker" => "340116",
+          "uprn" => "340116",
+          "lines" => ["NATURAL ENGLAND", "DEANERY ROAD"],
+          "town" => "BRISTOL",
+          "postcode" => "BS1 5AH",
+          "easting" => "358205",
+          "northing" => "172708",
+          "country" => "",
+          "dependentLocality" => "",
+          "dependentThroughfare" => "",
+          "administrativeArea" => "BRISTOL",
+          "localAuthorityUpdateDate" => "",
+          "royalMailUpdateDate" => "",
+          "partial" => "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
+          "subBuildingName" => "",
+          "buildingName" => "HORIZON HOUSE",
+          "thoroughfareName" => "DEANERY ROAD",
+          "organisationName" => "NATURAL ENGLAND",
+          "buildingNumber" => "",
+          "postOfficeBoxNumber" => "",
+          "departmentName" => "",
+          "doubleDependentLocality" => ""
+        }]
+      end
 
       addresses { [build(:address, :has_required_data, :contact)] }
 

--- a/spec/factories/forms/contact_address_manual_form.rb
+++ b/spec/factories/forms/contact_address_manual_form.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :contact_address_manual_form, class: WasteCarriersEngine::ContactAddressManualForm do
     trait :has_required_data do
-      house_number "Business Building"
-      address_line_1 "Foo Terrace"
-      address_line_2 "Bar Street"
-      town_city "Bazville"
-      postcode "12345"
-      country "FooBarBaz"
+      house_number { "Business Building" }
+      address_line_1 { "Foo Terrace" }
+      address_line_2 { "Bar Street" }
+      town_city { "Bazville" }
+      postcode { "12345" }
+      country { "FooBarBaz" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_address_manual_form")) }
     end

--- a/spec/factories/forms/contact_email_form.rb
+++ b/spec/factories/forms/contact_email_form.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :contact_email_form, class: WasteCarriersEngine::ContactEmailForm do
     trait :has_required_data do
-      contact_email "foo@example.com"
-      confirmed_email "foo@example.com"
+      contact_email { "foo@example.com" }
+      confirmed_email { "foo@example.com" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_email_form")) }
     end

--- a/spec/factories/forms/contact_name_form.rb
+++ b/spec/factories/forms/contact_name_form.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :contact_name_form, class: WasteCarriersEngine::ContactNameForm do
     trait :has_required_data do
-      first_name "Anne"
-      last_name "Edwards"
+      first_name { "Anne" }
+      last_name { "Edwards" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_name_form")) }
     end

--- a/spec/factories/forms/contact_phone_form.rb
+++ b/spec/factories/forms/contact_phone_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :contact_phone_form, class: WasteCarriersEngine::ContactPhoneForm do
     trait :has_required_data do
-      phone_number "03708 506 506"
+      phone_number { "03708 506 506" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_phone_form")) }
     end

--- a/spec/factories/forms/contact_postcode_form.rb
+++ b/spec/factories/forms/contact_postcode_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :contact_postcode_form, class: WasteCarriersEngine::ContactPostcodeForm do
     trait :has_required_data do
-      temp_contact_postcode "BS1 5AH"
+      temp_contact_postcode { "BS1 5AH" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "contact_postcode_form")) }
     end

--- a/spec/factories/forms/conviction_details_form.rb
+++ b/spec/factories/forms/conviction_details_form.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :conviction_details_form, class: WasteCarriersEngine::ConvictionDetailsForm do
     trait :has_required_data do
-      first_name "Foo"
-      last_name "Bar"
-      position "Baz"
-      dob_year 2000
-      dob_month 1
-      dob_day 1
-      dob Date.new(2000, 1, 1)
+      first_name { "Foo" }
+      last_name { "Bar" }
+      position { "Baz" }
+      dob_year { 2000 }
+      dob_month { 1 }
+      dob_day { 1 }
+      dob { Date.new(2000, 1, 1) }
 
       initialize_with { new(create(:transient_registration, :has_required_data, :declared_convictions, workflow_state: "conviction_details_form")) }
     end

--- a/spec/factories/forms/declaration_form.rb
+++ b/spec/factories/forms/declaration_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :declaration_form, class: WasteCarriersEngine::DeclarationForm do
     trait :has_required_data do
-      declaration 1
+      declaration { 1 }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "declaration_form")) }
     end

--- a/spec/factories/forms/declare_convictions_form.rb
+++ b/spec/factories/forms/declare_convictions_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :declare_convictions_form, class: WasteCarriersEngine::DeclareConvictionsForm do
     trait :has_required_data do
-      declared_convictions "no"
+      declared_convictions { "no" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "declare_convictions_form")) }
     end

--- a/spec/factories/forms/location_form.rb
+++ b/spec/factories/forms/location_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :location_form, class: WasteCarriersEngine::LocationForm do
     trait :has_required_data do
-      location "england"
+      location { "england" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "location_form")) }
     end

--- a/spec/factories/forms/main_people_form.rb
+++ b/spec/factories/forms/main_people_form.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :main_people_form, class: WasteCarriersEngine::MainPeopleForm do
     trait :has_required_data do
-      first_name "Foo"
-      last_name "Bar"
-      dob_year 2000
-      dob_month 1
-      dob_day 1
-      dob Date.new(2000, 1, 1)
+      first_name { "Foo" }
+      last_name { "Bar" }
+      dob_year { 2000 }
+      dob_month { 1 }
+      dob_day { 1 }
+      dob { Date.new(2000, 1, 1) }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "main_people_form")) }
     end

--- a/spec/factories/forms/other_businesses_form.rb
+++ b/spec/factories/forms/other_businesses_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :other_businesses_form, class: WasteCarriersEngine::OtherBusinessesForm do
     trait :has_required_data do
-      other_businesses "yes"
+      other_businesses { "yes" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "other_businesses_form")) }
     end

--- a/spec/factories/forms/payment_summary_form.rb
+++ b/spec/factories/forms/payment_summary_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :payment_summary_form, class: WasteCarriersEngine::PaymentSummaryForm do
     trait :has_required_data do
-      temp_payment_method "card"
+      temp_payment_method { "card" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "payment_summary_form")) }
     end

--- a/spec/factories/forms/service_provided_form.rb
+++ b/spec/factories/forms/service_provided_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :service_provided_form, class: WasteCarriersEngine::ServiceProvidedForm do
     trait :has_required_data do
-      is_main_service "yes"
+      is_main_service { "yes" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "service_provided_form")) }
     end

--- a/spec/factories/forms/tier_check_form.rb
+++ b/spec/factories/forms/tier_check_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :tier_check_form, class: WasteCarriersEngine::TierCheckForm do
     trait :has_required_data do
-      temp_tier_check "no"
+      temp_tier_check { "no" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "tier_check_form")) }
     end

--- a/spec/factories/forms/waste_types_form.rb
+++ b/spec/factories/forms/waste_types_form.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :waste_types_form, class: WasteCarriersEngine::WasteTypesForm do
     trait :has_required_data do
-      only_amf "yes"
+      only_amf { "yes" }
 
       initialize_with { new(create(:transient_registration, :has_required_data, workflow_state: "waste_types_form")) }
     end

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -1,32 +1,32 @@
 FactoryBot.define do
   factory :key_person, class: WasteCarriersEngine::KeyPerson do
     trait :has_required_data do
-      first_name "Kate"
-      last_name "Franklin"
-      position "Director"
-      dob_day 1
-      dob_month 1
-      dob_year 2000
+      first_name { "Kate" }
+      last_name { "Franklin" }
+      position { "Director" }
+      dob_day { 1 }
+      dob_month { 1 }
+      dob_year { 2000 }
 
       # Initialise with attributes so we can set the date of birth
       initialize_with { new(attributes) }
     end
 
     trait :main do
-      person_type "KEY"
+      person_type { "KEY" }
     end
 
     trait :relevant do
-      person_type "RELEVANT"
+      person_type { "RELEVANT" }
     end
 
     trait :has_matching_conviction do
-      first_name "Fred"
-      last_name "Blogs"
-      position "Director"
-      dob_day 1
-      dob_month 1
-      dob_year 1981
+      first_name { "Fred" }
+      last_name { "Blogs" }
+      position { "Director" }
+      dob_day { 1 }
+      dob_month { 1 }
+      dob_year { 1981 }
 
       # Initialise with attributes so we can set the date of birth
       initialize_with { new(attributes) }

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :metaData, class: WasteCarriersEngine::MetaData do
     trait :has_required_data do
-      date_registered Time.current
+      date_registered { Time.current }
     end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
   factory :registration, class: WasteCarriersEngine::Registration do
     trait :has_required_data do
-      account_email "foo@example.com"
-      business_type "limitedCompany"
-      company_name "Acme Waste"
-      company_no "09360070" # We need to use a valid company number
-      contact_email "foo@example.com"
-      first_name "Jane"
-      last_name "Doe"
-      registration_type "carrier_broker_dealer"
-      phone_number "03708 506506"
-      tier "UPPER"
+      account_email { "foo@example.com" }
+      business_type { "limitedCompany" }
+      company_name { "Acme Waste" }
+      company_no { "09360070" } # We need to use a valid company number
+      contact_email { "foo@example.com" }
+      first_name { "Jane" }
+      last_name { "Doe" }
+      registration_type { "carrier_broker_dealer" }
+      phone_number { "03708 506506" }
+      tier { "UPPER" }
 
       metaData { build(:metaData, :has_required_data) }
 
@@ -26,15 +26,15 @@ FactoryBot.define do
     end
 
     trait :has_required_overseas_data do
-      account_email "foo@example.com"
-      business_type "overseas"
-      company_name "Acme Waste"
-      contact_email "foo@example.com"
-      first_name "Jane"
-      last_name "Doe"
-      registration_type "carrier_broker_dealer"
-      phone_number "03708 506506"
-      tier "UPPER"
+      account_email { "foo@example.com" }
+      business_type { "overseas" }
+      company_name { "Acme Waste" }
+      contact_email { "foo@example.com" }
+      first_name { "Jane" }
+      last_name { "Doe" }
+      registration_type { "carrier_broker_dealer" }
+      phone_number { "03708 506506" }
+      tier { "UPPER" }
 
       metaData { build(:metaData, :has_required_data) }
 
@@ -51,12 +51,12 @@ FactoryBot.define do
 
     trait :expires_soon do
       metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
-      expires_on 2.months.from_now
+      expires_on { 2.months.from_now }
     end
 
     trait :expires_later do
       metaData { build(:metaData, :has_required_data, status: :ACTIVE) }
-      expires_on 2.years.from_now
+      expires_on { 2.years.from_now }
     end
 
     trait :is_pending do

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :transient_registration, class: WasteCarriersEngine::TransientRegistration do
     trait :has_required_data do
-      location "england"
-      declared_convictions "no"
-      temp_cards 1
+      location { "england" }
+      declared_convictions { "no" }
+      temp_cards { 1 }
 
       # Create a new registration when initializing so we can copy its data
       initialize_with { new(reg_identifier: create(:registration, :has_required_data, :expires_soon).reg_identifier) }
@@ -21,12 +21,12 @@ FactoryBot.define do
     end
 
     trait :has_postcode do
-      temp_company_postcode "BS1 5AH"
-      temp_contact_postcode "BS1 5AH"
+      temp_company_postcode { "BS1 5AH" }
+      temp_contact_postcode { "BS1 5AH" }
     end
 
     trait :declared_convictions do
-      declared_convictions "yes"
+      declared_convictions { "yes" }
     end
 
     trait :has_finance_details do
@@ -42,9 +42,9 @@ FactoryBot.define do
     # Overseas registrations
 
     trait :has_required_overseas_data do
-      location "overseas"
-      declared_convictions "no"
-      temp_cards 1
+      location { "overseas" }
+      declared_convictions { "no" }
+      temp_cards { 1 }
 
       # Create a new registration when initializing so we can copy its data
       initialize_with { new(reg_identifier: create(:registration, :has_required_overseas_data, :expires_soon).reg_identifier) }
@@ -58,8 +58,8 @@ FactoryBot.define do
     end
 
     trait :has_matching_convictions do
-      company_name "Test Waste Services"
-      company_no "12345678"
+      company_name { "Test Waste Services" }
+      company_no { "12345678" }
 
       key_people do
         [build(:key_person, :has_matching_conviction, :main)]

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
       "user#{n}@example.com"
     end
 
-    password "Secret123"
+    password { "Secret123" }
   end
 end


### PR DESCRIPTION
factory_bot 4.11.0 deprecates static attributes, which will be removed in v5. This meant that when we ran our test suite, we got a huge number of deprecation warnings. For example:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

expires_on { Fri, 21 Aug 2020 10:11:31 UTC +00:00 }
```

So this commit does exactly that.

For more info, see: https://github.com/thoughtbot/factory_bot/releases/tag/v4.11.0