### PR TITLE
Don't import revoked_reason to transient_registrations

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -118,9 +118,18 @@ module WasteCarriersEngine
     end
 
     def remove_invalid_attributes
+      remove_invalid_phone_numbers
+      remove_revoked_reason
+    end
+
+    def remove_invalid_phone_numbers
       validator = PhoneNumberValidator.new(attributes: :phone_number)
       return if validator.validate_each(self, :phone_number, phone_number)
       self.phone_number = nil
+    end
+
+    def remove_revoked_reason
+      metaData.revoked_reason = nil
     end
 
     # Check if a transient renewal already exists for this registration so we don't have

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -42,6 +42,19 @@ module WasteCarriersEngine
           expect(transient_registration.phone_number).to eq(nil)
         end
       end
+
+      context "when the source registration has a revoked_reason" do
+        let(:registration) do
+          create(:registration,
+                 :has_required_data,
+                 metaData: build(:metaData, revoked_reason: "foo"))
+        end
+
+        it "does not import it" do
+          transient_registration = TransientRegistration.new(reg_identifier: registration.reg_identifier)
+          expect(transient_registration.metaData.revoked_reason).to eq(nil)
+        end
+      end
     end
 
     describe "#reg_identifier" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-376

This attribute is used to store reasons for approving or rejecting a registration if it was flagged with possible conviction matches. Because these convictions would be three years old at least, they are no longer relevant to the renewal, so we should not import the old revoked_reason as it's not related.