### PR TITLE
Let users proceed to renewal_received after pending WP payment

### DIFF
--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -17,9 +17,7 @@ module WasteCarriersEngine
     def success
       return unless set_up_valid_transient_registration?(params[:reg_identifier])
 
-      order = find_order_by_code(params[:orderKey])
-
-      if new_worldpay_service(params, order).valid_success?
+      if worldpay_service(params).valid_success?
         @transient_registration.next!
         redirect_to_correct_form
       else
@@ -43,9 +41,7 @@ module WasteCarriersEngine
     def pending
       return unless set_up_valid_transient_registration?(params[:reg_identifier])
 
-      order = find_order_by_code(params[:orderKey])
-
-      if new_worldpay_service(params, order).valid_pending?
+      if worldpay_service(params).valid_pending?
         @transient_registration.next!
         redirect_to_correct_form
       else
@@ -95,13 +91,13 @@ module WasteCarriersEngine
     end
 
     def unsuccessful_response_is_valid?(action, params)
-      order = find_order_by_code(params[:orderKey])
       valid_method = "valid_#{action}?".to_sym
 
-      new_worldpay_service(params, order).public_send(valid_method)
+      worldpay_service(params).public_send(valid_method)
     end
 
-    def new_worldpay_service(params, order)
+    def worldpay_service(params)
+      order = find_order_by_code(params[:orderKey])
       WorldpayService.new(@transient_registration, order, current_user, params)
     end
   end

--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -41,7 +41,17 @@ module WasteCarriersEngine
     end
 
     def pending
-      respond_to_unsuccessful_payment(:pending)
+      return unless set_up_valid_transient_registration?(params[:reg_identifier])
+
+      order = find_order_by_code(params[:orderKey])
+
+      if new_worldpay_service(params, order).valid_pending?
+        @transient_registration.next!
+        redirect_to_correct_form
+      else
+        flash[:error] = I18n.t(".waste_carriers_engine.worldpay_forms.pending.invalid_response")
+        go_back
+      end
     end
 
     private

--- a/app/forms/waste_carriers_engine/renewal_received_form.rb
+++ b/app/forms/waste_carriers_engine/renewal_received_form.rb
@@ -1,12 +1,13 @@
 module WasteCarriersEngine
   class RenewalReceivedForm < BaseForm
-    attr_accessor :contact_email, :pending_convictions_check, :pending_payment
+    attr_accessor :contact_email, :pending_convictions_check, :pending_payment, :pending_worldpay_payment
 
     def initialize(transient_registration)
       super
       self.contact_email = @transient_registration.contact_email
       self.pending_convictions_check = @transient_registration.conviction_check_required?
-      self.pending_payment = (@transient_registration.temp_payment_method == "bank_transfer")
+      self.pending_payment = @transient_registration.pending_payment?
+      self.pending_worldpay_payment = @transient_registration.pending_worldpay_payment?
     end
 
     # Override BaseForm method as users shouldn't be able to submit this form

--- a/app/mailers/waste_carriers_engine/renewal_mailer.rb
+++ b/app/mailers/waste_carriers_engine/renewal_mailer.rb
@@ -17,12 +17,7 @@ module WasteCarriersEngine
       @transient_registration = transient_registration
       @total_to_pay = @transient_registration.finance_details.balance
 
-      template = if @transient_registration.pending_payment?
-                   "send_renewal_received_pending_payment_email"
-                 else
-                   "send_renewal_received_pending_conviction_check_email"
-                 end
-
+      template = renewal_received_template
       subject = I18n.t(".waste_carriers_engine.renewal_mailer.#{template}.subject",
                        reg_identifier: @transient_registration.reg_identifier)
 
@@ -34,6 +29,16 @@ module WasteCarriersEngine
     end
 
     private
+
+    def renewal_received_template
+      if @transient_registration.pending_worldpay_payment?
+        "send_renewal_received_processing_payment_email"
+      elsif @transient_registration.pending_payment?
+        "send_renewal_received_pending_payment_email"
+      else
+        "send_renewal_received_pending_conviction_check_email"
+      end
+    end
 
     def displayable_address(address)
       return [] unless address.present?

--- a/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
@@ -257,7 +257,7 @@ module WasteCarriersEngine
 
           transitions from: :worldpay_form,
                       to: :renewal_received_form,
-                      if: :pending_payment_or_convictions_check?,
+                      if: :pending_worldpay_payment_or_convictions_check?,
                       success: :send_renewal_received_email
 
           transitions from: :worldpay_form,
@@ -549,8 +549,8 @@ module WasteCarriersEngine
       temp_payment_method == "card"
     end
 
-    def pending_payment_or_convictions_check?
-      finance_details.balance.positive? || conviction_check_required?
+    def pending_worldpay_payment_or_convictions_check?
+      pending_worldpay_payment? || conviction_check_required?
     end
 
     def send_renewal_received_email

--- a/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
@@ -257,7 +257,7 @@ module WasteCarriersEngine
 
           transitions from: :worldpay_form,
                       to: :renewal_received_form,
-                      if: :pending_convictions_check?,
+                      if: :pending_payment_or_convictions_check?,
                       success: :send_renewal_received_email
 
           transitions from: :worldpay_form,
@@ -549,8 +549,8 @@ module WasteCarriersEngine
       temp_payment_method == "card"
     end
 
-    def pending_convictions_check?
-      conviction_check_required?
+    def pending_payment_or_convictions_check?
+      finance_details.balance.positive? || conviction_check_required?
     end
 
     def send_renewal_received_email

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -50,6 +50,17 @@ module WasteCarriersEngine
       order
     end
 
+    def self.valid_world_pay_status?(response_type, status)
+      allowed_statuses = {
+        success: ["AUTHORISED"],
+        failure: ["EXPIRED", "REFUSED"],
+        pending: ["SENT_FOR_AUTHORISATION", "SHOPPER_REDIRECTED"],
+        cancel: ["CANCELLED"],
+        error: ["ERROR"]
+      }
+      allowed_statuses[response_type].include?(status)
+    end
+
     def add_bank_transfer_attributes
       self.payment_method = "OFFLINE"
     end

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -95,8 +95,8 @@ module WasteCarriersEngine
       return false unless finance_details.present? &&
                           finance_details.orders.present? &&
                           finance_details.orders.first.present?
-      pending_statuses = ["SENT_FOR_AUTHORISATION", "SHOPPER_REDIRECTED"]
-      pending_statuses.include?(finance_details.orders.first.world_pay_status)
+
+      Order.valid_world_pay_status?(:pending, finance_details.orders.first.world_pay_status)
     end
 
     def pending_manual_conviction_check?

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -91,6 +91,14 @@ module WasteCarriersEngine
       renewal_application_submitted? && finance_details.present? && finance_details.balance.positive?
     end
 
+    def pending_worldpay_payment?
+      return false unless finance_details.present? &&
+                          finance_details.orders.present? &&
+                          finance_details.orders.first.present?
+      pending_statuses = ["SENT_FOR_AUTHORISATION", "SHOPPER_REDIRECTED"]
+      pending_statuses.include?(finance_details.orders.first.world_pay_status)
+    end
+
     def pending_manual_conviction_check?
       return false unless metaData.ACTIVE?
       renewal_application_submitted? && conviction_check_required?

--- a/app/services/waste_carriers_engine/worldpay_validator_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_validator_service.rb
@@ -106,17 +106,10 @@ module WasteCarriersEngine
       false
     end
 
-    def valid_status?(expected_status)
-      allowed_statuses = {
-        success: ["AUTHORISED"],
-        failure: ["EXPIRED", "REFUSED"],
-        pending: ["SENT_FOR_AUTHORISATION", "SHOPPER_REDIRECTED"],
-        cancel: ["CANCELLED"],
-        error: ["ERROR"]
-      }
-      return true if allowed_statuses[expected_status].include?(@status)
+    def valid_status?(response_type)
+      return true if Order.valid_world_pay_status?(response_type, @status)
 
-      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for #{expected_status}"
+      Rails.logger.error "Invalid WorldPay response: #{@status} is not valid payment status for #{response_type}"
       false
     end
   end

--- a/app/views/waste_carriers_engine/renewal_mailer/send_renewal_received_processing_payment_email.html.erb
+++ b/app/views/waste_carriers_engine/renewal_mailer/send_renewal_received_processing_payment_email.html.erb
@@ -1,0 +1,90 @@
+<!doctype html>
+<!--[if lt IE 7]>  <html class="ie ie6 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 7]>     <html class="ie ie7 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 8]>     <html class="ie ie8 lte9 lte8"> <![endif]-->
+<!--[if IE 9]>     <html class="ie ie9 lte9"> <![endif]-->
+<!--[if gt IE 9]>  <html> <![endif]-->
+<!--[if !IE]><!-->
+<html>
+<!--<![endif]-->
+
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <!-- Use title if it's in the page YAML frontmatter -->
+  <title>Waste Carriers Service</title>
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td width="100%" height="53px" bgcolor="#0b0c0c">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" bgcolor="#0b0c0c" valign="middle">
+              <%= email_image_tag("govuk_logotype_email.png", { alt: 'GOV.UK', border: '0' }) %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+    <tr>
+      <td width="100%">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" class="header" style="padding-top: 10px;" colspan="2">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+                <tr>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-weight: 400; font-size: 16px; line-height: 1; margin: 10px 0 10px 0;">&nbsp;</p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td bgcolor="#28a197" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 15px 0px;">
+                <%= t(".heading.header.#{@transient_registration.registration_type}") %>
+              </p>
+
+              <p style="font-size: 19px; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 0;">
+                <%= t(".heading.number") %>
+              </p>
+
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 15px 0px 30px 0px;">
+                <%= @transient_registration.reg_identifier %>
+              </p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".paragraph_1") %>
+              </p>
+
+              <ul>
+                <li style="font-size: 16px; color: #6f777b; line-height: 1.125; margin: 0 0 15px 0;">
+                  <%= t(".footer_list.item_1") %>
+                </li>
+                <li style="font-size: 16px; color: #6f777b; line-height: 1.125; margin: 0 0 30px 0;">
+                  <%= t(".footer_list.item_2") %>
+                </li>
+              </ul>
+            </td>
+            <td width="25%">
+              &nbsp;
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/waste_carriers_engine/renewal_received_forms/new.html.erb
+++ b/app/views/waste_carriers_engine/renewal_received_forms/new.html.erb
@@ -19,7 +19,10 @@
 
     <p><%= t(".paragraph_1", email: @renewal_received_form.contact_email) %></p>
 
-    <% if @renewal_received_form.pending_payment %>
+    <% if @renewal_received_form.pending_worldpay_payment %>
+    <h2 class="heading-medium"><%= t(".processing_payment_subheading") %></h2>
+    <p><%= t(".processing_payment_paragraph_1") %></p>
+    <% elsif @renewal_received_form.pending_payment %>
     <h2 class="heading-medium"><%= t(".awaiting_payment_subheading") %></h2>
     <p><%= t(".awaiting_payment_paragraph_1") %></p>
     <p><%= t(".awaiting_payment_paragraph_2") %></p>

--- a/config/locales/forms/renewal_received_forms/en.yml
+++ b/config/locales/forms/renewal_received_forms/en.yml
@@ -6,6 +6,8 @@ en:
         heading: Application received
         highlight_text: "Your registration number is still"
         paragraph_1: "We have sent a confirmation email to %{email}."
+        processing_payment_subheading: "Processing your payment"
+        processing_payment_paragraph_1: We are currently processing your payment and will let you know when it has been received.
         awaiting_payment_subheading: "Next step: pay the renewal charge"
         awaiting_payment_paragraph_1: We've sent an email telling you how to pay the charge.
         awaiting_payment_paragraph_2: Please allow 5 working days for your payment to reach us.

--- a/config/locales/mailers/renewal_mailer.en.yml
+++ b/config/locales/mailers/renewal_mailer.en.yml
@@ -66,3 +66,16 @@ en:
         footer_list:
           item_1: "If you have enquiries please contact the Environment Agency helpline: 03708 506506"
           item_2: "This is an automated email, please do not reply"
+
+      send_renewal_received_processing_payment_email:
+        subject: "Your application to renew waste carriers registration %{reg_identifier} has been received"
+        heading:
+          header:
+            carrier_dealer: "Your application to renew your waste carrier and dealer registration has been received"
+            broker_dealer: "Your application to renew your waste broker and dealer registration has been received"
+            carrier_broker_dealer: "Your application to renew your waste carrier, broker and dealer registration has been received"
+          number: "Your registration number is still"
+        paragraph_1: "We are currently processing your payment. We'll email you to let you know when your renewal application has been successful."
+        footer_list:
+          item_1: "If you have enquiries please contact the Environment Agency helpline: 03708 506506"
+          item_2: "This is an automated email, please do not reply"

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
       payments {[]}
     end
 
+    trait :has_order do
+      orders { [build(:order, :has_required_data)] }
+    end
+
     trait :has_order_and_payment do
       orders { [build(:order, :has_required_data)] }
       payments { [build(:payment)] }

--- a/spec/mailers/waste_carriers_engine/renewal_mailer_spec.rb
+++ b/spec/mailers/waste_carriers_engine/renewal_mailer_spec.rb
@@ -58,6 +58,21 @@ module WasteCarriersEngine
         expect(mail.body.encoded).to include(transient_registration.reg_identifier)
       end
 
+      context "when there is a pending worldpay payment" do
+        before do
+          allow(transient_registration).to receive(:pending_worldpay_payment?).and_return(true)
+        end
+
+        it "uses the correct subject" do
+          subject = "Your application to renew waste carriers registration #{transient_registration.reg_identifier} has been received"
+          expect(mail.subject).to eq(subject)
+        end
+
+        it "includes the correct template in the body" do
+          expect(mail.body.encoded).to include("processing your payment")
+        end
+      end
+
       context "when there is an unpaid balance" do
         before do
           transient_registration.finance_details.balance = 550

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -156,5 +156,15 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "valid_world_pay_status?" do
+      it "returns true when the status matches the values for the response type" do
+        expect(Order.valid_world_pay_status?(:success, "AUTHORISED")).to eq(true)
+      end
+
+      it "returns false when the status does not match the values for the response type" do
+        expect(Order.valid_world_pay_status?(:success, "FOO")).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -183,7 +183,7 @@ module WasteCarriersEngine
 
         context "when the order's world_pay_status is pending" do
           before do
-            transient_registration.finance_details.orders.first.world_pay_status = "SENT_FOR_AUTHORISATION"
+            allow(Order).to receive(:valid_world_pay_status?).and_return(true)
           end
 
           it "returns true" do
@@ -192,6 +192,10 @@ module WasteCarriersEngine
         end
 
         context "when the order's world_pay_status is not pending" do
+          before do
+            allow(Order).to receive(:valid_world_pay_status?).and_return(false)
+          end
+
           it "returns false" do
             expect(transient_registration.pending_worldpay_payment?).to eq(false)
           end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -175,6 +175,40 @@ module WasteCarriersEngine
       end
     end
 
+    describe "pending_worldpay_payment?" do
+      context "when the renewal has an order" do
+        before do
+          transient_registration.finance_details = build(:finance_details, :has_order)
+        end
+
+        context "when the order's world_pay_status is pending" do
+          before do
+            transient_registration.finance_details.orders.first.world_pay_status = "SENT_FOR_AUTHORISATION"
+          end
+
+          it "returns true" do
+            expect(transient_registration.pending_worldpay_payment?).to eq(true)
+          end
+        end
+
+        context "when the order's world_pay_status is not pending" do
+          it "returns false" do
+            expect(transient_registration.pending_worldpay_payment?).to eq(false)
+          end
+        end
+      end
+
+      context "when the renewal has no order" do
+        before do
+          transient_registration.finance_details = build(:finance_details)
+        end
+
+        it "returns false" do
+          expect(transient_registration.pending_worldpay_payment?).to eq(false)
+        end
+      end
+    end
+
     describe "pending_manual_conviction_check?" do
       context "when the renewal is not in a completed workflow_state" do
         it "returns false" do

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
@@ -19,12 +19,12 @@ module WasteCarriersEngine
 
         context "when a conviction check is not required" do
           before do
-            transient_registration.conviction_sign_offs = nil
+            allow(transient_registration).to receive(:conviction_check_required?).and_return(false)
           end
 
-          context "when the balance is 0" do
-            it "changes to :renewal_complete_form after the 'next' event" do
-              expect(transient_registration).to transition_from(:worldpay_form).to(:renewal_complete_form).on_event(:next)
+          context "when there is no pending WorldPay payment" do
+            before do
+              allow(transient_registration).to receive(:pending_worldpay_payment?).and_return(false)
             end
 
             it "does not send a confirmation email after the 'next' event" do
@@ -34,9 +34,9 @@ module WasteCarriersEngine
             end
           end
 
-          context "when there is a positive balance" do
+          context "when there is a pending WorldPay payment" do
             before do
-              transient_registration.finance_details.balance = 100
+              allow(transient_registration).to receive(:pending_worldpay_payment?).and_return(true)
             end
 
             it "changes to :renewal_received_form after the 'next' event" do
@@ -53,7 +53,7 @@ module WasteCarriersEngine
 
         context "when a conviction check is required" do
           before do
-            transient_registration.conviction_sign_offs = [build(:conviction_sign_off)]
+            allow(transient_registration).to receive(:conviction_check_required?).and_return(true)
           end
 
           it "changes to :renewal_received_form after the 'next' event" do

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -134,6 +134,7 @@ module WasteCarriersEngine
           context "when the params are valid" do
             before do
               allow_any_instance_of(WorldpayService).to receive(:valid_pending?).and_return(true)
+              allow_any_instance_of(TransientRegistration).to receive(:pending_worldpay_payment?).and_return(true)
             end
 
             it "redirects to renewal_received_form" do

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -63,9 +63,10 @@ module WasteCarriersEngine
             }
           end
 
-          context "when the params are valid" do
+          context "when the params are valid and the balance is paid" do
             before do
               allow_any_instance_of(WorldpayService).to receive(:valid_success?).and_return(true)
+              transient_registration.finance_details.update_attributes(balance: 0)
             end
 
             it "redirects to renewal_complete_form" do

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -69,9 +69,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          params[:paymentStatus] = "foo"
-          # Change the MAC param to still be valid as this relies on the paymentStatus
-          params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
@@ -135,9 +133,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          params[:paymentStatus] = "foo"
-          # Change the MAC param to still be valid as this relies on the paymentStatus
-          params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
@@ -159,9 +155,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          params[:paymentStatus] = "foo"
-          # Change the MAC param to still be valid as this relies on the paymentStatus
-          params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do
@@ -190,9 +184,7 @@ module WasteCarriersEngine
 
         context "when the paymentStatus is invalid" do
           before do
-            params[:paymentStatus] = "foo"
-            # Change the MAC param to still be valid as this relies on the paymentStatus
-            params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+            allow(Order).to receive(:valid_world_pay_status?).and_return(false)
           end
 
           it "returns false" do
@@ -215,9 +207,7 @@ module WasteCarriersEngine
 
       context "when the paymentStatus is invalid" do
         before do
-          params[:paymentStatus] = "foo"
-          # Change the MAC param to still be valid as this relies on the paymentStatus
-          params[:mac] = "ecf0c84b1efa523ae847dd26cdf7b798"
+          allow(Order).to receive(:valid_world_pay_status?).and_return(false)
         end
 
         it "returns false" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-409

Sometimes WorldPay can't approve a payment immediately, although it may be approved after a delay.

In this case, we should let the user continue with the process as they will likely be charged eventually. However, as we don't want the renewal to be completed until payment has been taken, we should send it to the 'renewal received' state until a back office user records the payment.