### PR TITLE
Allow renewals that expire after submission to complete

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -42,7 +42,8 @@ module WasteCarriersEngine
         end
 
         event :renew do
-          transitions from: :ACTIVE,
+          transitions from: %i[ACTIVE
+                               EXPIRED],
                       to: :ACTIVE,
                       guard: %i[close_to_expiry_date?
                                 should_not_be_expired?],

--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -75,7 +75,16 @@ module WasteCarriersEngine
 
     # Guards
     def renewal_allowed?
+      return true if renewal_application_submitted?
+
       close_to_expiry_date? && should_not_be_expired?
+    end
+
+    def renewal_application_submitted?
+      transient_registration = TransientRegistration.where(reg_identifier: registration.reg_identifier).first
+      return false unless transient_registration.present?
+
+      transient_registration.workflow_state == "renewal_received_form"
     end
 
     def close_to_expiry_date?
@@ -89,7 +98,6 @@ module WasteCarriersEngine
       current_day = Time.now.in_time_zone("London").to_date
       current_day < expiry_day
     end
-
 
     # expires_on is stored as a Time in UTC and then converted to a Date.
     # If a user first registered near midnight around the transition between GMT and BST (or the other way round),

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -599,6 +599,24 @@ module WasteCarriersEngine
             expect(registration.metaData).to_not allow_event :renew
           end
 
+          context "when a transient registration exists" do
+            let(:transient_registration) { TransientRegistration.create(reg_identifier: registration.reg_identifier) }
+
+            it "cannot be renewed" do
+              expect(registration.metaData).to_not allow_event :renew
+            end
+
+            context "when the transient_registration is in a submitted state" do
+              before do
+                transient_registration.workflow_state = "renewal_received_form"
+              end
+
+              it "can be renewed" do
+                expect(registration.metaData).to allow_event :renew
+              end
+            end
+          end
+
           it "cannot be revoked" do
             expect(registration.metaData).to_not allow_event :revoke
           end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -589,7 +589,7 @@ module WasteCarriersEngine
         end
 
         context "when a registration is expired" do
-          let(:registration) { build(:registration, :is_expired, expires_on: 1.month.ago) }
+          let(:registration) { build(:registration, :has_required_data, :is_expired, expires_on: 1.month.ago) }
 
           it "has 'expired' status" do
             expect(registration.metaData).to have_state(:EXPIRED)
@@ -600,7 +600,13 @@ module WasteCarriersEngine
           end
 
           context "when a transient registration exists" do
-            let(:transient_registration) { TransientRegistration.create(reg_identifier: registration.reg_identifier) }
+            let(:transient_registration) { build(:transient_registration, :has_required_data) }
+
+            before do
+              # These checks require the registration to be persisted
+              registration.save!
+              transient_registration.update_attributes(reg_identifier: registration.reg_identifier)
+            end
 
             it "cannot be renewed" do
               expect(registration.metaData).to_not allow_event :renew
@@ -608,7 +614,7 @@ module WasteCarriersEngine
 
             context "when the transient_registration is in a submitted state" do
               before do
-                transient_registration.workflow_state = "renewal_received_form"
+                transient_registration.update_attributes(workflow_state: "renewal_received_form")
               end
 
               it "can be renewed" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-514

If a user submits a renewal request before the expiry date, but the renewal isn't confirmed until after the expiry date because of delayed payment or conviction checks, it should still be possible to complete the renewal.