### PR TITLE
Remove details in version page we do not use

### DIFF
--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -3,10 +3,6 @@
 <div class="text">
   <h1 class="heading-large"><%= Rails.configuration.application_name %></h1>
   <p>
-    <label><%= t(".app_version") %></label>
-    <strong><%= Rails.configuration.application_version %></strong>
-  </p>
-  <p>
     <label><%= t(".commit") %></label>
     <strong>
       <%= link_to(current_git_commit,
@@ -14,10 +10,6 @@
                   target: "_blank",
                   class: "btn-link") %>
     </strong>
-  </p>
-  <p>
-    <label><%= t ('.engine_version') %></label>
-    <strong><%= WasteCarriersEngine::VERSION %></strong>
   </p>
   <p>
     <label><%= t(".render_time") %></label>

--- a/config/locales/pages/version/en.yml
+++ b/config/locales/pages/version/en.yml
@@ -1,7 +1,5 @@
 en:
   pages:
     version:
-      app_version: "Application version:"
-      engine_version: "Engine version:"
       commit: "Commit hash:"
       render_time: "Page rendered at:"


### PR DESCRIPTION
The original design for the version page, which gives us the delivery team information about the particular app thats running assumed we would be updating the app version each time we released.

By the time we shipped, our release process dumped this aspect and instead just focuses on generating tags. So all we need to know is the commit hash, because then we can cross check that against the tags we have to confirm what version of a thing we have deployed.

Hence this change removes the app and engine versions from the version page.