### PR TITLE
Add ability to generate a CHANGELOG.md

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,19 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (2.0.0)
+      faraday (~> 0.8)
     ffi (1.9.25)
+    github_changelog_generator (1.14.3)
+      activesupport
+      faraday-http-cache
+      multi_json
+      octokit (~> 4.6)
+      rainbow (>= 2.1)
+      rake (>= 10.0)
+      retriable (~> 2.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govuk_elements_rails (3.1.3)
@@ -147,9 +159,12 @@ GEM
       origin (~> 2.3)
       tzinfo (>= 0.3.37)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     origin (2.3.1)
     orm_adapter (0.5.0)
     phonelib (0.6.26)
@@ -186,6 +201,7 @@ GEM
       activesupport (= 4.2.10)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -197,6 +213,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    retriable (2.1.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.0)
@@ -220,6 +237,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     secure_headers (5.0.5)
       useragent (>= 0.15.0)
     simplecov (0.16.1)
@@ -277,6 +297,7 @@ DEPENDENCIES
   devise (>= 4.4.3)
   dotenv-rails
   factory_bot_rails
+  github_changelog_generator
   govuk_elements_rails (~> 3.1)
   govuk_template (~> 0.23)
   jquery-rails
@@ -299,4 +320,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/lib/tasks/changelog.rake
+++ b/lib/tasks/changelog.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "github_changelog_generator/task"
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+end

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -46,4 +46,12 @@ Gem::Specification.new do |s|
 
   # Used to get a 2-character country code for Worldpay
   s.add_dependency "countries"
+
+  # Allows us to automatically generate the change log from the tags, issues,
+  # labels and pull requests on GitHub. Added as a dependency so all dev's have
+  # access to it to generate a log, and so they are using the same version.
+  # New dev's should first create GitHub personal app token and add it to their
+  # ~/.bash_profile (or equivalent)
+  # https://github.com/skywinder/github-changelog-generator#github-token
+  s.add_development_dependency "github_changelog_generator"
 end


### PR DESCRIPTION
Added the [github-changelog-generator](https://github.com/skywinder/github-changelog-generator) gem to the project so that once we have linked the project to a GitHub repo we can automatically generate and maintain a CHANGELOG.md file for the project.

github-changelog-generator generates the log based on the tags, issues, labels and pull requests it finds in GitHub for the repo.

To simplify its use we have also added a rake task you can call (`bundle exec rake changelog`) to update CHANGELOG.md.