### PR TITLE
Resolve warning msg about overwiting field _id

### DIFF
--- a/app/models/waste_carriers_engine/counter.rb
+++ b/app/models/waste_carriers_engine/counter.rb
@@ -2,7 +2,6 @@ module WasteCarriersEngine
   class Counter
     include Mongoid::Document
 
-    field :_id, type: String
     field :seq, type: Integer
 
     def increment


### PR DESCRIPTION
Often when running tests or interacting with the waste carriers renewals project, and even when running tests in other projects you would get this error message

```
W, [2018-11-23T13:52:20.447269 #18255]  WARN -- : Overwriting existing field _id in class WasteCarriersEngine::Counter.
```

After some investigation spotted that in the model `Counter` we define the field `_id`. This is not something we do in others, and is the default field name MongoDb gives to documents to hold their unique ID's.

As such we shouldn't be defining it, and its removal also clears up the error message.