### PR TITLE
Take gem into account when building email_image_tag

### DIFF
--- a/app/helpers/waste_carriers_engine/mailer_helper.rb
+++ b/app/helpers/waste_carriers_engine/mailer_helper.rb
@@ -5,12 +5,12 @@ module WasteCarriersEngine
     # service. We have found this a more reliable method and is the same used as
     # in WEX and FRAE
     def email_image_tag(image, **options)
-      path = "app/assets/images/#{image}"
+      path = "/app/assets/images/#{image}"
 
       full_path = Rails.root.join(path)
 
       unless File.exist?(full_path)
-        full_path = "#{path}"
+        full_path = "#{Gem.loaded_specs['waste_carriers_engine'].full_gem_path}#{path}"
       end
 
       attachments[image] = File.read(full_path)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( *.jpg )
+Rails.application.config.assets.precompile += %w( *.jpg *.png )


### PR DESCRIPTION
This method was borrowed from waste-carriers-frontend. However, as that isn't an engine, the path it built for the engine didn't work when mounted into host applications (although tests did pass when run against the engine itself). waste-exemptions-shared turns out to be a better model to follow for working image attachments in an engine.