### PR TITLE
Rescue StandardErrors in request services

### DIFF
--- a/app/services/waste_carriers_engine/address_finder_service.rb
+++ b/app/services/waste_carriers_engine/address_finder_service.rb
@@ -27,13 +27,9 @@ module WasteCarriersEngine
       rescue RestClient::BadRequest
         Rails.logger.debug "OS Places: resource not found"
         :not_found
-      rescue RestClient::ExceptionWithResponse => e
+      rescue StandardError => e
         Airbrake.notify(e) if defined?(Airbrake)
-        Rails.logger.error "OS Places response error: " + e.to_s
-        :error
-      rescue SocketError => e
-        Airbrake.notify(e) if defined?(Airbrake)
-        Rails.logger.error "OS Places socket error: " + e.to_s
+        Rails.logger.error "OS Places error: " + e.to_s
         :error
       end
     end

--- a/app/services/waste_carriers_engine/companies_house_service.rb
+++ b/app/services/waste_carriers_engine/companies_house_service.rb
@@ -25,11 +25,7 @@ module WasteCarriersEngine
       rescue RestClient::ResourceNotFound
         Rails.logger.debug "Companies House: resource not found"
         :not_found
-      rescue RestClient::ExceptionWithResponse => e
-        Airbrake.notify(e) if defined?(Airbrake)
-        Rails.logger.error "Companies House error: " + e.to_s
-        :error
-      rescue SocketError => e
+      rescue StandardError => e
         Airbrake.notify(e) if defined?(Airbrake)
         Rails.logger.error "Companies House error: " + e.to_s
         :error

--- a/app/services/waste_carriers_engine/entity_matching_service.rb
+++ b/app/services/waste_carriers_engine/entity_matching_service.rb
@@ -34,17 +34,9 @@ module WasteCarriersEngine
           Rails.logger.error "Entity Matching JSON error: " + e.to_s
           unknown_result_data
         end
-      rescue RestClient::ExceptionWithResponse => e
+      rescue StandardError => e
         Airbrake.notify(e) if defined?(Airbrake)
         Rails.logger.error "Entity Matching response error: " + e.to_s
-        unknown_result_data
-      rescue Errno::ECONNREFUSED => e
-        Airbrake.notify(e) if defined?(Airbrake)
-        Rails.logger.error "Entity Matching connection error: " + e.to_s
-        unknown_result_data
-      rescue SocketError => e
-        Airbrake.notify(e) if defined?(Airbrake)
-        Rails.logger.error "Entity Matching socket error: " + e.to_s
         unknown_result_data
       end
     end

--- a/spec/services/waste_carriers_engine/address_finder_service_spec.rb
+++ b/spec/services/waste_carriers_engine/address_finder_service_spec.rb
@@ -42,7 +42,7 @@ module WasteCarriersEngine
       end
     end
 
-    context "when the request returns a socket error" do
+    context "when the request returns an error" do
       it "returns :error" do
         VCR.turned_off do
           host = Rails.configuration.os_places_service_url

--- a/spec/services/waste_carriers_engine/companies_house_service_spec.rb
+++ b/spec/services/waste_carriers_engine/companies_house_service_spec.rb
@@ -42,7 +42,7 @@ module WasteCarriersEngine
       end
     end
 
-    context "when the request returns a socket error" do
+    context "when the request returns an error" do
       it "returns :error" do
         VCR.turned_off do
           host = "https://api.companieshouse.gov.uk/"

--- a/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
+++ b/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
@@ -84,19 +84,7 @@ module WasteCarriersEngine
         end
       end
 
-      context "when the request returns a connection refused error" do
-        it "creates a new conviction_search_result" do
-          VCR.turned_off do
-            host = Rails.configuration.wcrs_services_url
-            stub_request(:any, /.*#{host}.*/).to_raise(Errno::ECONNREFUSED)
-
-            entity_matching_service.check_people_for_matches
-            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("UNKNOWN")
-          end
-        end
-      end
-
-      context "when the request returns a socket error" do
+      context "when the request returns an error" do
         it "creates a new conviction_search_result" do
           VCR.turned_off do
             host = Rails.configuration.wcrs_services_url


### PR DESCRIPTION
Previously our services which make requests were able to rescue specific errors. However, the way each `rescue` block dealt with the errors was generally the same, causing duplication. This also meant that any errors which weren't specified were not rescued and instead caused disruption to the user.

This PR replaces duplicated, error-specific `rescue` blocks with a `rescue StandardError => e` block, which reduces duplication and covers a much broader range of errors.