### PR TITLE
Changing from partnership to LLP blocks user journey on CH number page

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -68,7 +68,14 @@ module WasteCarriersEngine
 
     def company_no_changed?
       return false unless company_no_required?
-      old_company_no = Registration.where(reg_identifier: reg_identifier).first.company_no.to_s
+
+      registration = Registration.where(reg_identifier: reg_identifier).first
+      # LLP is a new business type, so users who previously were forced to select 'partnership' would not have had the
+      # opportunity to enter a company_no. Therefore we have nothing to compare against and should allow users to
+      # continue the renewal journey.
+      return false if registration.business_type == "partnership"
+
+      old_company_no = registration.company_no.to_s
       # It was previously valid to have company_nos with less than 8 digits
       # The form prepends 0s to make up the length, so we should do this for the old number to match
       old_company_no = "0#{old_company_no}" while old_company_no.length < 8

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_registration_number_form_spec.rb
@@ -17,6 +17,33 @@ module WasteCarriersEngine
         it "changes to :company_name_form after the 'next' event" do
           expect(transient_registration).to transition_from(:registration_number_form).to(:company_name_form).on_event(:next)
         end
+
+        context "when the company_no has changed" do
+          before do
+            transient_registration.company_no = "01234567"
+          end
+
+          context "when the business used to be a partnership and is now an LLP" do
+            before do
+              transient_registration.business_type = "limitedLiabilityPartnership"
+              Registration.where(reg_identifier: transient_registration.reg_identifier).first.update_attributes(business_type: "partnership")
+            end
+
+            it "changes to :company_name_form after the 'next' event" do
+              expect(transient_registration).to transition_from(:registration_number_form).to(:company_name_form).on_event(:next)
+            end
+          end
+
+          context "when the business is a limited_company" do
+            before do
+              transient_registration.business_type = "limitedCompany"
+            end
+
+            it "changes to :cannot_renew_company_no_change_form after the 'next' event" do
+              expect(transient_registration).to transition_from(:registration_number_form).to(:cannot_renew_company_no_change_form).on_event(:next)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-451

Being able to register as an LLP is a new feature, so previously LLPs would have had to register as a limited company or a partnership. However, when changing the business_type during renewal from partnership to LLP, you cannot continue after entering the Companies House number for the LLP because it tells you that number has changed. This is because partnerships never enter a Companies House number, so we have nothing to compare it to.

This change disables the comparison if the business type for the registration used to be 'partnership'.