### PR TITLE
Add new method to build non-Worldpay payments

### DIFF
--- a/app/models/waste_carriers_engine/payment.rb
+++ b/app/models/waste_carriers_engine/payment.rb
@@ -18,7 +18,6 @@ module WasteCarriersEngine
     field :updatedByUser, as: :updated_by_user,                   type: String
     field :comment,                                               type: String
     field :paymentType, as: :payment_type,                        type: String
-    field :manualPayment, as: :manual_payment,                    type: String
 
     def self.new_from_worldpay(order, current_user)
       payment = Payment.new
@@ -30,6 +29,27 @@ module WasteCarriersEngine
       payment[:registration_reference] = "Worldpay"
       payment[:comment] = "Paid via Worldpay"
       payment[:updated_by_user] = current_user.email
+      payment.finance_details = order.finance_details
+
+      payment
+    end
+
+    def self.new_from_non_worldpay(params, order)
+      payment = Payment.new
+
+      payment[:amount] = params[:amount]
+      payment[:comment] = params[:comment]
+      payment[:currency] = "GBP"
+      payment[:date_entered] = Date.current
+      payment[:date_received] = params[:date_received]
+      payment[:date_received_day] = params[:date_received_day]
+      payment[:date_received_month] = params[:date_received_month]
+      payment[:date_received_year] = params[:date_received_year]
+      payment[:order_key] = order[:order_code]
+      payment[:payment_type] = params[:payment_type]
+      payment[:registration_reference] = params[:registration_reference]
+      payment[:updated_by_user] = params[:updated_by_user]
+
       payment.finance_details = order.finance_details
 
       payment

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -44,6 +44,81 @@ module WasteCarriersEngine
       end
     end
 
+    describe "new_from_non_worldpay" do
+      before do
+        Timecop.freeze(Time.new(2018, 1, 1)) do
+          FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+        end
+      end
+
+      let(:params) do
+        {
+          amount: 100,
+          comment: "foo",
+          date_received: Date.new(2018, 1, 1),
+          date_received_day: 1,
+          date_received_month: 1,
+          date_received_year: 2018,
+          payment_type: "BANKTRANSFER",
+          registration_reference: "foo",
+          updated_by_user: current_user.email
+        }
+      end
+
+      let(:order) { transient_registration.finance_details.orders.first }
+      let(:payment) { Payment.new_from_non_worldpay(params, order) }
+
+      it "should set the correct amount" do
+        expect(payment.amount).to eq(params[:amount])
+      end
+
+      it "should set the correct comment" do
+        expect(payment.comment).to eq(params[:comment])
+      end
+
+      it "should set the correct currency" do
+        expect(payment.currency).to eq("GBP")
+      end
+
+      it "should set the correct date_entered" do
+        Timecop.freeze(Time.new(2018, 1, 1)) do
+          expect(payment.date_entered).to eq(Date.new(2018, 1, 1))
+        end
+      end
+
+      it "should set the correct date_received" do
+        expect(payment.date_received).to eq(params[:date_received])
+      end
+
+      it "should set the correct date_received_day" do
+        expect(payment.date_received_day).to eq(params[:date_received_day])
+      end
+
+      it "should set the correct date_received_month" do
+        expect(payment.date_received_month).to eq(params[:date_received_month])
+      end
+
+      it "should set the correct date_received_year" do
+        expect(payment.date_received_year).to eq(params[:date_received_year])
+      end
+
+      it "should set the correct order_key" do
+        expect(payment.order_key).to eq("1514764800")
+      end
+
+      it "should set the correct payment_type" do
+        expect(payment.payment_type).to eq(params[:payment_type])
+      end
+
+      it "should set the correct registration_reference" do
+        expect(payment.registration_reference).to eq(params[:registration_reference])
+      end
+
+      it "should set the correct updated_by_user" do
+        expect(payment.updated_by_user).to eq(params[:updated_by_user])
+      end
+    end
+
     describe "update_after_worldpay" do
       let(:order) { transient_registration.finance_details.orders.first }
       let(:payment) { Payment.new_from_worldpay(order, current_user) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-377

Initally we were building these payments in the back office: https://github.com/DEFRA/waste-carriers-back-office/pull/97 However, making creating a new payment the responsibility of the Payment model feels like a better fit. This also means we are more consistent with how we create different types of payments.

Also removed the manual_payment attribute, as after looking at the waste-carriers-service, it doesn't look like this is ever persisted or used for anything.