### PR TITLE
Fix broken HighVoltage routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -421,6 +421,6 @@ WasteCarriersEngine::Engine.routes.draw do
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 
-  # Static pages with HighVoltage - don't include "/pages/" in the path
-  resources :pages, only: [:show], controller: "pages", path: ""
+  # Static pages with HighVoltage
+  resources :pages, only: [:show], controller: "pages"
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-516

We were trying to put HighVoltage pages at the root, but this resulted in them not being accessible when mounted in an application. Allowing them to sit at "/pages" as normal means they can be accessed from "/fo/pages" and "/bo/pages", which fixes the issue.