### PR TITLE
Send WorldPay emails to contact_email for AD renewals

### DIFF
--- a/app/services/waste_carriers_engine/worldpay_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_service.rb
@@ -75,7 +75,7 @@ module WasteCarriersEngine
     end
 
     def send_request
-      xml_service = WorldpayXmlService.new(@transient_registration, @order)
+      xml_service = WorldpayXmlService.new(@transient_registration, @order, @current_user)
       xml = xml_service.build_xml
 
       Rails.logger.debug "Sending initial request to WorldPay"

--- a/app/services/waste_carriers_engine/worldpay_xml_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_xml_service.rb
@@ -2,9 +2,10 @@ require "countries"
 
 module WasteCarriersEngine
   class WorldpayXmlService
-    def initialize(transient_registration, order)
+    def initialize(transient_registration, order, current_user)
       @transient_registration = transient_registration
       @order = order
+      @current_user = current_user
     end
 
     def build_xml

--- a/app/services/waste_carriers_engine/worldpay_xml_service.rb
+++ b/app/services/waste_carriers_engine/worldpay_xml_service.rb
@@ -62,7 +62,7 @@ module WasteCarriersEngine
     end
 
     def build_shopper(xml)
-      email = @transient_registration.account_email
+      email = get_email
 
       xml.shopper do
         xml.shopperEmailAddress email
@@ -99,6 +99,14 @@ module WasteCarriersEngine
       # If we didn't provide a country or no match was found, use GB as default
       return "GB" if country.nil?
       country.alpha2
+    end
+
+    def get_email
+      if @current_user.email == @transient_registration.account_email
+        @transient_registration.account_email
+      else
+        @transient_registration.contact_email
+      end
     end
   end
 end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -54,6 +54,10 @@ FactoryBot.define do
       finance_details { build(:finance_details, balance: 0) }
     end
 
+    trait :has_different_contact_email do
+      contact_email { "contact-foo@example.com" }
+    end
+
     # Overseas registrations
 
     trait :has_required_overseas_data do

--- a/spec/fixtures/files/request_to_worldpay_ad.xml
+++ b/spec/fixtures/files/request_to_worldpay_ad.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay/DTD WorldPay PaymentService v1/EN" "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+  <submit>
+    <order orderCode="1234567890">
+      <description>Your Waste Carrier Registration CBDU9999</description>
+      <amount currencyCode="GBP" value="10000" exponent="2"/>
+      <orderContent>Waste Carrier Registration renewal: CBDU9999 for Acme Waste</orderContent>
+      <paymentMethodMask>
+        <include code="VISA-SSL"/>
+        <include code="MAESTRO-SSL"/>
+        <include code="ECMC-SSL"/>
+      </paymentMethodMask>
+      <shopper>
+        <shopperEmailAddress>contact-foo@example.com</shopperEmailAddress>
+      </shopper>
+      <billingAddress>
+        <address>
+          <firstName>Jane</firstName>
+          <lastName>Doe</lastName>
+          <address1>42 Foo Gardens</address1>
+          <address2/>
+          <postalCode>FA1 1KE</postalCode>
+          <city>Baz City</city>
+          <countryCode>SK</countryCode>
+        </address>
+      </billingAddress>
+    </order>
+  </submit>
+</paymentService>

--- a/spec/services/waste_carriers_engine/worldpay_xml_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_xml_service_spec.rb
@@ -6,6 +6,7 @@ module WasteCarriersEngine
     let(:transient_registration) do
       create(:transient_registration,
              :has_required_data,
+             :has_different_contact_email,
              :has_overseas_addresses,
              :has_finance_details,
              temp_cards: 0)
@@ -25,9 +26,18 @@ module WasteCarriersEngine
     end
 
     describe "build_xml" do
-      it "returns correctly-formatted XML" do
-        xml = File.read("./spec/fixtures/files/request_to_worldpay.xml")
-        expect(worldpay_xml_service.build_xml).to eq(xml)
+      context "when it's a digital registration" do
+        it "returns correctly-formatted XML" do
+          xml = File.read("./spec/fixtures/files/request_to_worldpay.xml")
+          expect(worldpay_xml_service.build_xml).to eq(xml)
+        end
+      end
+
+      context "when it's an assisted digital registration" do
+        it "returns correctly-formatted XML" do
+          xml = File.read("./spec/fixtures/files/request_to_worldpay_ad.xml")
+          expect(worldpay_xml_service.build_xml).to eq(xml)
+        end
       end
     end
   end

--- a/spec/services/waste_carriers_engine/worldpay_xml_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_xml_service_spec.rb
@@ -12,7 +12,8 @@ module WasteCarriersEngine
              temp_cards: 0)
     end
     let(:order) { transient_registration.finance_details.orders.first }
-    let(:worldpay_xml_service) { WorldpayXmlService.new(transient_registration, order) }
+    let(:current_user) { build(:user) }
+    let(:worldpay_xml_service) { WorldpayXmlService.new(transient_registration, order, current_user) }
 
     before do
       # Set a specific reg_identifier so we can match our XML
@@ -27,6 +28,10 @@ module WasteCarriersEngine
 
     describe "build_xml" do
       context "when it's a digital registration" do
+        before do
+          current_user.email = transient_registration.account_email
+        end
+
         it "returns correctly-formatted XML" do
           xml = File.read("./spec/fixtures/files/request_to_worldpay.xml")
           expect(worldpay_xml_service.build_xml).to eq(xml)
@@ -34,6 +39,10 @@ module WasteCarriersEngine
       end
 
       context "when it's an assisted digital registration" do
+        before do
+          current_user.email = "not-the-same-account@example.com"
+        end
+
         it "returns correctly-formatted XML" do
           xml = File.read("./spec/fixtures/files/request_to_worldpay_ad.xml")
           expect(worldpay_xml_service.build_xml).to eq(xml)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-489

Users sometimes go through the assisted digital route to renew because they cannot access their account. When a user goes through WorldPay for payment, we send the account email through to WorldPay, which it then uses to send confirmation of the payment. If the user is AD because they can't access the account, this makes the confirmation meaningless.

So if a renewal is done via assisted digital, we should be passing the contact email to WorldPay, and not the account email.