### PR TITLE
Update rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,12 @@
 AllCops:
   TargetRubyVersion: 2.4
-  # Cop names are not displayed in offense messages by default. We find it useful to include this information so we can
-  # use it to investigate what the fix may be.
+  # Cop names are not displayed in offense messages by default. We find it
+  # useful to include this information so we can use it to investigate what the
+  # fix may be.
   DisplayCopNames: true
-  # Style guide URLs are not displayed in offense messages by default. Again we find it useful to go straight to the
-  # documentation for a rule when investigating what the fix may be.
+  # Style guide URLs are not displayed in offense messages by default. Again we
+  # find it useful to go straight to the documentation for a rule when
+  # investigating what the fix may be.
   DisplayStyleGuide: true
   Include:
     - "**/*.gemspec"
@@ -12,95 +14,80 @@ AllCops:
     - "**/*.rb"
     - "**/Gemfile"
     - "**/Rakefile"
-    - "**/bin/*"
     - "**/config.ru"
   Exclude:
-    - "config/**/*"
-    - "script/**/*"
-    - !ruby/regexp /old_and_unused\.rb$/
-    # Bin contains standard files created when Rails is initialised and therefore they should be left as is
-    - "bin/**/*"
-    # Rakefile is generated when Rails is initialised and therefore should be left as is
-    - "Rakefile"
-    # spec_helper is generated when rspec is initialised and therefore should be left as is
-    - "spec/spec_helper.rb"
+    # config contains standard files created when Rails is initialised and
+    # therefore they should be left as is
+    - "**/config/**/*"
+    # bin contains standard files created when Rails is initialised and
+    # therefore they should be left as is
+    - "**/bin/*"
+    # locally when we run rubocop it ignores the vendor folder but when running
+    # in Travis-CI it seems to include. This will stop this from happening
+    - "**/vendor/**/*"
+    ## schema.rb is generated automatically based on migrations, so leave as is
     - "**/db/schema.rb"
-    - "**/db/migrate/*"
-    - .git-hooks/**/*
 
-# When using Ruby >= 2.3, Rubocop wants to add a comment to the top of *.rb
-# to aid migration to frozen literals in Ruby 3.0. We are not interested in
-# modifying every file at this point, so this cop is disabled for now.
-Style/FrozenStringLiteralComment:
+# It is our opinion that code is easier to read if a white space is
+# permitted between the initial declaration and the first statement. Ditto the
+# last statement and the closing tag.
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
-# TODO: Understand what the issue is and whether this needs to be more formally disabled (i.e. the dev team agree)
-# We don't understand this for now - seems to prevent perfectly reasonable meta-programming
-Lint/NestedMethodDefinition:
-  Enabled: false
-
-# We felt as a team that the default size of 15 was too low, and blocked what to us are sound methods which would not
-# add any value if broken up, for exampler composer type methods. Therefore we agreed to up the score to 20 to allow
-# for these types of methods
+# We felt as a team that the default size of 15 was too low, and blocked what to
+# us are sound methods which would not add any value if broken up, for example
+# composer type methods. Therefore we agreed to up the score to 30 to allow for
+# these types of methods
 Metrics/AbcSize:
-  Max: 40
-
-# We believe the default of 10 lines for a method length is too restrictive and often quickly hit just because we need
-# to specify the namesspace, class and method before then doing something with it.
-Metrics/MethodLength:
   Max: 30
-Metrics/ModuleLength:
-  Max: 400
-  Exclude:
-    - spec/**/*_spec.rb
 
-# We believe the default 80 characters is too restrictive and that lines can still be readable and maintainable
-# when no more than 120 characters. This also allows us to maximise our scree space.
+# We don't feel it makes sense to split specs and factories over multiple files,
+# or when in a context be forced to try and come up with slightly different ones
+# in order to reduce the block length. Hence we exclude specs and factories from
+# this rule.
+# Shared examples are the same as specs, but don't have the _spec.rb extension
+# hence they are listed separately
+Metrics/BlockLength:
+  Exclude:
+    - "**/spec/**/*_spec.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/spec/support/shared_examples/*.rb"
+
+# We believe the default 80 characters is too restrictive and that lines can
+# still be readable and maintainable when no more than 120 characters. This also
+# allows us to maximise our screen space.
 Metrics/LineLength:
   Max: 120
   Exclude:
-    - spec/factories/*.rb
-    - spec/features/*_spec.rb
-    - spec/routing/*_spec.rb
+    - "**/spec/**/*_spec.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/spec/support/shared_examples/*.rb"
 
-# Turn these off as can totally mess with the expect{...}.to syntax
-# Also reports on model validations using Proc.new { style blocks but trying to use do .. end raises invalid syntax
-Style/BlockDelimiters:
+# We wish we were good enough to remain within the rubocop limit of 10 lines
+# however we often just seem to tip over by a few lines. Hence we have chosen
+# to bump it to 20.
+Metrics/MethodLength:
+  Max: 20
+
+# Spec files can be quite long, so we shouldn't be forced to break them up
+# if it doesn't make sense.
+Metrics/ModuleLength:
   Exclude:
-    - spec/**/*_spec.rb
-
-# Rubymine disagrees and not sure how to fix Rubymine indentation right now
-Style/CaseIndentation:
-  Enabled: false
+    - "**/spec/**/*_spec.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/spec/support/shared_examples/*.rb"
 
 # As a web app, as long as the team commit to using well named classes for
 # controllers, models etc it should not be necessary to add top-level class
 # documentation.
 Style/Documentation:
   Enabled: false
-Style/EmptyLinesAroundBlockBody:
-    Enabled: false
-# Looks cluttered/ugly having your first method directly after the module/class declaration
-Style/EmptyLinesAroundModuleBody:
-  Enabled: false
-Style/EmptyLinesAroundClassBody:
-  Enabled: false
-
-# We've found the sprintf style for formatting strings can be useful when storing a formatted string as a template,
-# and passing in strings that can vary with context. Therefore we chose to disable this rule.
-Style/FormatString:
-  Enabled: false
-
-Style/MethodCalledOnDoEndBlock:
-  Exclude:
-    - spec/**/*_spec.rb
 
 # There are no relative performance improvements using '' over "", therefore we believe there is more
 # value in using "" for all strings irrespective of whether string interpolation is used
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-
-# Rubocop 0.42 introduced this cop - disabling for now until we have time to resolve
-# the issues it raises.
-Style/MethodMissing:
-  Enabled: false


### PR DESCRIPTION
The existing configuration for rubocop was taken from our [DST-Guides](https://github.com/DEFRA/dst-guides) repo, though unbeknownst to the dev that took them that version was already out of date.

Now its gotten to the stage that some linters are erroring when attempting to run rubocop checks whilst we work, which means dev's need to decide to either ignore the notifications or disable the linter; neither is a great decision.

So this updates the config to match the front and back office projects. It should be noted this does not resolve any violations. That is something we intend to resolve in the future.

With the update we can switch back on our linters and receive no more pesky error messages 😊