### PR TITLE
Don't include registrations test page in production

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 WasteCarriersEngine::Engine.routes.draw do
-  resources :registrations, only: [:index]
+  unless Rails.env.production?
+    resources :registrations, only: [:index]
+  end
 
   resources :renewal_start_forms,
             only: [:new, :create],


### PR DESCRIPTION
We have a page at /fo/registrations or /bo/registrations which is used for testing. However we don't want this to be available in production, so this disables the route when the engine is used in a production environment.