### PR TITLE
Remove may_renew? from pending_manual_conviction_check?

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -122,9 +122,6 @@ module WasteCarriersEngine
     end
 
     def pending_manual_conviction_check?
-      registration = Registration.where(reg_identifier: reg_identifier).first
-      return false unless registration.metaData.may_renew?
-
       renewal_application_submitted? && conviction_check_required?
     end
 


### PR DESCRIPTION
A transient registration is pending a conviction check if

- its submitted
- the user declared a conviction, or the automated checker matched the organisation or an individual

Previously it was concerning itself with whether it could also be renewed. This is most likely due to the fact prior to the introduction of named mongoid scopes for searching, this would be used to filter out those that needed an approval to continue.

This change makes the decision that whether a registration can be renewed is irrelevant to the question are there outstanding conviction checks for this transient registration.

It also means one less hit on the db 😁