### PR TITLE
Escape URIs when sending conviction check requests

### DIFF
--- a/app/services/waste_carriers_engine/entity_matching_service.rb
+++ b/app/services/waste_carriers_engine/entity_matching_service.rb
@@ -25,7 +25,8 @@ module WasteCarriersEngine
       Rails.logger.debug "Sending request to Entity Matching service"
 
       begin
-        response = RestClient::Request.execute(method: :get, url: url)
+        response = RestClient::Request.execute(method: :get,
+                                               url: URI.encode(url))
 
         begin
           JSON.parse(response)

--- a/spec/cassettes/entity_matching_person_has_matches_unicode.yml
+++ b/spec/cassettes/entity_matching_person_has_matches_unicode.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8003/match/person?dateofbirth=01-01-1981&firstname=Jos%C3%A9&lastname=Blogs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:8003
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Oct 2018 18:08:08 GMT
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: '{"match_result":"NO","matching_system":null,"reference":null,"matched_name":null,"searched_at":1539713288704,"confirmed":"no","confirmed_at":null,"confirmed_by":null}'
+    http_version: 
+  recorded_at: Tue, 16 Oct 2018 18:08:10 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/entity_matching_person_unicode.yml
+++ b/spec/cassettes/entity_matching_person_unicode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Oct 2018 18:08:08 GMT
+      - Tue, 16 Oct 2018 18:12:55 GMT
       Content-Type:
       - application/json
       Vary:
@@ -30,7 +30,7 @@ http_interactions:
       - '166'
     body:
       encoding: UTF-8
-      string: '{"match_result":"NO","matching_system":null,"reference":null,"matched_name":null,"searched_at":1539713288704,"confirmed":"no","confirmed_at":null,"confirmed_by":null}'
+      string: '{"match_result":"NO","matching_system":null,"reference":null,"matched_name":null,"searched_at":1539713575766,"confirmed":"no","confirmed_at":null,"confirmed_by":null}'
     http_version: 
-  recorded_at: Tue, 16 Oct 2018 18:08:10 GMT
+  recorded_at: Tue, 16 Oct 2018 18:12:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
+++ b/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
@@ -67,7 +67,7 @@ module WasteCarriersEngine
         end
 
         it "escapes the unicode characters and creates a valid conviction_search_result for the person" do
-          VCR.use_cassette("entity_matching_person_has_matches_unicode") do
+          VCR.use_cassette("entity_matching_person_unicode") do
             entity_matching_service.check_people_for_matches
             expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("NO")
           end

--- a/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
+++ b/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
@@ -61,6 +61,19 @@ module WasteCarriersEngine
         end
       end
 
+      context "when a person's name contains unicode characters" do
+        before do
+          transient_registration.key_people.first.first_name = "José"
+        end
+
+        it "escapes the unicode characters and creates a valid conviction_search_result for the person" do
+          VCR.use_cassette("entity_matching_person_has_matches_unicode") do
+            entity_matching_service.check_people_for_matches
+            expect(transient_registration.reload.key_people.first.conviction_search_result.match_result).to eq("NO")
+          end
+        end
+      end
+
       context "when the response cannot be parsed as JSON" do
         before do
           allow_any_instance_of(RestClient::Request).to receive(:execute).and_return("foo")


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-510

If a user has a person or company with Unicode in the name, the EntityMatchingService attempted to include that Unicode character in the request, which then led to an InvalidURIError. Encoding the URL before we use it solves this problem.