### PR TITLE
Block renewal rejection in initial conviction check state

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_conviction_workflow_status.rb
@@ -29,8 +29,7 @@ module WasteCarriersEngine
         end
 
         event :reject do
-          transitions from: %i[possible_match
-                               checks_in_progress],
+          transitions from: :checks_in_progress,
                       to: :rejected,
                       after: :revoke_parent
         end

--- a/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
+++ b/spec/models/waste_carriers_engine/conviction_sign_off_spec.rb
@@ -26,8 +26,8 @@ module WasteCarriersEngine
           expect(conviction_sign_off).to allow_event :approve
         end
 
-        it "can be rejected" do
-          expect(conviction_sign_off).to allow_event :reject
+        it "cannot be rejected" do
+          expect(conviction_sign_off).to_not allow_event :reject
         end
       end
 
@@ -99,6 +99,7 @@ module WasteCarriersEngine
 
       context "when the reject event happens" do
         before do
+          conviction_sign_off.workflow_state = "checks_in_progress"
           conviction_sign_off.reject
         end
 

--- a/spec/support/shared_examples/transient_registration_scope.rb
+++ b/spec/support/shared_examples/transient_registration_scope.rb
@@ -160,6 +160,7 @@ RSpec.shared_examples "TransientRegistration named scopes" do
     end
 
     let(:convictions_rejected_renewal) do
+      convictions_renewal.conviction_sign_offs.first.begin_checks!
       convictions_renewal.conviction_sign_offs.first.reject!
       convictions_renewal
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-483

When the conviction check is in its initial state, users should not be able to reject the renewal immediately, as anything with relevant convictions has to go through a more thorough process before rejection.

A few specs relied on immediately rejecting a conviction check, so these had to be updated.