### PR TITLE
Add error pages for unhandled exceptions

### DIFF
--- a/app/controllers/waste_carriers_engine/errors_controller.rb
+++ b/app/controllers/waste_carriers_engine/errors_controller.rb
@@ -1,0 +1,39 @@
+module WasteCarriersEngine
+  class ErrorsController < ApplicationController
+    def show
+      render(
+        template: file_for(template),
+        locals: { message: exception.try(:message) }
+      )
+    end
+
+    protected
+
+    def error_code
+      @error_code ||= params[:id]
+    end
+
+    def template_exists(name)
+      File.exist?(template_path(name))
+    end
+
+    def template_path(name)
+      File.expand_path(
+        "app/views/#{file_for(name)}.html.erb",
+        WasteCarriersEngine::Engine.root
+      )
+    end
+
+    def template
+      @template ||= template_exists(error_code) ? error_code : "generic"
+    end
+
+    def file_for(name)
+      "waste_carriers_engine/errors/error_#{name}"
+    end
+
+    def exception
+      env["action_dispatch.exception"]
+    end
+  end
+end

--- a/app/views/waste_carriers_engine/errors/error_401.html.erb
+++ b/app/views/waste_carriers_engine/errors/error_401.html.erb
@@ -1,0 +1,6 @@
+<h1 class="heading-large">
+  <%= t(".heading") %>
+</h1>
+
+<p><%= t(".sorry") %></p>
+<p><%= t(".clarification") %></p>

--- a/app/views/waste_carriers_engine/errors/error_403.html.erb
+++ b/app/views/waste_carriers_engine/errors/error_403.html.erb
@@ -1,0 +1,6 @@
+<h1 class="heading-large">
+  <%= t(".heading") %>
+</h1>
+
+<p><%= t(".sorry") %></p>
+<p><%= t(".clarification") %></p>

--- a/app/views/waste_carriers_engine/errors/error_404.html.erb
+++ b/app/views/waste_carriers_engine/errors/error_404.html.erb
@@ -1,0 +1,6 @@
+<h1 class="heading-large">
+  <%= t(".heading") %>
+</h1>
+
+<p><%= t(".sorry") %></p>
+<p><%= t(".clarification") %></p>

--- a/app/views/waste_carriers_engine/errors/error_422.html.erb
+++ b/app/views/waste_carriers_engine/errors/error_422.html.erb
@@ -1,0 +1,6 @@
+<h1 class="heading-large">
+  <%= t(".heading") %>
+</h1>
+
+<p><%= t(".sorry") %></p>
+<p><%= t(".clarification") %></p>

--- a/app/views/waste_carriers_engine/errors/error_generic.html.erb
+++ b/app/views/waste_carriers_engine/errors/error_generic.html.erb
@@ -1,0 +1,6 @@
+<h1 class="heading-large">
+  <%= t(".heading") %>
+</h1>
+
+<p><%= t(".sorry") %></p>
+<p><%= t(".try_again") %></p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,8 +16,8 @@ Rails.application.configure do
   config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  # Show error pages and disable caching.
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/config/initializers/exception_handling.rb
+++ b/config/initializers/exception_handling.rb
@@ -1,0 +1,3 @@
+unless Rails.application.config.consider_all_requests_local
+  Rails.application.config.exceptions_app = WasteCarriersEngine::Engine.routes
+end

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -1,0 +1,28 @@
+en:
+  waste_carriers_engine:
+    errors:
+      error_generic:
+        heading: Something went wrong
+        sorry: Sorry, there was a technical problem. It has been reported to our support team.
+        clarification: If it happens again, call the Environment Agency helpline 03708 506 506.
+        try_again: Please try again in a few minutes.
+      error_401:
+        heading: Unauthorised
+        sorry: Sorry, you don't have permission to access this page.
+        clarification: Please check the web address you entered is correct.
+      error_403:
+        # As per https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+        # We do not wish to make this information available to the client, therefore using messaging for 404-not-found instead.
+        heading: Page not found
+        sorry: Sorry, we can't find that page.
+        clarification: Please check the web address you entered is correct.
+        link: Start again
+      error_404:
+        heading: Page not found
+        sorry: Sorry, we can't find that page.
+        clarification: Please check the web address you entered was correct.
+        link: Start again
+      error_422:
+        heading: There was a problem
+        sorry: Sorry, the system wasn't able to complete that step.
+        clarification: You could go back and try it again.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -403,6 +403,9 @@ WasteCarriersEngine::Engine.routes.draw do
               on: :collection
             end
 
+  # See http://patrickperey.com/railscast-053-handling-exceptions/
+  get "(errors)/:id", to: "errors#show", as: "error"
+
   # Static pages with HighVoltage - don't include "/pages/" in the path
   resources :pages, only: [:show], controller: "pages", path: ""
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -16,8 +16,8 @@ Rails.application.configure do
   config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  # Show error pages and disable caching.
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/spec/requests/waste_carriers_engine/errors_spec.rb
+++ b/spec/requests/waste_carriers_engine/errors_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe "Errors", type: :request do
+    describe "#show" do
+      it "renders matching error template when one exists" do
+        get error_path("401")
+        expect(response).to render_template(:error_401)
+      end
+
+      it "renders generic error template when no matching error template exists" do
+        get error_path("unknown")
+        expect(response).to render_template(:error_generic)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-308

If an error occurs, we don't want users to be kicked out to a scary or unclear error page. Instead, we should present a page which uses the same GOV.UK templates, explains an issue has occurred and states what their next steps are.