### PR TITLE
Add scopes for different conviction check states

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -39,6 +39,7 @@ module WasteCarriersEngine
     scope :convictions_possible_match, -> { submitted.where("conviction_sign_offs.0.workflow_state": "possible_match") }
     scope :convictions_checks_in_progress, -> { submitted.where("conviction_sign_offs.0.workflow_state": "checks_in_progress") }
     scope :convictions_approved, -> { submitted.where("conviction_sign_offs.0.workflow_state": "approved") }
+    scope :convictions_rejected, -> { submitted.where("conviction_sign_offs.0.workflow_state": "rejected") }
 
     # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
     def registration_type_changed?

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -37,6 +37,7 @@ module WasteCarriersEngine
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 
     scope :convictions_possible_match, -> { submitted.where("conviction_sign_offs.0.workflow_state": "possible_match") }
+    scope :convictions_checks_in_progress, -> { submitted.where("conviction_sign_offs.0.workflow_state": "checks_in_progress") }
 
     # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
     def registration_type_changed?

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -36,6 +36,8 @@ module WasteCarriersEngine
     scope :pending_payment, -> { submitted.where(:"financeDetails.balance".gt => 0) }
     scope :pending_approval, -> { submitted.where("conviction_sign_offs.0.confirmed": "no") }
 
+    scope :convictions_possible_match, -> { submitted.where("conviction_sign_offs.0.workflow_state": "possible_match") }
+
     # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
     def registration_type_changed?
       # Don't compare registration types if the new one hasn't been set

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -38,6 +38,7 @@ module WasteCarriersEngine
 
     scope :convictions_possible_match, -> { submitted.where("conviction_sign_offs.0.workflow_state": "possible_match") }
     scope :convictions_checks_in_progress, -> { submitted.where("conviction_sign_offs.0.workflow_state": "checks_in_progress") }
+    scope :convictions_approved, -> { submitted.where("conviction_sign_offs.0.workflow_state": "approved") }
 
     # Check if the user has changed the registration type, as this incurs an additional 40GBP charge
     def registration_type_changed?

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -122,6 +122,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
     let(:convictions_checks_in_progress_renewal) do
       convictions_renewal.conviction_sign_offs.first.begin_checks!
+      convictions_renewal
     end
 
     describe "#convictions_possible_match" do
@@ -133,6 +134,18 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
       it "does not return others" do
         expect(scope).not_to include(convictions_checks_in_progress_renewal)
+      end
+    end
+
+    describe "#convictions_checks_in_progress" do
+      let(:scope) { WasteCarriersEngine::TransientRegistration.convictions_checks_in_progress }
+
+      it "returns renewals where a conviction_sign_off is in the checks_in_progress state" do
+        expect(scope).to include(convictions_checks_in_progress_renewal)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(convictions_possible_match_renewal)
       end
     end
   end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -105,4 +105,35 @@ RSpec.shared_examples "TransientRegistration named scopes" do
       expect(WasteCarriersEngine::TransientRegistration.pending_approval).not_to include(in_progress_renewal)
     end
   end
+
+  describe "conviction check scopes" do
+    let(:convictions_renewal) do
+      create(
+        :transient_registration,
+        :has_required_data,
+        :requires_conviction_check,
+        workflow_state: :renewal_received_form
+      )
+    end
+
+    let(:convictions_possible_match_renewal) do
+      convictions_renewal
+    end
+
+    let(:convictions_checks_in_progress_renewal) do
+      convictions_renewal.conviction_sign_offs.first.begin_checks!
+    end
+
+    describe "#convictions_possible_match" do
+      let(:scope) { WasteCarriersEngine::TransientRegistration.convictions_possible_match }
+
+      it "returns renewals where a conviction_sign_off is in the possible_match state" do
+        expect(scope).to include(convictions_possible_match_renewal)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(convictions_checks_in_progress_renewal)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -130,6 +130,11 @@ RSpec.shared_examples "TransientRegistration named scopes" do
       convictions_renewal
     end
 
+    let(:convictions_rejected_renewal) do
+      convictions_renewal.conviction_sign_offs.first.reject!
+      convictions_renewal
+    end
+
     describe "#convictions_possible_match" do
       let(:scope) { WasteCarriersEngine::TransientRegistration.convictions_possible_match }
 
@@ -159,6 +164,18 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
       it "returns renewals where a conviction_sign_off is in the approved state" do
         expect(scope).to include(convictions_approved_renewal)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(convictions_possible_match_renewal)
+      end
+    end
+
+    describe "#convictions_rejected" do
+      let(:scope) { WasteCarriersEngine::TransientRegistration.convictions_rejected }
+
+      it "returns renewals where a conviction_sign_off is in the rejected state" do
+        expect(scope).to include(convictions_rejected_renewal)
       end
 
       it "does not return others" do

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -125,6 +125,11 @@ RSpec.shared_examples "TransientRegistration named scopes" do
       convictions_renewal
     end
 
+    let(:convictions_approved_renewal) do
+      convictions_renewal.conviction_sign_offs.first.approve!(build(:user))
+      convictions_renewal
+    end
+
     describe "#convictions_possible_match" do
       let(:scope) { WasteCarriersEngine::TransientRegistration.convictions_possible_match }
 
@@ -142,6 +147,18 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
       it "returns renewals where a conviction_sign_off is in the checks_in_progress state" do
         expect(scope).to include(convictions_checks_in_progress_renewal)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(convictions_possible_match_renewal)
+      end
+    end
+
+    describe "#convictions_approved" do
+      let(:scope) { WasteCarriersEngine::TransientRegistration.convictions_approved }
+
+      it "returns renewals where a conviction_sign_off is in the approved state" do
+        expect(scope).to include(convictions_approved_renewal)
       end
 
       it "does not return others" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-483

Now that we have workflow_states for conviction_sign_offs, we can use these to filter transient_registrations. This PR creates new scopes for the various states a conviction_sign_off can be in.
