### PR TITLE
Deal with Unix millisecond times in conviction data

### DIFF
--- a/app/models/waste_carriers_engine/conviction_search_result.rb
+++ b/app/models/waste_carriers_engine/conviction_search_result.rb
@@ -22,7 +22,8 @@ module WasteCarriersEngine
       result.matching_system = data["matching_system"]
       result.reference = data["reference"]
       result.matched_name = data["matched_name"]
-      result.searched_at = data["searched_at"]
+      # The service provides searched_at as milliseconds from the Unix epoch, so conversion is required
+      result.searched_at = Time.at(data["searched_at"] / 1_000).to_datetime
       result.confirmed = data["confirmed"]
 
       result

--- a/app/services/waste_carriers_engine/entity_matching_service.rb
+++ b/app/services/waste_carriers_engine/entity_matching_service.rb
@@ -58,7 +58,8 @@ module WasteCarriersEngine
       {
         "match_result" => "UNKNOWN",
         "matching_system" => "ERROR",
-        "searched_at" => Time.now.to_i,
+        # Get time in milliseconds
+        "searched_at" => Time.now.to_i * 1_000,
         "confirmed" => "no"
       }
     end

--- a/spec/models/waste_carriers_engine/conviction_search_result.rb
+++ b/spec/models/waste_carriers_engine/conviction_search_result.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe ConvictionSearchResult, type: :model do
+    describe "new_from_entity_matching_service" do
+      context "when given data from the entity matching service" do
+        let(:data) do
+          {
+            "match_result" => "YES",
+            "matching_system" => "PQR",
+            "reference" => "7766",
+            "matched_name" => "Test Waste Services Ltd.",
+            "searched_at" => 4815162342,
+            "confirmed" => "no",
+            "confirmed_at" => nil,
+            "confirmed_by" => nil
+          }
+        end
+        let(:conviction_sign_off) { ConvictionSearchResult.new_from_entity_matching_service(data) }
+
+        it "assigns the correct value to match_result" do
+          expect(conviction_sign_off.match_result).to eq(data["match_result"])
+        end
+
+        it "assigns the correct value to matching_system" do
+          expect(conviction_sign_off.matching_system).to eq(data["matching_system"])
+        end
+
+        it "assigns the correct value to reference" do
+          expect(conviction_sign_off.reference).to eq(data["reference"])
+        end
+
+        it "assigns the correct value to matched_name" do
+          expect(conviction_sign_off.matched_name).to eq(data["matched_name"])
+        end
+
+        it "assigns the correct value to searched_at" do
+          expected_datetime = DateTime.new(1970, 2, 25, 17, 32, 42)
+          expect(conviction_sign_off.searched_at).to eq(expected_datetime)
+        end
+
+        it "assigns the correct value to confirmed" do
+          expect(conviction_sign_off.confirmed).to eq(data["confirmed"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When we get a response back from the waste-carriers-service for the EntityMatchingService, the value for `searched_at` is given in milliseconds since the Unix epoch. We should convert this when we get it so it's stored in a more Rails-friendly format.