### PR TITLE
Don't say conv check is pending if renewal impossible

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -85,6 +85,7 @@ module WasteCarriersEngine
     end
 
     def pending_manual_conviction_check?
+      return false unless metaData.ACTIVE?
       renewal_application_submitted? && conviction_check_required?
     end
 

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -202,8 +202,20 @@ module WasteCarriersEngine
             allow(transient_registration).to receive(:conviction_check_required?).and_return(true)
           end
 
-          it "returns true" do
-            expect(transient_registration.pending_manual_conviction_check?).to eq(true)
+          context "when the registration is not active" do
+            before do
+              transient_registration.metaData.revoke!
+            end
+
+            it "returns false" do
+              expect(transient_registration.pending_manual_conviction_check?).to eq(false)
+            end
+          end
+
+          context "when the registration is active" do
+            it "returns true" do
+              expect(transient_registration.pending_manual_conviction_check?).to eq(true)
+            end
           end
         end
       end


### PR DESCRIPTION
If a renewal is revoked, it should no longer be possible for it to still need a conviction check.