### PR TITLE
Implement separate controller actions for WorldPay responses

### DIFF
--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -47,7 +47,7 @@ module WasteCarriersEngine
 
       order = find_order_by_code(params[:orderKey])
 
-      if valid_worldpay_failure_response?(params, order)
+      if valid_worldpay_cancel_response?(params, order)
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
       else
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
@@ -61,7 +61,7 @@ module WasteCarriersEngine
 
       order = find_order_by_code(params[:orderKey])
 
-      if valid_worldpay_failure_response?(params, order)
+      if valid_worldpay_error_response?(params, order)
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
       else
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
@@ -75,7 +75,7 @@ module WasteCarriersEngine
 
       order = find_order_by_code(params[:orderKey])
 
-      if valid_worldpay_failure_response?(params, order)
+      if valid_worldpay_pending_response?(params, order)
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
       else
         flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
@@ -120,6 +120,21 @@ module WasteCarriersEngine
     def valid_worldpay_failure_response?(params, order)
       worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
       worldpay_service.valid_failure?
+    end
+
+    def valid_worldpay_cancel_response?(params, order)
+      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
+      worldpay_service.valid_cancel?
+    end
+
+    def valid_worldpay_error_response?(params, order)
+      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
+      worldpay_service.valid_error?
+    end
+
+    def valid_worldpay_pending_response?(params, order)
+      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
+      worldpay_service.valid_pending?
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -42,6 +42,48 @@ module WasteCarriersEngine
       go_back
     end
 
+    def cancel
+      return unless set_up_valid_transient_registration?(params[:reg_identifier])
+
+      order = find_order_by_code(params[:orderKey])
+
+      if valid_worldpay_failure_response?(params, order)
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
+      else
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
+      end
+
+      go_back
+    end
+
+    def error
+      return unless set_up_valid_transient_registration?(params[:reg_identifier])
+
+      order = find_order_by_code(params[:orderKey])
+
+      if valid_worldpay_failure_response?(params, order)
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
+      else
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
+      end
+
+      go_back
+    end
+
+    def pending
+      return unless set_up_valid_transient_registration?(params[:reg_identifier])
+
+      order = find_order_by_code(params[:orderKey])
+
+      if valid_worldpay_failure_response?(params, order)
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
+      else
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
+      end
+
+      go_back
+    end
+
     private
 
     def prepare_for_payment

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -29,59 +29,19 @@ module WasteCarriersEngine
     end
 
     def failure
-      return unless set_up_valid_transient_registration?(params[:reg_identifier])
-
-      order = find_order_by_code(params[:orderKey])
-
-      if valid_worldpay_failure_response?(params, order)
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
-      else
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
-      end
-
-      go_back
+      respond_to_unsuccessful_payment(:valid_worldpay_failure_response?)
     end
 
     def cancel
-      return unless set_up_valid_transient_registration?(params[:reg_identifier])
-
-      order = find_order_by_code(params[:orderKey])
-
-      if valid_worldpay_cancel_response?(params, order)
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
-      else
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
-      end
-
-      go_back
+      respond_to_unsuccessful_payment(:valid_worldpay_cancel_response?)
     end
 
     def error
-      return unless set_up_valid_transient_registration?(params[:reg_identifier])
-
-      order = find_order_by_code(params[:orderKey])
-
-      if valid_worldpay_error_response?(params, order)
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
-      else
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
-      end
-
-      go_back
+      respond_to_unsuccessful_payment(:valid_worldpay_error_response?)
     end
 
     def pending
-      return unless set_up_valid_transient_registration?(params[:reg_identifier])
-
-      order = find_order_by_code(params[:orderKey])
-
-      if valid_worldpay_pending_response?(params, order)
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
-      else
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
-      end
-
-      go_back
+      respond_to_unsuccessful_payment(:valid_worldpay_pending_response?)
     end
 
     private
@@ -91,6 +51,20 @@ module WasteCarriersEngine
       order = @transient_registration.finance_details.orders.first
       worldpay_service = WorldpayService.new(@transient_registration, order, current_user)
       worldpay_service.prepare_for_payment
+    end
+
+    def respond_to_unsuccessful_payment(valid_response_method)
+      return unless set_up_valid_transient_registration?(params[:reg_identifier])
+
+      order = find_order_by_code(params[:orderKey])
+
+      if self.send(valid_response_method, params, order)
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
+      else
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
+      end
+
+      go_back
     end
 
     def set_up_valid_transient_registration?(reg_identifier)

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -29,19 +29,19 @@ module WasteCarriersEngine
     end
 
     def failure
-      respond_to_unsuccessful_payment(:valid_failure?)
+      respond_to_unsuccessful_payment(:failure)
     end
 
     def cancel
-      respond_to_unsuccessful_payment(:valid_cancel?)
+      respond_to_unsuccessful_payment(:cancel)
     end
 
     def error
-      respond_to_unsuccessful_payment(:valid_error?)
+      respond_to_unsuccessful_payment(:error)
     end
 
     def pending
-      respond_to_unsuccessful_payment(:valid_pending?)
+      respond_to_unsuccessful_payment(:pending)
     end
 
     private
@@ -53,17 +53,18 @@ module WasteCarriersEngine
       worldpay_service.prepare_for_payment
     end
 
-    def respond_to_unsuccessful_payment(valid_method)
+    def respond_to_unsuccessful_payment(action)
       return unless set_up_valid_transient_registration?(params[:reg_identifier])
 
       order = find_order_by_code(params[:orderKey])
 
+      valid_method = "valid_#{action}?".to_sym
       response_is_valid = new_worldpay_service(params, order).public_send(valid_method)
 
       if response_is_valid
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.message.#{params[:paymentStatus]}")
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.#{action}.message")
       else
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.failure.invalid_response")
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.#{action}.invalid_response")
       end
 
       go_back

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -113,28 +113,27 @@ module WasteCarriersEngine
     end
 
     def valid_worldpay_success_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
-      worldpay_service.valid_success?
+      new_worldpay_service(params, order).valid_success?
     end
 
     def valid_worldpay_failure_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
-      worldpay_service.valid_failure?
+      new_worldpay_service(params, order).valid_failure?
     end
 
     def valid_worldpay_cancel_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
-      worldpay_service.valid_cancel?
+      new_worldpay_service(params, order).valid_cancel?
     end
 
     def valid_worldpay_error_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
-      worldpay_service.valid_error?
+      new_worldpay_service(params, order).valid_error?
     end
 
     def valid_worldpay_pending_response?(params, order)
-      worldpay_service = WorldpayService.new(@transient_registration, order, current_user, params)
-      worldpay_service.valid_pending?
+      new_worldpay_service(params, order).valid_pending?
+    end
+
+    def new_worldpay_service(params, order)
+      WorldpayService.new(@transient_registration, order, current_user, params)
     end
   end
 end

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -56,16 +56,11 @@ module WasteCarriersEngine
     def respond_to_unsuccessful_payment(action)
       return unless set_up_valid_transient_registration?(params[:reg_identifier])
 
-      order = find_order_by_code(params[:orderKey])
-
-      valid_method = "valid_#{action}?".to_sym
-      response_is_valid = new_worldpay_service(params, order).public_send(valid_method)
-
-      if response_is_valid
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.#{action}.message")
-      else
-        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.#{action}.invalid_response")
-      end
+      flash[:error] = if unsuccessful_response_is_valid?(action, params)
+                        I18n.t(".waste_carriers_engine.worldpay_forms.#{action}.message")
+                      else
+                        I18n.t(".waste_carriers_engine.worldpay_forms.#{action}.invalid_response")
+                      end
 
       go_back
     end
@@ -87,6 +82,13 @@ module WasteCarriersEngine
     def get_order_key(order_key)
       return nil unless order_key.present?
       order_key.match(/[0-9]{10}$/).to_s
+    end
+
+    def unsuccessful_response_is_valid?(action, params)
+      order = find_order_by_code(params[:orderKey])
+      valid_method = "valid_#{action}?".to_sym
+
+      new_worldpay_service(params, order).public_send(valid_method)
     end
 
     def new_worldpay_service(params, order)

--- a/app/services/waste_carriers_engine/worldpay_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_service.rb
@@ -38,38 +38,30 @@ module WasteCarriersEngine
     end
 
     def valid_failure?
-      worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
-      return false unless worldpay_validator_service.valid_failure?
-
-      @order.update_after_worldpay(@params[:paymentStatus])
-      true
+      valid_unsuccessful_payment?(:valid_failure?)
     end
 
     def valid_pending?
-      worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
-      return false unless worldpay_validator_service.valid_pending?
-
-      @order.update_after_worldpay(@params[:paymentStatus])
-      true
+      valid_unsuccessful_payment?(:valid_pending?)
     end
 
     def valid_cancel?
-      worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
-      return false unless worldpay_validator_service.valid_cancel?
-
-      @order.update_after_worldpay(@params[:paymentStatus])
-      true
+      valid_unsuccessful_payment?(:valid_cancel?)
     end
 
     def valid_error?
+      valid_unsuccessful_payment?(:valid_error?)
+    end
+
+    private
+
+    def valid_unsuccessful_payment?(validation_method)
       worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
-      return false unless worldpay_validator_service.valid_error?
+      return false unless worldpay_validator_service.public_send(validation_method)
 
       @order.update_after_worldpay(@params[:paymentStatus])
       true
     end
-
-    private
 
     def prepare_params(params)
       return if params.nil?

--- a/app/services/waste_carriers_engine/worldpay_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_service.rb
@@ -45,6 +45,30 @@ module WasteCarriersEngine
       true
     end
 
+    def valid_pending?
+      worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
+      return false unless worldpay_validator_service.valid_pending?
+
+      @order.update_after_worldpay(@params[:paymentStatus])
+      true
+    end
+
+    def valid_cancel?
+      worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
+      return false unless worldpay_validator_service.valid_cancel?
+
+      @order.update_after_worldpay(@params[:paymentStatus])
+      true
+    end
+
+    def valid_error?
+      worldpay_validator_service = WorldpayValidatorService.new(@order, @params)
+      return false unless worldpay_validator_service.valid_error?
+
+      @order.update_after_worldpay(@params[:paymentStatus])
+      true
+    end
+
     private
 
     def prepare_params(params)

--- a/app/services/waste_carriers_engine/worldpay_url_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_url_service.rb
@@ -19,52 +19,29 @@ module WasteCarriersEngine
     private
 
     def success_url
-      ["&successURL=", success_path].join
+      ["&successURL=", build_path(:success)].join
     end
 
     def pending_url
-      ["&pendingURL=", pending_path].join
+      ["&pendingURL=", build_path(:pending)].join
     end
 
     def failure_url
-      ["&failureURL=", failure_path].join
+      ["&failureURL=", build_path(:failure)].join
     end
 
     def cancel_url
-      ["&cancelURL=", cancel_path].join
+      ["&cancelURL=", build_path(:cancel)].join
     end
 
     def error_url
-      ["&errorURL=", error_path].join
+      ["&errorURL=", build_path(:error)].join
     end
 
-    def success_path
+    def build_path(action)
+      path = "#{action}_worldpay_forms_path"
       url = [Rails.configuration.host,
-             WasteCarriersEngine::Engine.routes.url_helpers.success_worldpay_forms_path(@reg_identifier)]
-      CGI.escape(url.join)
-    end
-
-    def pending_path
-      url = [Rails.configuration.host,
-             WasteCarriersEngine::Engine.routes.url_helpers.pending_worldpay_forms_path(@reg_identifier)]
-      CGI.escape(url.join)
-    end
-
-    def failure_path
-      url = [Rails.configuration.host,
-             WasteCarriersEngine::Engine.routes.url_helpers.failure_worldpay_forms_path(@reg_identifier)]
-      CGI.escape(url.join)
-    end
-
-    def cancel_path
-      url = [Rails.configuration.host,
-             WasteCarriersEngine::Engine.routes.url_helpers.cancel_worldpay_forms_path(@reg_identifier)]
-      CGI.escape(url.join)
-    end
-
-    def error_path
-      url = [Rails.configuration.host,
-             WasteCarriersEngine::Engine.routes.url_helpers.error_worldpay_forms_path(@reg_identifier)]
+             WasteCarriersEngine::Engine.routes.url_helpers.public_send(path, @reg_identifier)]
       CGI.escape(url.join)
     end
   end

--- a/app/services/waste_carriers_engine/worldpay_url_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_url_service.rb
@@ -9,36 +9,22 @@ module WasteCarriersEngine
 
     def format_link
       [@base_url,
-       success_url,
-       pending_url,
-       failure_url,
-       cancel_url,
-       error_url].join
+       redirect_url_for(:success),
+       redirect_url_for(:pending),
+       redirect_url_for(:failure),
+       redirect_url_for(:cancel),
+       redirect_url_for(:error)].join
     end
 
     private
 
-    def success_url
-      ["&successURL=", build_path(:success)].join
+    def redirect_url_for(action)
+      param_name = "&#{action}URL="
+      param_value = build_path_for(action)
+      [param_name, param_value].join
     end
 
-    def pending_url
-      ["&pendingURL=", build_path(:pending)].join
-    end
-
-    def failure_url
-      ["&failureURL=", build_path(:failure)].join
-    end
-
-    def cancel_url
-      ["&cancelURL=", build_path(:cancel)].join
-    end
-
-    def error_url
-      ["&errorURL=", build_path(:error)].join
-    end
-
-    def build_path(action)
+    def build_path_for(action)
       path = "#{action}_worldpay_forms_path"
       url = [Rails.configuration.host,
              WasteCarriersEngine::Engine.routes.url_helpers.public_send(path, @reg_identifier)]

--- a/app/services/waste_carriers_engine/worldpay_url_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_url_service.rb
@@ -23,7 +23,7 @@ module WasteCarriersEngine
     end
 
     def pending_url
-      ["&pendingURL=", failure_path].join
+      ["&pendingURL=", pending_path].join
     end
 
     def failure_url
@@ -31,11 +31,11 @@ module WasteCarriersEngine
     end
 
     def cancel_url
-      ["&cancelURL=", failure_path].join
+      ["&cancelURL=", cancel_path].join
     end
 
     def error_url
-      ["&errorURL=", failure_path].join
+      ["&errorURL=", error_path].join
     end
 
     def success_path
@@ -44,9 +44,27 @@ module WasteCarriersEngine
       CGI.escape(url.join)
     end
 
+    def pending_path
+      url = [Rails.configuration.host,
+             WasteCarriersEngine::Engine.routes.url_helpers.pending_worldpay_forms_path(@reg_identifier)]
+      CGI.escape(url.join)
+    end
+
     def failure_path
       url = [Rails.configuration.host,
              WasteCarriersEngine::Engine.routes.url_helpers.failure_worldpay_forms_path(@reg_identifier)]
+      CGI.escape(url.join)
+    end
+
+    def cancel_path
+      url = [Rails.configuration.host,
+             WasteCarriersEngine::Engine.routes.url_helpers.cancel_worldpay_forms_path(@reg_identifier)]
+      CGI.escape(url.join)
+    end
+
+    def error_path
+      url = [Rails.configuration.host,
+             WasteCarriersEngine::Engine.routes.url_helpers.error_worldpay_forms_path(@reg_identifier)]
       CGI.escape(url.join)
     end
   end

--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -110,7 +110,7 @@ module WasteCarriersEngine
       allowed_statuses = {
         success: ["AUTHORISED"],
         failure: ["EXPIRED", "REFUSED"],
-        pending: ["PENDING"],
+        pending: ["SENT_FOR_AUTHORISATION", "SHOPPER_REDIRECTED"],
         cancel: ["CANCELLED"],
         error: ["ERROR"]
       }

--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -18,23 +18,23 @@ module WasteCarriersEngine
     end
 
     def valid_success?
-      valid_order? && valid_params? && valid_success_payment_status?
+      valid_order? && valid_params? && valid_status?(:success)
     end
 
     def valid_failure?
-      valid_order? && valid_params? && valid_failure_payment_status?
+      valid_order? && valid_params? && valid_status?(:failure)
     end
 
     def valid_pending?
-      valid_order? && valid_params? && valid_pending_payment_status?
+      valid_order? && valid_params? && valid_status?(:pending)
     end
 
     def valid_cancel?
-      valid_order? && valid_params? && valid_cancel_payment_status?
+      valid_order? && valid_params? && valid_status?(:cancel)
     end
 
     def valid_error?
-      valid_order? && valid_params? && valid_error_payment_status?
+      valid_order? && valid_params? && valid_status?(:error)
     end
 
     private
@@ -102,40 +102,17 @@ module WasteCarriersEngine
       false
     end
 
-    def valid_success_payment_status?
-      return true if @status == "AUTHORISED"
+    def valid_status?(expected_status)
+      allowed_statuses = {
+        success: ["AUTHORISED"],
+        failure: ["EXPIRED", "REFUSED"],
+        pending: ["PENDING"],
+        cancel: ["CANCELLED"],
+        error: ["ERROR"]
+      }
+      return true if allowed_statuses[expected_status].include?(@status)
 
-      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for success"
-      false
-    end
-
-    def valid_failure_payment_status?
-      statuses = %w[EXPIRED
-                    REFUSED]
-      return true if statuses.include?(@status)
-
-      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for failure"
-      false
-    end
-
-    def valid_pending_payment_status?
-      return true if @status == "PENDING"
-
-      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for pending"
-      false
-    end
-
-    def valid_cancel_payment_status?
-      return true if @status == "CANCELLED"
-
-      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for cancel"
-      false
-    end
-
-    def valid_error_payment_status?
-      return true if @status == "ERROR"
-
-      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for error"
+      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for #{expected_status}"
       false
     end
   end

--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -25,6 +25,18 @@ module WasteCarriersEngine
       valid_order? && valid_params? && valid_failure_payment_status?
     end
 
+    def valid_pending?
+      valid_order? && valid_params? && valid_pending_payment_status?
+    end
+
+    def valid_cancel?
+      valid_order? && valid_params? && valid_cancel_payment_status?
+    end
+
+    def valid_error?
+      valid_order? && valid_params? && valid_error_payment_status?
+    end
+
     private
 
     def valid_order?
@@ -98,13 +110,32 @@ module WasteCarriersEngine
     end
 
     def valid_failure_payment_status?
-      statuses = %w[CANCELLED
-                    ERROR
-                    EXPIRED
+      statuses = %w[EXPIRED
                     REFUSED]
       return true if statuses.include?(@status)
 
       Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for failure"
+      false
+    end
+
+    def valid_pending_payment_status?
+      return true if @status == "PENDING"
+
+      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for pending"
+      false
+    end
+
+    def valid_cancel_payment_status?
+      return true if @status == "CANCELLED"
+
+      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for cancel"
+      false
+    end
+
+    def valid_error_payment_status?
+      return true if @status == "ERROR"
+
+      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for error"
       false
     end
   end

--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -18,26 +18,30 @@ module WasteCarriersEngine
     end
 
     def valid_success?
-      valid_order? && valid_params? && valid_status?(:success)
+      valid?(:success)
     end
 
     def valid_failure?
-      valid_order? && valid_params? && valid_status?(:failure)
+      valid?(:failure)
     end
 
     def valid_pending?
-      valid_order? && valid_params? && valid_status?(:pending)
+      valid?(:pending)
     end
 
     def valid_cancel?
-      valid_order? && valid_params? && valid_status?(:cancel)
+      valid?(:cancel)
     end
 
     def valid_error?
-      valid_order? && valid_params? && valid_status?(:error)
+      valid?(:error)
     end
 
     private
+
+    def valid?(action)
+      valid_order? && valid_params? && valid_status?(action)
+    end
 
     def valid_order?
       return true if @order.present?

--- a/config/locales/forms/worldpay_forms/en.yml
+++ b/config/locales/forms/worldpay_forms/en.yml
@@ -1,14 +1,20 @@
 en:
   waste_carriers_engine:
     worldpay_forms:
+      cancel:
+        invalid_response: "Invalid WorldPay cancel response"
+        message: "Your attempt to pay has been cancelled. Please try again or select a different payment method."
+      error:
+        invalid_response: "Invalid WorldPay error response"
+        message: "An error has occurred with WorldPay and your payment has not been processed. Please try again or select a different payment method."
       failure:
         invalid_response: "Invalid WorldPay failure response"
-        message:
-          CANCELLED: "Your attempt to pay has been cancelled. Please try again or select a different payment method."
-          ERROR: "An error has occurred with WorldPay and your payment has not been processed. Please try again or select a different payment method."
-          REFUSED: "Your payment has been refused. Please try again or select a different payment method."
+        message: "Your payment has been refused. Please try again or select a different payment method."
       new:
         setup_error: "An error has occurred when preparing for your WorldPay payment. Please try again or select a different payment method."
+      pending:
+        invalid_response: "Invalid WorldPay pending response"
+        message: "Your payment is still pending."
       success:
         invalid_response: "Invalid WorldPay success response"
   activemodel:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -351,6 +351,21 @@ WasteCarriersEngine::Engine.routes.draw do
               to: "worldpay_forms#failure",
               as: "failure",
               on: :collection
+
+              get "cancel/:reg_identifier",
+              to: "worldpay_forms#cancel",
+              as: "cancel",
+              on: :collection
+
+              get "error/:reg_identifier",
+              to: "worldpay_forms#error",
+              as: "error",
+              on: :collection
+
+              get "pending/:reg_identifier",
+              to: "worldpay_forms#pending",
+              as: "pending",
+              on: :collection
             end
 
   resources :bank_transfer_forms,

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -152,6 +152,123 @@ module WasteCarriersEngine
             end
           end
         end
+
+        describe "#cancel" do
+          before do
+            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+          end
+
+          let(:order) do
+            transient_registration.finance_details.orders.first
+          end
+
+          let(:params) do
+            {
+              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
+              reg_identifier: reg_id
+            }
+          end
+
+          context "when the params are valid" do
+            before do
+              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
+            end
+
+            it "redirects to payment_summary_form" do
+              get cancel_worldpay_forms_path(reg_id), params
+              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+            end
+          end
+
+          context "when the params are not valid" do
+            before do
+              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
+            end
+
+            it "redirects to payment_summary_form" do
+              get cancel_worldpay_forms_path(reg_id), params
+              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+            end
+          end
+        end
+
+        describe "#error" do
+          before do
+            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+          end
+
+          let(:order) do
+            transient_registration.finance_details.orders.first
+          end
+
+          let(:params) do
+            {
+              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
+              reg_identifier: reg_id
+            }
+          end
+
+          context "when the params are valid" do
+            before do
+              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
+            end
+
+            it "redirects to payment_summary_form" do
+              get error_worldpay_forms_path(reg_id), params
+              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+            end
+          end
+
+          context "when the params are not valid" do
+            before do
+              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
+            end
+
+            it "redirects to payment_summary_form" do
+              get error_worldpay_forms_path(reg_id), params
+              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+            end
+          end
+        end
+
+        describe "#pending" do
+          before do
+            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+          end
+
+          let(:order) do
+            transient_registration.finance_details.orders.first
+          end
+
+          let(:params) do
+            {
+              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
+              reg_identifier: reg_id
+            }
+          end
+
+          context "when the params are valid" do
+            before do
+              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
+            end
+
+            it "redirects to payment_summary_form" do
+              get pending_worldpay_forms_path(reg_id), params
+              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+            end
+          end
+
+          context "when the params are not valid" do
+            before do
+              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
+            end
+
+            it "redirects to payment_summary_form" do
+              get pending_worldpay_forms_path(reg_id), params
+              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+            end
+          end
+        end
       end
     end
   end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -117,19 +117,19 @@ module WasteCarriersEngine
     end
 
     describe "#cancel" do
-      it_should_behave_like "GET unsuccessful Worldpay response", :valid_cancel?
+      it_should_behave_like "GET unsuccessful Worldpay response", :cancel
     end
 
     describe "#error" do
-      it_should_behave_like "GET unsuccessful Worldpay response", :valid_error?
+      it_should_behave_like "GET unsuccessful Worldpay response", :error
     end
 
     describe "#failure" do
-      it_should_behave_like "GET unsuccessful Worldpay response", :valid_failure?
+      it_should_behave_like "GET unsuccessful Worldpay response", :failure
     end
 
     describe "#pending" do
-      it_should_behave_like "GET unsuccessful Worldpay response", :valid_pending?
+      it_should_behave_like "GET unsuccessful Worldpay response", :pending
     end
   end
 end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -113,163 +113,23 @@ module WasteCarriersEngine
             end
           end
         end
-
-        describe "#failure" do
-          before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
-          end
-
-          let(:order) do
-            transient_registration.finance_details.orders.first
-          end
-
-          let(:params) do
-            {
-              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
-              reg_identifier: reg_id
-            }
-          end
-
-          context "when the params are valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
-            end
-
-            it "redirects to payment_summary_form" do
-              get failure_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-
-          context "when the params are not valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
-            end
-
-            it "redirects to payment_summary_form" do
-              get failure_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-        end
-
-        describe "#cancel" do
-          before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
-          end
-
-          let(:order) do
-            transient_registration.finance_details.orders.first
-          end
-
-          let(:params) do
-            {
-              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
-              reg_identifier: reg_id
-            }
-          end
-
-          context "when the params are valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_cancel?).and_return(true)
-            end
-
-            it "redirects to payment_summary_form" do
-              get cancel_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-
-          context "when the params are not valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_cancel?).and_return(false)
-            end
-
-            it "redirects to payment_summary_form" do
-              get cancel_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-        end
-
-        describe "#error" do
-          before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
-          end
-
-          let(:order) do
-            transient_registration.finance_details.orders.first
-          end
-
-          let(:params) do
-            {
-              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
-              reg_identifier: reg_id
-            }
-          end
-
-          context "when the params are valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_error?).and_return(true)
-            end
-
-            it "redirects to payment_summary_form" do
-              get error_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-
-          context "when the params are not valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_error?).and_return(false)
-            end
-
-            it "redirects to payment_summary_form" do
-              get error_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-        end
-
-        describe "#pending" do
-          before do
-            FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
-          end
-
-          let(:order) do
-            transient_registration.finance_details.orders.first
-          end
-
-          let(:params) do
-            {
-              orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
-              reg_identifier: reg_id
-            }
-          end
-
-          context "when the params are valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_pending?).and_return(true)
-            end
-
-            it "redirects to payment_summary_form" do
-              get pending_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-
-          context "when the params are not valid" do
-            before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_pending?).and_return(false)
-            end
-
-            it "redirects to payment_summary_form" do
-              get pending_worldpay_forms_path(reg_id), params
-              expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
-            end
-          end
-        end
       end
+    end
+
+    describe "#cancel" do
+      it_should_behave_like "GET unsuccessful Worldpay response", :valid_cancel?
+    end
+
+    describe "#error" do
+      it_should_behave_like "GET unsuccessful Worldpay response", :valid_error?
+    end
+
+    describe "#failure" do
+      it_should_behave_like "GET unsuccessful Worldpay response", :valid_failure?
+    end
+
+    describe "#pending" do
+      it_should_behave_like "GET unsuccessful Worldpay response", :valid_pending?
     end
   end
 end

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -171,7 +171,7 @@ module WasteCarriersEngine
 
           context "when the params are valid" do
             before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
+              allow_any_instance_of(WorldpayService).to receive(:valid_cancel?).and_return(true)
             end
 
             it "redirects to payment_summary_form" do
@@ -182,7 +182,7 @@ module WasteCarriersEngine
 
           context "when the params are not valid" do
             before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
+              allow_any_instance_of(WorldpayService).to receive(:valid_cancel?).and_return(false)
             end
 
             it "redirects to payment_summary_form" do
@@ -210,7 +210,7 @@ module WasteCarriersEngine
 
           context "when the params are valid" do
             before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
+              allow_any_instance_of(WorldpayService).to receive(:valid_error?).and_return(true)
             end
 
             it "redirects to payment_summary_form" do
@@ -221,7 +221,7 @@ module WasteCarriersEngine
 
           context "when the params are not valid" do
             before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
+              allow_any_instance_of(WorldpayService).to receive(:valid_error?).and_return(false)
             end
 
             it "redirects to payment_summary_form" do
@@ -249,7 +249,7 @@ module WasteCarriersEngine
 
           context "when the params are valid" do
             before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(true)
+              allow_any_instance_of(WorldpayService).to receive(:valid_pending?).and_return(true)
             end
 
             it "redirects to payment_summary_form" do
@@ -260,7 +260,7 @@ module WasteCarriersEngine
 
           context "when the params are not valid" do
             before do
-              allow_any_instance_of(WorldpayService).to receive(:valid_failure?).and_return(false)
+              allow_any_instance_of(WorldpayService).to receive(:valid_pending?).and_return(false)
             end
 
             it "redirects to payment_summary_form" do

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -177,152 +177,20 @@ module WasteCarriersEngine
       end
     end
 
-    describe "valid_failure?" do
-      before do
-        params[:paymentStatus] = "REFUSED"
-      end
-
-      context "when the params are valid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_failure?).and_return(true)
-        end
-
-        it "returns true" do
-          expect(worldpay_service.valid_failure?).to eq(true)
-        end
-
-        it "updates the order status" do
-          worldpay_service.valid_failure?
-          expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq("REFUSED")
-        end
-      end
-
-      context "when the params are invalid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_failure?).and_return(false)
-        end
-
-        it "returns false" do
-          expect(worldpay_service.valid_failure?).to eq(false)
-        end
-
-        it "does not update the order" do
-          unmodified_order = transient_registration.finance_details.orders.first
-          worldpay_service.valid_failure?
-          expect(transient_registration.reload.finance_details.orders.first).to eq(unmodified_order)
-        end
-      end
+    describe "#valid_failure?" do
+      it_should_behave_like "WorldpayService valid unsuccessful action", :valid_failure?, "REFUSED"
     end
 
-    describe "valid_pending?" do
-      before do
-        params[:paymentStatus] = "PENDING"
-      end
-
-      context "when the params are valid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_pending?).and_return(true)
-        end
-
-        it "returns true" do
-          expect(worldpay_service.valid_pending?).to eq(true)
-        end
-
-        it "updates the order status" do
-          worldpay_service.valid_pending?
-          expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq("PENDING")
-        end
-      end
-
-      context "when the params are invalid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_pending?).and_return(false)
-        end
-
-        it "returns false" do
-          expect(worldpay_service.valid_pending?).to eq(false)
-        end
-
-        it "does not update the order" do
-          unmodified_order = transient_registration.finance_details.orders.first
-          worldpay_service.valid_pending?
-          expect(transient_registration.reload.finance_details.orders.first).to eq(unmodified_order)
-        end
-      end
+    describe "#valid_pending?" do
+      it_should_behave_like "WorldpayService valid unsuccessful action", :valid_pending?, "PENDING"
     end
 
-    describe "valid_cancel?" do
-      before do
-        params[:paymentStatus] = "CANCELLED"
-      end
-
-      context "when the params are valid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_cancel?).and_return(true)
-        end
-
-        it "returns true" do
-          expect(worldpay_service.valid_cancel?).to eq(true)
-        end
-
-        it "updates the order status" do
-          worldpay_service.valid_cancel?
-          expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq("CANCELLED")
-        end
-      end
-
-      context "when the params are invalid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_cancel?).and_return(false)
-        end
-
-        it "returns false" do
-          expect(worldpay_service.valid_cancel?).to eq(false)
-        end
-
-        it "does not update the order" do
-          unmodified_order = transient_registration.finance_details.orders.first
-          worldpay_service.valid_cancel?
-          expect(transient_registration.reload.finance_details.orders.first).to eq(unmodified_order)
-        end
-      end
+    describe "#valid_cancel?" do
+      it_should_behave_like "WorldpayService valid unsuccessful action", :valid_cancel?, "CANCELLED"
     end
 
-    describe "valid_error?" do
-      before do
-        params[:paymentStatus] = "ERROR"
-      end
-
-      context "when the params are valid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_error?).and_return(true)
-        end
-
-        it "returns true" do
-          expect(worldpay_service.valid_error?).to eq(true)
-        end
-
-        it "updates the order status" do
-          worldpay_service.valid_error?
-          expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq("ERROR")
-        end
-      end
-
-      context "when the params are invalid" do
-        before do
-          allow_any_instance_of(WorldpayValidatorService).to receive(:valid_error?).and_return(false)
-        end
-
-        it "returns false" do
-          expect(worldpay_service.valid_error?).to eq(false)
-        end
-
-        it "does not update the order" do
-          unmodified_order = transient_registration.finance_details.orders.first
-          worldpay_service.valid_error?
-          expect(transient_registration.reload.finance_details.orders.first).to eq(unmodified_order)
-        end
-      end
+    describe "#valid_error?" do
+      it_should_behave_like "WorldpayService valid unsuccessful action", :valid_error?, "ERROR"
     end
   end
 end

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -182,7 +182,7 @@ module WasteCarriersEngine
     end
 
     describe "#valid_pending?" do
-      it_should_behave_like "WorldpayService valid unsuccessful action", :valid_pending?, "PENDING"
+      it_should_behave_like "WorldpayService valid unsuccessful action", :valid_pending?, "SENT_FOR_AUTHORISATION"
     end
 
     describe "#valid_cancel?" do

--- a/spec/services/waste_carriers_engine/worldpay_url_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_url_service_spec.rb
@@ -28,7 +28,7 @@ module WasteCarriersEngine
       end
 
       it "includes the pending URL" do
-        pending_url = "&pendingURL=" + CGI.escape("#{root}/worldpay/failure/#{reg_id}")
+        pending_url = "&pendingURL=" + CGI.escape("#{root}/worldpay/pending/#{reg_id}")
         expect(url).to include(pending_url)
       end
 
@@ -38,12 +38,12 @@ module WasteCarriersEngine
       end
 
       it "includes the cancel URL" do
-        cancel_url = "&cancelURL=" + CGI.escape("#{root}/worldpay/failure/#{reg_id}")
+        cancel_url = "&cancelURL=" + CGI.escape("#{root}/worldpay/cancel/#{reg_id}")
         expect(url).to include(cancel_url)
       end
 
       it "includes the error URL" do
-        error_url = "&errorURL=" + CGI.escape("#{root}/worldpay/failure/#{reg_id}")
+        error_url = "&errorURL=" + CGI.escape("#{root}/worldpay/error/#{reg_id}")
         expect(url).to include(error_url)
       end
     end

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -24,7 +24,17 @@ module WasteCarriersEngine
     end
 
     let(:order) { transient_registration.finance_details.orders.first }
-    let(:params) {}
+    let(:params) do
+      {
+        orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
+        paymentStatus: "REFUSED",
+        paymentAmount: order.total_amount,
+        paymentCurrency: "GBP",
+        mac: "b32f74da10bf1d9ebfd262d673e58fb9",
+        source: "WP",
+        reg_identifier: transient_registration.reg_identifier
+      }
+    end
 
     let(:worldpay_validator_service) { WorldpayValidatorService.new(order, params) }
 
@@ -115,22 +125,52 @@ module WasteCarriersEngine
     end
 
     describe "valid_failure?" do
-      let(:params) do
-        {
-          orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
-          paymentStatus: "REFUSED",
-          paymentAmount: order.total_amount,
-          paymentCurrency: "GBP",
-          mac: "b32f74da10bf1d9ebfd262d673e58fb9",
-          source: "WP",
-          reg_identifier: transient_registration.reg_identifier
-        }
+      before do
+        params[:paymentStatus] = "REFUSED"
       end
 
       it "returns true" do
         expect(worldpay_validator_service.valid_failure?).to eq(true)
       end
 
+      context "when the paymentStatus is invalid" do
+        before do
+          params[:paymentStatus] = "foo"
+          # Change the MAC param to still be valid as this relies on the paymentStatus
+          params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+        end
+
+        it "returns false" do
+          expect(worldpay_validator_service.valid_failure?).to eq(false)
+        end
+      end
+    end
+
+    describe "valid_pending?" do
+      before do
+        params[:paymentStatus] = "PENDING"
+        # Change the MAC param to still be valid as this relies on the paymentStatus
+        params[:mac] = "69849a1b01ac1324d4874e4082aa766c"
+      end
+
+      it "returns true" do
+        expect(worldpay_validator_service.valid_pending?).to eq(true)
+      end
+
+      context "when the paymentStatus is invalid" do
+        before do
+          params[:paymentStatus] = "foo"
+          # Change the MAC param to still be valid as this relies on the paymentStatus
+          params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+        end
+
+        it "returns false" do
+          expect(worldpay_validator_service.valid_pending?).to eq(false)
+        end
+      end
+    end
+
+    describe "valid_cancel?" do
       context "when the paymentStatus is cancelled and params are valid" do
         let(:params) do
           {
@@ -145,12 +185,34 @@ module WasteCarriersEngine
         end
 
         it "returns true" do
-          expect(worldpay_validator_service.valid_failure?).to eq(true)
+          expect(worldpay_validator_service.valid_cancel?).to eq(true)
+        end
+
+        context "when the paymentStatus is invalid" do
+          before do
+            params[:paymentStatus] = "foo"
+            # Change the MAC param to still be valid as this relies on the paymentStatus
+            params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+          end
+
+          it "returns false" do
+            expect(worldpay_validator_service.valid_cancel?).to eq(false)
+          end
         end
       end
+    end
 
-      # We test most of the individual param validations when testing :valid_success?,
-      # so just test the unique ones for :valid_failure?
+    describe "valid_error?" do
+      before do
+        params[:paymentStatus] = "ERROR"
+        # Change the MAC param to still be valid as this relies on the paymentStatus
+        params[:mac] = "850b1aaf91a079cd888fe9a848835cd5"
+      end
+
+      it "returns true" do
+        expect(worldpay_validator_service.valid_error?).to eq(true)
+      end
+
       context "when the paymentStatus is invalid" do
         before do
           params[:paymentStatus] = "foo"
@@ -159,7 +221,7 @@ module WasteCarriersEngine
         end
 
         it "returns false" do
-          expect(worldpay_validator_service.valid_failure?).to eq(false)
+          expect(worldpay_validator_service.valid_error?).to eq(false)
         end
       end
     end

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -148,9 +148,9 @@ module WasteCarriersEngine
 
     describe "valid_pending?" do
       before do
-        params[:paymentStatus] = "PENDING"
+        params[:paymentStatus] = "SENT_FOR_AUTHORISATION"
         # Change the MAC param to still be valid as this relies on the paymentStatus
-        params[:mac] = "69849a1b01ac1324d4874e4082aa766c"
+        params[:mac] = "439facf7d9e31b4e6a4b35478803ff6f"
       end
 
       it "returns true" do

--- a/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
+++ b/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
@@ -1,0 +1,58 @@
+RSpec.shared_examples "GET unsuccessful Worldpay response" do |validation_action|
+  context "when a valid user is signed in" do
+    let(:user) { create(:user) }
+    before(:each) do
+      sign_in(user)
+    end
+
+    context "when a valid transient registration exists" do
+      let(:transient_registration) do
+        create(:transient_registration,
+               :has_required_data,
+               :has_addresses,
+               :has_conviction_search_result,
+               :has_key_people,
+               account_email: user.email,
+               workflow_state: "worldpay_form")
+      end
+      let(:reg_id) { transient_registration[:reg_identifier] }
+
+      before do
+        WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, user)
+      end
+
+      let(:order) do
+        transient_registration.finance_details.orders.first
+      end
+
+      let(:params) do
+        {
+          orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
+          reg_identifier: reg_id
+        }
+      end
+
+      context "when the params are valid" do
+        before do
+          allow_any_instance_of(WasteCarriersEngine::WorldpayService).to receive(validation_action).and_return(true)
+        end
+
+        it "redirects to payment_summary_form" do
+          get pending_worldpay_forms_path(reg_id), params
+          expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+        end
+      end
+
+      context "when the params are not valid" do
+        before do
+          allow_any_instance_of(WasteCarriersEngine::WorldpayService).to receive(validation_action).and_return(false)
+        end
+
+        it "redirects to payment_summary_form" do
+          get pending_worldpay_forms_path(reg_id), params
+          expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
+++ b/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "GET unsuccessful Worldpay response" do |validation_action|
+RSpec.shared_examples "GET unsuccessful Worldpay response" do |action|
   context "when a valid user is signed in" do
     let(:user) { create(:user) }
     before(:each) do
@@ -32,13 +32,19 @@ RSpec.shared_examples "GET unsuccessful Worldpay response" do |validation_action
         }
       end
 
+      let(:validation_action) { "valid_#{action}?".to_sym }
+      let(:path) do
+        path_route = "#{action}_worldpay_forms_path".to_sym
+        self.public_send(path_route, reg_id)
+      end
+
       context "when the params are valid" do
         before do
           allow_any_instance_of(WasteCarriersEngine::WorldpayService).to receive(validation_action).and_return(true)
         end
 
         it "redirects to payment_summary_form" do
-          get pending_worldpay_forms_path(reg_id), params
+          get path, params
           expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
         end
       end
@@ -49,7 +55,7 @@ RSpec.shared_examples "GET unsuccessful Worldpay response" do |validation_action
         end
 
         it "redirects to payment_summary_form" do
-          get pending_worldpay_forms_path(reg_id), params
+          get path, params
           expect(response).to redirect_to(new_payment_summary_form_path(reg_id))
         end
       end

--- a/spec/support/shared_examples/worldpay_service_valid_unsuccessful_action.rb
+++ b/spec/support/shared_examples/worldpay_service_valid_unsuccessful_action.rb
@@ -1,0 +1,62 @@
+RSpec.shared_examples "WorldpayService valid unsuccessful action" do |valid_action, status|
+  let(:transient_registration) do
+    create(:transient_registration,
+           :has_required_data,
+           :has_overseas_addresses,
+           :has_finance_details,
+           temp_cards: 0)
+  end
+  let(:current_user) { build(:user) }
+
+  before do
+    allow(Rails.configuration).to receive(:renewal_charge).and_return(10_500)
+
+    WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, current_user)
+  end
+
+  let(:order) { transient_registration.finance_details.orders.first }
+  # An incomplete set of params which should still be valid when we stub the validation service
+  let(:params) do
+    {
+      orderKey: "#{Rails.configuration.worldpay_admin_code}^#{Rails.configuration.worldpay_merchantcode}^#{order.order_code}",
+      paymentStatus: status,
+      paymentAmount: order.total_amount,
+      reg_identifier: transient_registration.reg_identifier
+    }
+  end
+
+  let(:worldpay_service) do
+    WasteCarriersEngine::WorldpayService.new(transient_registration, order, current_user, params)
+  end
+
+  context "when the params are valid" do
+    before do
+      allow_any_instance_of(WasteCarriersEngine::WorldpayValidatorService).to receive(valid_action).and_return(true)
+    end
+
+    it "returns true" do
+      expect(worldpay_service.public_send(valid_action)).to eq(true)
+    end
+
+    it "updates the order status" do
+      worldpay_service.public_send(valid_action)
+      expect(transient_registration.reload.finance_details.orders.first.world_pay_status).to eq(status)
+    end
+  end
+
+  context "when the params are invalid" do
+    before do
+      allow_any_instance_of(WasteCarriersEngine::WorldpayValidatorService).to receive(valid_action).and_return(false)
+    end
+
+    it "returns false" do
+      expect(worldpay_service.public_send(valid_action)).to eq(false)
+    end
+
+    it "does not update the order" do
+      unmodified_order = transient_registration.finance_details.orders.first
+      worldpay_service.public_send(valid_action)
+      expect(transient_registration.reload.finance_details.orders.first).to eq(unmodified_order)
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-409

Currently we have 2 different actions to deal with WorldPay responses - success or failure. However, there are actually 4 different responses from WorldPay that could lead to 'failure' - the payment could be pending, cancelled or throw an error as well as failing.

We should have separate controller actions to deal with each of these 5 scenarios. This will allow us to respond more appropriately to the different circumstances of a payment not immediately going through.