### PR TITLE
Update date_activated and date_registered when renewing

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -46,7 +46,8 @@ module WasteCarriersEngine
                       to: :ACTIVE,
                       guard: %i[close_to_expiry_date?
                                 should_not_be_expired?],
-                      after: :extend_expiry_date
+                      after: %i[extend_expiry_date
+                                update_activation_timestamps]
         end
       end
 
@@ -71,6 +72,11 @@ module WasteCarriersEngine
       def extend_expiry_date
         new_expiry_date = expiry_date_after_renewal(registration.expires_on)
         registration.expires_on = new_expiry_date
+      end
+
+      def update_activation_timestamps
+        self.date_registered = DateTime.current
+        self.date_activated = date_registered
       end
 
       def log_status_change

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -541,6 +541,20 @@ module WasteCarriersEngine
               # Use .to_i to ignore milliseconds when comparing time
               expect(new_expiry_date.to_i).to eq((old_expiry_date + 3.years).to_i)
             end
+
+            it "updates the registration's date_registered" do
+              Timecop.freeze do
+                registration.metaData.renew
+                expect(registration.metaData.date_registered).to eq(DateTime.current)
+              end
+            end
+
+            it "updates the registration's date_activated" do
+              Timecop.freeze do
+                registration.metaData.renew
+                expect(registration.metaData.date_activated).to eq(DateTime.current)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-426

These dates should relate to the current period of renewal. Currently, if an IR registration is renewed, we update these values to match the renewal date. So we should follow the same behaviour when renewing a non-IR registration.