### PR TITLE
Duplicate house number in addresses

### DIFF
--- a/app/models/waste_carriers_engine/address.rb
+++ b/app/models/waste_carriers_engine/address.rb
@@ -73,16 +73,14 @@ module WasteCarriersEngine
     end
 
     def assign_address_lines(data)
-      lines = []
-      lines << data["organisationName"]
-      lines << data["subBuildingName"]
-      lines << data["buildingName"]
-      lines << [data["buildingNumber"], data["thoroughfareName"]].join(" ")
+      lines = data["lines"]
+      lines.insert(0, data["buildingNumber"])
+      lines.reject!(&:blank?)
+
       address_attributes = %i[address_line_1
                               address_line_2
                               address_line_3
                               address_line_4]
-      lines.reject!(&:empty?)
 
       # Assign lines one at a time until we run out of lines to assign
       write_attribute(address_attributes.shift, lines.shift) until lines.empty?

--- a/spec/models/waste_carriers_engine/address_spec.rb
+++ b/spec/models/waste_carriers_engine/address_spec.rb
@@ -8,30 +8,51 @@ module WasteCarriersEngine
       context "when it is given address data" do
         let(:data) do
           {
-            "organisationName" => "Foo Industries",
-            "subBuildingName" => "Suite 5",
-            "buildingName" => "The Bar Building",
+            "buildingName" => "Foo Buildings",
             "buildingNumber" => "5",
-            "thoroughfareName" => "Baz Street"
+            "dependentLocality" => "Baz Village",
+            "thoroughfareName" => "Bar Street",
+            "lines" => [
+              "FOO BUILDINGS",
+              "BAR STREET",
+              "BAZ VILLAGE"
+            ]
           }
         end
 
         it "should assign the correct address lines" do
           address.assign_address_lines(data)
-          expect(address[:address_line_1]).to eq("Foo Industries")
-          expect(address[:address_line_2]).to eq("Suite 5")
-          expect(address[:address_line_3]).to eq("The Bar Building")
-          expect(address[:address_line_4]).to eq("5 Baz Street")
+          expect(address[:address_line_1]).to eq("5")
+          expect(address[:address_line_2]).to eq("FOO BUILDINGS")
+          expect(address[:address_line_3]).to eq("BAR STREET")
+          expect(address[:address_line_4]).to eq("BAZ VILLAGE")
         end
 
-        context "when not all address fields are used" do
-          before { data["buildingName"] = "" }
+        context "when the buildingNumber is not used" do
+          before do
+            data.delete("buildingNumber")
+          end
 
           it "should skip blank fields when assigning lines" do
             address.assign_address_lines(data)
-            expect(address[:address_line_1]).to eq("Foo Industries")
-            expect(address[:address_line_2]).to eq("Suite 5")
-            expect(address[:address_line_3]).to eq("5 Baz Street")
+            expect(address[:address_line_1]).to eq("FOO BUILDINGS")
+            expect(address[:address_line_2]).to eq("BAR STREET")
+            expect(address[:address_line_3]).to eq("BAZ VILLAGE")
+            expect(address[:address_line_4].present?).to eq(false)
+          end
+        end
+
+        context "when the lines are not all used" do
+          before do
+            data["lines"] = ["FOO BUILDINGS", "BAR STREET"]
+          end
+
+          it "should skip blank fields when assigning lines" do
+            address.assign_address_lines(data)
+            expect(address[:address_line_1]).to eq("5")
+            expect(address[:address_line_2]).to eq("FOO BUILDINGS")
+            expect(address[:address_line_3]).to eq("BAR STREET")
+            expect(address[:address_line_4].present?).to eq(false)
           end
         end
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-500

Addresses created in the renewals journey can display as having a duplicate house number when they are used by waste-carriers-frontend, for example:

123
123 Waste Street
Wastetown
AB1 2CD

This is because the renewals engine assigns the values of address_lines in a different way. For consistency's sake, we should change this to match how waste-carriers-frontend does it.

---

🔥 WIP 🔥 