### PR TITLE
Improve dashboard search performance

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -30,6 +30,7 @@ module WasteCarriersEngine
              "addresses.postcode": /#{term}/i)
     }
     scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
+    scope :in_progress, -> { where(:workflow_state.nin => %w[renewal_complete_form renewal_received_form]) }
     scope :paid, -> { submitted.where("financeDetails.balance": 0) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -29,9 +29,7 @@ module WasteCarriersEngine
              { last_name: /#{term}/i },
              "addresses.postcode": /#{term}/i)
     }
-    scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
     scope :in_progress, -> { where(:workflow_state.nin => %w[renewal_complete_form renewal_received_form]) }
-    scope :paid, -> { submitted.where("financeDetails.balance": 0) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -32,6 +32,7 @@ module WasteCarriersEngine
              "addresses.postcode": /#{term}/i)
     }
     scope :in_progress, -> { where(:workflow_state.nin => %w[renewal_complete_form renewal_received_form]) }
+    scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -23,6 +23,12 @@ module WasteCarriersEngine
     field :temp_payment_method, type: String
     field :temp_tier_check, type: String # 'yes' or 'no' - should refactor to boolean
 
+    scope :reference, ->(reference) { where(reg_identifier: reference) }
+    scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
+    scope :paid, -> { submitted.where("financeDetails.balance": 0) }
+    scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
+    scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
+
     # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
     def registration_type_changed?
       # Don't compare registration types if the new one hasn't been set

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -23,7 +23,12 @@ module WasteCarriersEngine
     field :temp_payment_method, type: String
     field :temp_tier_check, type: String # 'yes' or 'no' - should refactor to boolean
 
-    scope :reference, ->(reference) { where(reg_identifier: reference) }
+    scope :search_term, ->(term) {
+      any_of({ reg_identifier: /\A#{term}\z/i },
+             { company_name: /#{term}/i },
+             { last_name: /#{term}/i },
+             "addresses.postcode": /#{term}/i)
+    }
     scope :submitted, -> { where(:workflow_state.in => %w[renewal_complete_form renewal_received_form]) }
     scope :paid, -> { submitted.where("financeDetails.balance": 0) }
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WasteCarriersEngine
   class TransientRegistration
     include Mongoid::Document
@@ -37,6 +39,7 @@ module WasteCarriersEngine
     def registration_type_changed?
       # Don't compare registration types if the new one hasn't been set
       return false unless registration_type
+
       original_registration_type = Registration.where(reg_identifier: reg_identifier).first.registration_type
       original_registration_type != registration_type
     end
@@ -51,6 +54,7 @@ module WasteCarriersEngine
 
     def projected_renewal_end_date
       return unless expires_on.present?
+
       expiry_date_after_renewal(expires_on.to_date)
     end
 
@@ -63,6 +67,7 @@ module WasteCarriersEngine
 
     def total_registration_card_charge
       return 0 unless temp_cards.present?
+
       temp_cards * Rails.configuration.card_charge
     end
 
@@ -73,6 +78,7 @@ module WasteCarriersEngine
     # Some business types should not have a company_no
     def company_no_required?
       return false if overseas?
+
       %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
     end
 
@@ -112,6 +118,7 @@ module WasteCarriersEngine
     def pending_manual_conviction_check?
       registration = Registration.where(reg_identifier: reg_identifier).first
       return false unless registration.metaData.may_renew?
+
       renewal_application_submitted? && conviction_check_required?
     end
 
@@ -152,6 +159,7 @@ module WasteCarriersEngine
     def remove_invalid_phone_numbers
       validator = PhoneNumberValidator.new(attributes: :phone_number)
       return if validator.validate_each(self, :phone_number, phone_number)
+
       self.phone_number = nil
     end
 
@@ -163,6 +171,7 @@ module WasteCarriersEngine
     # multiple renewals in progress at once
     def no_renewal_in_progress?
       return unless TransientRegistration.where(reg_identifier: reg_identifier).exists?
+
       errors.add(:reg_identifier, :renewal_in_progress)
     end
   end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -57,6 +57,10 @@ module WasteCarriersEngine
       end
     end
 
+    describe "scope" do
+      it_should_behave_like "TransientRegistration named scopes"
+    end
+
     describe "#reg_identifier" do
       context "when a TransientRegistration is created" do
         it "is not valid if the reg_identifier is in the wrong format" do

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "TransientRegistration named scopes" do
+  context "#search_term" do
+    it "returns everything when no search term is given" do
+      expect(WasteCarriersEngine::TransientRegistration.search_term(nil).length).to eq(WasteCarriersEngine::TransientRegistration.all.length)
+    end
+
+    it "returns only matching renewal when a reg. identifier is given" do
+      matching_renewal = create(:transient_registration, :has_required_data)
+      create(:transient_registration, :has_required_data)
+      results = WasteCarriersEngine::TransientRegistration.search_term(
+        matching_renewal.reg_identifier
+      )
+
+      expect(results).to include(matching_renewal)
+      expect(results.length).to eq(1)
+    end
+
+    it "returns all matching renewals when a general name is given" do
+      create(:transient_registration, :has_required_data, company_name: "Stan Lee Waste Company")
+      create(:transient_registration, :has_required_data, last_name: "Lee")
+      non_matching_renewal = create(:transient_registration, :has_required_data, company_name: "Excelsior Waste")
+      results = WasteCarriersEngine::TransientRegistration.search_term("lee")
+
+      expect(results).not_to include(non_matching_renewal)
+      expect(results.length).to eq(2)
+    end
+
+    it "returns all matching renewals when a postcode is given" do
+      ["SW1A 2AA", "BS1 5AH"].each do |postcode|
+        address = build(:address, postcode: postcode)
+        create(:transient_registration, :has_required_data, addresses: [address])
+      end
+
+      results = WasteCarriersEngine::TransientRegistration.search_term("SW1A 2AA")
+
+      expect(results.first.addresses[0].postcode).to eq("SW1A 2AA")
+      expect(results.length).to eq(1)
+    end
+  end
+
+  context "#in_progress" do
+    it "returns in progress renewals when they exist" do
+      in_progress_renewal = create(:transient_registration, :has_required_data)
+      expect(WasteCarriersEngine::TransientRegistration.in_progress).to include(in_progress_renewal)
+    end
+
+    it "does not return submitted renewals" do
+      submitted_renewal = create(
+        :transient_registration,
+        :has_required_data,
+        workflow_state: :renewal_complete_form
+      )
+      expect(WasteCarriersEngine::TransientRegistration.in_progress).not_to include(submitted_renewal)
+    end
+  end
+
+  context "#submitted" do
+    it "returns submitted renewals" do
+      submitted_renewal = create(
+        :transient_registration,
+        :has_required_data,
+        workflow_state: :renewal_complete_form
+      )
+      expect(WasteCarriersEngine::TransientRegistration.submitted).to include(submitted_renewal)
+    end
+
+    it "does not return in progress renewals" do
+      in_progress_renewal = create(:transient_registration, :has_required_data)
+      expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
+    end
+  end
+
+  context "#pending_payment" do
+    it "returns renewals pending payment" do
+      pending_payment_renewal = create(
+        :transient_registration,
+        :has_required_data,
+        :has_unpaid_balance,
+        workflow_state: :renewal_complete_form
+      )
+      expect(WasteCarriersEngine::TransientRegistration.pending_payment).to include(pending_payment_renewal)
+    end
+
+    it "does not return others" do
+      in_progress_renewal = create(:transient_registration, :has_required_data)
+      expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
+    end
+  end
+
+  context "#pending_approval" do
+    it "returns renewals pending conviction approval" do
+      pending_approval_renewal = create(
+        :transient_registration,
+        :has_required_data,
+        :requires_conviction_check,
+        workflow_state: :renewal_complete_form
+      )
+      expect(WasteCarriersEngine::TransientRegistration.pending_approval).to include(pending_approval_renewal)
+    end
+
+    it "does not return others" do
+      in_progress_renewal = create(:transient_registration, :has_required_data)
+      expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
+    end
+  end
+end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -85,7 +85,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
     it "does not return others" do
       in_progress_renewal = create(:transient_registration, :has_required_data)
-      expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
+      expect(WasteCarriersEngine::TransientRegistration.pending_payment).not_to include(in_progress_renewal)
     end
   end
 
@@ -102,7 +102,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
     it "does not return others" do
       in_progress_renewal = create(:transient_registration, :has_required_data)
-      expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
+      expect(WasteCarriersEngine::TransientRegistration.pending_approval).not_to include(in_progress_renewal)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-531

In production our users have reported that when attempting to apply a filter in the dashboard, it becomes unresponsive and eventually leads to a "service unavailable" page.

Initial investigation has shown that the problem is each time a user searches the app is pulling back all transient registrations and then iterating through them,  checking for the matching criteria.

One watching the logs this actually results in the ORM Mongoid querying for each transient registration. Hence its not putting a massive load on MongoDB, but it is now taking so long that the browsers is timing out leading to the service unavailable page.

This change is about improving the performance of the search in the dashboard, such that it no longer times out, and ideally is a scalable solution i.e. we want be back here again in another 6 months.
