### PR TITLE
Remove redundant check in CanChangeRegistrationStatus

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_registration_status.rb
@@ -95,13 +95,6 @@ module WasteCarriersEngine
       check_service.in_renewal_window?
     end
 
-    def renewal_application_submitted?
-      transient_registration = matching_transient_registration
-      return false unless transient_registration.present?
-
-      transient_registration.workflow_state == "renewal_received_form"
-    end
-
     def renewal_declaration_confirmed?
       transient_registration = matching_transient_registration
       return false unless transient_registration.present?


### PR DESCRIPTION
A call to this check was removed in a previous PR, plus its duplicated by `TransientRegistration.renewal_application_submitted?`.

Removing it from the concern as part of general housekeeping.