### PR TITLE
Refactor scope tests for consistency

### DIFF
--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -57,16 +57,25 @@ RSpec.shared_examples "TransientRegistration named scopes" do
       end
     end
 
-    it "returns all matching renewals when a postcode is given" do
-      ["SW1A 2AA", "BS1 5AH"].each do |postcode|
-        address = build(:address, postcode: postcode)
+    context "when a postcode search term is given" do
+      let(:matching_postcode_renewal) do
+        address = build(:address, postcode: "SW1A 2AA")
         create(:transient_registration, :has_required_data, addresses: [address])
       end
 
-      results = WasteCarriersEngine::TransientRegistration.search_term("SW1A 2AA")
+      let(:non_matching_postcode_renewal) do
+        address = build(:address, postcode: "BS1 5AH")
+        create(:transient_registration, :has_required_data, addresses: [address])
+      end
 
-      expect(results.first.addresses[0].postcode).to eq("SW1A 2AA")
-      expect(results.length).to eq(1)
+      it "returns all matching renewals when a postcode is given" do
+        results = WasteCarriersEngine::TransientRegistration.search_term(
+          matching_postcode_renewal.addresses.first.postcode
+        )
+
+        expect(results).to include(matching_postcode_renewal)
+        expect(results).not_to include(non_matching_postcode_renewal)
+      end
     end
   end
 

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -26,20 +26,23 @@ RSpec.shared_examples "TransientRegistration named scopes" do
   end
 
   describe "#search_term" do
+    let(:term) { nil }
+    let(:scope) { WasteCarriersEngine::TransientRegistration.search_term(term) }
+
     it "returns everything when no search term is given" do
-      expect(WasteCarriersEngine::TransientRegistration.search_term(nil).length).to eq(WasteCarriersEngine::TransientRegistration.all.length)
+      expect(scope.length).to eq(WasteCarriersEngine::TransientRegistration.all.length)
     end
 
-    it "returns only matching renewal when a reg. identifier is given" do
-      results = WasteCarriersEngine::TransientRegistration.search_term(
-        in_progress_renewal.reg_identifier
-      )
+    context "when the search term is a reg_identifier" do
+      let(:term) { in_progress_renewal.reg_identifier }
 
-      expect(results).to include(in_progress_renewal)
-      expect(results.length).to eq(1)
+      it "returns only the matching renewal" do
+        expect(scope).to include(in_progress_renewal)
+        expect(scope.length).to eq(1)
+      end
     end
 
-    context "when a search term is given" do
+    context "when the search term is a name" do
       let(:matching_company_name_renewal) do
         create(:transient_registration, :has_required_data, company_name: "Stan Lee Waste Company")
       end
@@ -48,12 +51,12 @@ RSpec.shared_examples "TransientRegistration named scopes" do
         create(:transient_registration, :has_required_data, last_name: "Lee")
       end
 
-      it "returns all matching renewals" do
-        results = WasteCarriersEngine::TransientRegistration.search_term("lee")
+      let(:term) { "Lee" }
 
-        expect(results).to include(matching_company_name_renewal)
-        expect(results).to include(matching_person_name_renewal)
-        expect(results).not_to include(in_progress_renewal)
+      it "returns all matching renewals" do
+        expect(scope).to include(matching_company_name_renewal)
+        expect(scope).to include(matching_person_name_renewal)
+        expect(scope).not_to include(in_progress_renewal)
       end
     end
 
@@ -68,13 +71,11 @@ RSpec.shared_examples "TransientRegistration named scopes" do
         create(:transient_registration, :has_required_data, addresses: [address])
       end
 
-      it "returns all matching renewals when a postcode is given" do
-        results = WasteCarriersEngine::TransientRegistration.search_term(
-          matching_postcode_renewal.addresses.first.postcode
-        )
+      let(:term) { matching_postcode_renewal.addresses.first.postcode }
 
-        expect(results).to include(matching_postcode_renewal)
-        expect(results).not_to include(non_matching_postcode_renewal)
+      it "returns all matching renewals when a postcode is given" do
+        expect(scope).to include(matching_postcode_renewal)
+        expect(scope).not_to include(non_matching_postcode_renewal)
       end
     end
   end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -31,13 +31,11 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
 
     it "returns only matching renewal when a reg. identifier is given" do
-      matching_renewal = create(:transient_registration, :has_required_data)
-      create(:transient_registration, :has_required_data)
       results = WasteCarriersEngine::TransientRegistration.search_term(
-        matching_renewal.reg_identifier
+        in_progress_renewal.reg_identifier
       )
 
-      expect(results).to include(matching_renewal)
+      expect(results).to include(in_progress_renewal)
       expect(results.length).to eq(1)
     end
 

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -36,9 +36,12 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     context "when the search term is a reg_identifier" do
       let(:term) { in_progress_renewal.reg_identifier }
 
-      it "returns only the matching renewal" do
+      it "returns renewals with a matching reg_identifier" do
         expect(scope).to include(in_progress_renewal)
-        expect(scope.length).to eq(1)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(submitted_renewal)
       end
     end
 
@@ -53,29 +56,33 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
       let(:term) { "Lee" }
 
-      it "returns all matching renewals" do
+      it "returns renewals with a matching company_name" do
         expect(scope).to include(matching_company_name_renewal)
+      end
+
+      it "returns renewals with a matching last_name" do
         expect(scope).to include(matching_person_name_renewal)
+      end
+
+      it "does not return others" do
         expect(scope).not_to include(in_progress_renewal)
       end
     end
 
-    context "when a postcode search term is given" do
+    context "when the search term is a postcode" do
       let(:matching_postcode_renewal) do
         address = build(:address, postcode: "SW1A 2AA")
         create(:transient_registration, :has_required_data, addresses: [address])
       end
 
-      let(:non_matching_postcode_renewal) do
-        address = build(:address, postcode: "BS1 5AH")
-        create(:transient_registration, :has_required_data, addresses: [address])
-      end
-
       let(:term) { matching_postcode_renewal.addresses.first.postcode }
 
-      it "returns all matching renewals when a postcode is given" do
+      it "returns renewals with a matching postcode" do
         expect(scope).to include(matching_postcode_renewal)
-        expect(scope).not_to include(non_matching_postcode_renewal)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(in_progress_renewal)
       end
     end
   end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -80,42 +80,50 @@ RSpec.shared_examples "TransientRegistration named scopes" do
   end
 
   describe "#in_progress" do
+    let(:scope) { WasteCarriersEngine::TransientRegistration.in_progress }
+
     it "returns in progress renewals when they exist" do
-      expect(WasteCarriersEngine::TransientRegistration.in_progress).to include(in_progress_renewal)
+      expect(scope).to include(in_progress_renewal)
     end
 
     it "does not return submitted renewals" do
-      expect(WasteCarriersEngine::TransientRegistration.in_progress).not_to include(submitted_renewal)
+      expect(scope).not_to include(submitted_renewal)
     end
   end
 
   describe "#submitted" do
+    let(:scope) { WasteCarriersEngine::TransientRegistration.submitted }
+
     it "returns submitted renewals" do
-      expect(WasteCarriersEngine::TransientRegistration.submitted).to include(submitted_renewal)
+      expect(scope).to include(submitted_renewal)
     end
 
     it "does not return in progress renewals" do
-      expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
+      expect(scope).not_to include(in_progress_renewal)
     end
   end
 
   describe "#pending_payment" do
+    let(:scope) { WasteCarriersEngine::TransientRegistration.pending_payment }
+
     it "returns renewals pending payment" do
-      expect(WasteCarriersEngine::TransientRegistration.pending_payment).to include(pending_payment_renewal)
+      expect(scope).to include(pending_payment_renewal)
     end
 
     it "does not return others" do
-      expect(WasteCarriersEngine::TransientRegistration.pending_payment).not_to include(in_progress_renewal)
+      expect(scope).not_to include(in_progress_renewal)
     end
   end
 
   describe "#pending_approval" do
+    let(:scope) { WasteCarriersEngine::TransientRegistration.pending_approval }
+
     it "returns renewals pending conviction approval" do
-      expect(WasteCarriersEngine::TransientRegistration.pending_approval).to include(pending_approval_renewal)
+      expect(scope).to include(pending_approval_renewal)
     end
 
     it "does not return others" do
-      expect(WasteCarriersEngine::TransientRegistration.pending_approval).not_to include(in_progress_renewal)
+      expect(scope).not_to include(in_progress_renewal)
     end
   end
 end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -1,6 +1,30 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "TransientRegistration named scopes" do
+  let(:in_progress_renewal) do
+    create(:transient_registration, :has_required_data)
+  end
+
+  let(:submitted_renewal) do
+    create(:transient_registration,
+           :has_required_data,
+           workflow_state: :renewal_received_form)
+  end
+
+  let(:pending_payment_renewal) do
+    create(:transient_registration,
+           :has_required_data,
+           :has_unpaid_balance,
+           workflow_state: :renewal_received_form)
+  end
+
+  let(:pending_approval_renewal) do
+    create(:transient_registration,
+           :has_required_data,
+           :requires_conviction_check,
+           workflow_state: :renewal_received_form)
+  end
+
   describe "#search_term" do
     it "returns everything when no search term is given" do
       expect(WasteCarriersEngine::TransientRegistration.search_term(nil).length).to eq(WasteCarriersEngine::TransientRegistration.all.length)
@@ -42,66 +66,40 @@ RSpec.shared_examples "TransientRegistration named scopes" do
 
   describe "#in_progress" do
     it "returns in progress renewals when they exist" do
-      in_progress_renewal = create(:transient_registration, :has_required_data)
       expect(WasteCarriersEngine::TransientRegistration.in_progress).to include(in_progress_renewal)
     end
 
     it "does not return submitted renewals" do
-      submitted_renewal = create(
-        :transient_registration,
-        :has_required_data,
-        workflow_state: :renewal_complete_form
-      )
       expect(WasteCarriersEngine::TransientRegistration.in_progress).not_to include(submitted_renewal)
     end
   end
 
   describe "#submitted" do
     it "returns submitted renewals" do
-      submitted_renewal = create(
-        :transient_registration,
-        :has_required_data,
-        workflow_state: :renewal_complete_form
-      )
       expect(WasteCarriersEngine::TransientRegistration.submitted).to include(submitted_renewal)
     end
 
     it "does not return in progress renewals" do
-      in_progress_renewal = create(:transient_registration, :has_required_data)
       expect(WasteCarriersEngine::TransientRegistration.submitted).not_to include(in_progress_renewal)
     end
   end
 
   describe "#pending_payment" do
     it "returns renewals pending payment" do
-      pending_payment_renewal = create(
-        :transient_registration,
-        :has_required_data,
-        :has_unpaid_balance,
-        workflow_state: :renewal_complete_form
-      )
       expect(WasteCarriersEngine::TransientRegistration.pending_payment).to include(pending_payment_renewal)
     end
 
     it "does not return others" do
-      in_progress_renewal = create(:transient_registration, :has_required_data)
       expect(WasteCarriersEngine::TransientRegistration.pending_payment).not_to include(in_progress_renewal)
     end
   end
 
   describe "#pending_approval" do
     it "returns renewals pending conviction approval" do
-      pending_approval_renewal = create(
-        :transient_registration,
-        :has_required_data,
-        :requires_conviction_check,
-        workflow_state: :renewal_complete_form
-      )
       expect(WasteCarriersEngine::TransientRegistration.pending_approval).to include(pending_approval_renewal)
     end
 
     it "does not return others" do
-      in_progress_renewal = create(:transient_registration, :has_required_data)
       expect(WasteCarriersEngine::TransientRegistration.pending_approval).not_to include(in_progress_renewal)
     end
   end

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "TransientRegistration named scopes" do
-  context "#search_term" do
+  describe "#search_term" do
     it "returns everything when no search term is given" do
       expect(WasteCarriersEngine::TransientRegistration.search_term(nil).length).to eq(WasteCarriersEngine::TransientRegistration.all.length)
     end
@@ -40,7 +40,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
   end
 
-  context "#in_progress" do
+  describe "#in_progress" do
     it "returns in progress renewals when they exist" do
       in_progress_renewal = create(:transient_registration, :has_required_data)
       expect(WasteCarriersEngine::TransientRegistration.in_progress).to include(in_progress_renewal)
@@ -56,7 +56,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
   end
 
-  context "#submitted" do
+  describe "#submitted" do
     it "returns submitted renewals" do
       submitted_renewal = create(
         :transient_registration,
@@ -72,7 +72,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
   end
 
-  context "#pending_payment" do
+  describe "#pending_payment" do
     it "returns renewals pending payment" do
       pending_payment_renewal = create(
         :transient_registration,
@@ -89,7 +89,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
   end
 
-  context "#pending_approval" do
+  describe "#pending_approval" do
     it "returns renewals pending conviction approval" do
       pending_approval_renewal = create(
         :transient_registration,

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -46,6 +46,8 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
 
     context "when the search term is a name" do
+      let(:term) { "Lee" }
+
       let(:matching_company_name_renewal) do
         create(:transient_registration, :has_required_data, company_name: "Stan Lee Waste Company")
       end
@@ -53,8 +55,6 @@ RSpec.shared_examples "TransientRegistration named scopes" do
       let(:matching_person_name_renewal) do
         create(:transient_registration, :has_required_data, last_name: "Lee")
       end
-
-      let(:term) { "Lee" }
 
       it "returns renewals with a matching company_name" do
         expect(scope).to include(matching_company_name_renewal)
@@ -70,12 +70,12 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
 
     context "when the search term is a postcode" do
+      let(:term) { "SW1A 2AA" }
+
       let(:matching_postcode_renewal) do
-        address = build(:address, postcode: "SW1A 2AA")
+        address = build(:address, postcode: term)
         create(:transient_registration, :has_required_data, addresses: [address])
       end
-
-      let(:term) { matching_postcode_renewal.addresses.first.postcode }
 
       it "returns renewals with a matching postcode" do
         expect(scope).to include(matching_postcode_renewal)

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -39,14 +39,22 @@ RSpec.shared_examples "TransientRegistration named scopes" do
       expect(results.length).to eq(1)
     end
 
-    it "returns all matching renewals when a general name is given" do
-      create(:transient_registration, :has_required_data, company_name: "Stan Lee Waste Company")
-      create(:transient_registration, :has_required_data, last_name: "Lee")
-      non_matching_renewal = create(:transient_registration, :has_required_data, company_name: "Excelsior Waste")
-      results = WasteCarriersEngine::TransientRegistration.search_term("lee")
+    context "when a search term is given" do
+      let(:matching_company_name_renewal) do
+        create(:transient_registration, :has_required_data, company_name: "Stan Lee Waste Company")
+      end
 
-      expect(results).not_to include(non_matching_renewal)
-      expect(results.length).to eq(2)
+      let(:matching_person_name_renewal) do
+        create(:transient_registration, :has_required_data, last_name: "Lee")
+      end
+
+      it "returns all matching renewals" do
+        results = WasteCarriersEngine::TransientRegistration.search_term("lee")
+
+        expect(results).to include(matching_company_name_renewal)
+        expect(results).to include(matching_person_name_renewal)
+        expect(results).not_to include(in_progress_renewal)
+      end
     end
 
     it "returns all matching renewals when a postcode is given" do


### PR DESCRIPTION
Update our specs for transient_registration scopes so we are testing them in a consistent way.

This came from a discussion on https://github.com/DEFRA/waste-carriers-renewals/pull/304#pullrequestreview-177890073