### PR TITLE
 Better renewal end screens for back office users

### DIFF
--- a/app/forms/waste_carriers_engine/renewal_complete_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_complete_form.rb
@@ -13,13 +13,6 @@ module WasteCarriersEngine
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit; end
 
-    def dashboard_link(current_user)
-      return unless current_user.present?
-      id = current_user.id
-      root = Rails.configuration.wcrs_frontend_url
-      "#{root}/user/#{id}/registrations"
-    end
-
     private
 
     def build_certificate_link

--- a/app/forms/waste_carriers_engine/renewal_received_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_form.rb
@@ -11,12 +11,5 @@ module WasteCarriersEngine
 
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit; end
-
-    def dashboard_link(current_user)
-      return unless current_user.present?
-      id = current_user.id
-      root = Rails.configuration.wcrs_frontend_url
-      "#{root}/user/#{id}/registrations"
-    end
   end
 end

--- a/app/helpers/waste_carriers_engine/application_helper.rb
+++ b/app/helpers/waste_carriers_engine/application_helper.rb
@@ -44,6 +44,14 @@ module WasteCarriersEngine
       end
     end
 
+    def dashboard_link(current_user)
+      return unless current_user.present?
+      id = current_user.id
+      root = Rails.configuration.wcrs_frontend_url
+      I18n.t("waste_carriers_engine.dashboard_link", root: root, id: id)
+      # "#{root}/user/#{id}/registrations"
+    end
+
     private
 
     def title_text

--- a/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_complete_forms/new.html.erb
@@ -53,7 +53,7 @@
     <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_complete_form.reg_identifier %>
-    <%= link_to t(".next_button"), @renewal_complete_form.dashboard_link(current_user), class: 'button' %>
+    <%= link_to t(".next_button"), dashboard_link(current_user), class: 'button' %>
   <% end %>
 
 <% end %>

--- a/app/views/waste_carriers_engine/renewal_received_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_forms/new.html.erb
@@ -39,7 +39,7 @@
     <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
 
     <%= f.hidden_field :reg_identifier, value: @renewal_received_form.reg_identifier %>
-    <%= link_to t(".next_button"), @renewal_received_form.dashboard_link(current_user), class: 'button' %>
+    <%= link_to t(".next_button"), dashboard_link(current_user), class: 'button' %>
   <% end %>
 
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   waste_carriers_engine:
+    dashboard_link: "%{root}/user/%{id}/registrations"
     errors:
       messages:
         weak_password: Your password is not strong enough. It must include at least one lowercase letter, uppercase letter and number

--- a/lib/waste_carriers_engine/engine.rb
+++ b/lib/waste_carriers_engine/engine.rb
@@ -13,9 +13,11 @@ module WasteCarriersEngine
       g.helper false
     end
 
-    # Load I18n translation files
+    # Load I18n translation files from engine before loading ones from the host app
+    # This means values in the host app can override those in the engine
     config.before_initialize do
-      config.i18n.load_path += Dir["#{config.root}/config/locales/**/*.yml"]
+      engine_locales = Dir["#{config.root}/config/locales/**/*.yml"]
+      config.i18n.load_path = engine_locales + config.i18n.load_path
     end
   end
 end

--- a/spec/helpers/waste_carriers_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/application_helper_spec.rb
@@ -46,5 +46,17 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "dashboard_link" do
+      before do
+        allow(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://www.example.com")
+      end
+
+      it "returns the correct value" do
+        user = build(:user)
+        expected_url = "http://www.example.com/user/#{user.id}/registrations"
+        expect(helper.dashboard_link(user)).to eq(expected_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-478

Currently the renewal_complete and renewal_received forms show the same content to all users regardless of which app they are mounted in.

Most of the time, this is fine - however, it does cause some problems on these two pages at the end of the renewals journey, as back office users require different links and information.