### PR TITLE
Fix validation on copy card page

### DIFF
--- a/app/forms/waste_carriers_engine/cards_form.rb
+++ b/app/forms/waste_carriers_engine/cards_form.rb
@@ -9,6 +9,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
+      # If temp_cards is blank, sub in 0 so it passes validation
       self.temp_cards = if params[:temp_cards].present?
                           params[:temp_cards]
                         else
@@ -19,8 +20,6 @@ module WasteCarriersEngine
       super(attributes, params[:reg_identifier])
     end
 
-    # Must be a positive integer or 0
-    # Leaving it blank is also valid - this will automatically sub in a 0 since the field is marked as an Integer
     validates :temp_cards, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   end
 end

--- a/app/forms/waste_carriers_engine/cards_form.rb
+++ b/app/forms/waste_carriers_engine/cards_form.rb
@@ -9,7 +9,11 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.temp_cards = params[:temp_cards]
+      self.temp_cards = if params[:temp_cards].present?
+                          params[:temp_cards]
+                        else
+                          0
+                        end
       attributes = { temp_cards: temp_cards }
 
       super(attributes, params[:reg_identifier])

--- a/app/forms/waste_carriers_engine/cards_form.rb
+++ b/app/forms/waste_carriers_engine/cards_form.rb
@@ -17,7 +17,6 @@ module WasteCarriersEngine
 
     # Must be a positive integer or 0
     # Leaving it blank is also valid - this will automatically sub in a 0 since the field is marked as an Integer
-    validates :temp_cards, numericality: { only_integer: true, greater_than_or_equal_to: 0 },
-                           allow_blank: true
+    validates :temp_cards, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   end
 end

--- a/app/models/waste_carriers_engine/order.rb
+++ b/app/models/waste_carriers_engine/order.rb
@@ -38,7 +38,8 @@ module WasteCarriersEngine
 
       order[:order_items] = [OrderItem.new_renewal_item]
       order[:order_items] << OrderItem.new_type_change_item if transient_registration.registration_type_changed?
-      order[:order_items] << OrderItem.new_copy_cards_item(card_count) if card_count.positive?
+      # TODO: Review whether card_count.present? is still necessary - this was a fix put in to deal with WC-498
+      order[:order_items] << OrderItem.new_copy_cards_item(card_count) if card_count.present? && card_count.positive?
 
       order.generate_description
 

--- a/spec/forms/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cards_forms_spec.rb
@@ -42,8 +42,8 @@ module WasteCarriersEngine
             cards_form.temp_cards = ""
           end
 
-          it "is valid" do
-            expect(cards_form).to be_valid
+          it "is not valid" do
+            expect(cards_form).to_not be_valid
           end
         end
 

--- a/spec/forms/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cards_forms_spec.rb
@@ -25,6 +25,22 @@ module WasteCarriersEngine
           expect(cards_form.submit(invalid_params)).to eq(false)
         end
       end
+
+      context "when temp_cards is blank" do
+        let(:cards_form) { build(:cards_form, :has_required_data) }
+        let(:transient_registration) { TransientRegistration.where(reg_identifier: cards_form.reg_identifier).first }
+        let(:blank_params) do
+          {
+            reg_identifier: cards_form.reg_identifier,
+            temp_cards: ""
+          }
+        end
+
+        it "should change the value to zero" do
+          cards_form.submit(blank_params)
+          expect(transient_registration.reload.temp_cards).to eq(0)
+        end
+      end
     end
 
     context "when a valid transient registration exists" do

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -80,7 +80,22 @@ module WasteCarriersEngine
         end
       end
 
-      context "when there are no copy cards" do
+      context "when temp_cards is 0" do
+        before do
+          transient_registration.temp_cards = 0
+        end
+
+        it "should not include a copy cards item" do
+          matching_item = order[:order_items].find { |item| item[:type] == "COPY_CARDS" }
+          expect(matching_item).to be_nil
+        end
+      end
+
+      context "when temp_cards is not present" do
+        before do
+          transient_registration.temp_cards = nil
+        end
+
         it "should not include a copy cards item" do
           matching_item = order[:order_items].find { |item| item[:type] == "COPY_CARDS" }
           expect(matching_item).to be_nil


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-498

Our validation for the `temp_cards` field on the copy card form assumed that leaving it blank would sub in a zero, because the field is classed as an Integer in the database.

This is not the case - if the field already existed, the value is replaced with null, and if it doesn't exist then it's not created.

This means that when the order_items are created, checks against the value of the field fail and we get an error.