### PR TITLE
Refactor transient registration unit tests

### DIFF
--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Can have registration attributes" do
+  describe "#conviction_check_approved?" do
+    context "when there are no conviction_sign_offs" do
+      before do
+        transient_registration.conviction_sign_offs = nil
+      end
+
+      it "returns false" do
+        expect(transient_registration.conviction_check_approved?).to eq(false)
+      end
+    end
+
+    context "when there is a conviction_sign_off" do
+      before do
+        transient_registration.conviction_sign_offs = [build(:conviction_sign_off)]
+      end
+
+      context "when confirmed is no" do
+        before do
+          transient_registration.conviction_sign_offs.first.confirmed = "no"
+        end
+
+        it "returns false" do
+          expect(transient_registration.conviction_check_approved?).to eq(false)
+        end
+      end
+
+      context "when confirmed is yes" do
+        before do
+          transient_registration.conviction_sign_offs.first.confirmed = "yes"
+        end
+
+        it "returns true" do
+          expect(transient_registration.conviction_check_approved?).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Started by following http://www.betterspecs.org/#describe and ensuring where we are describing an instance method we start the description with a #.

However then to make this task a little easier, decided to reorder the tests slightly so that shared examples come first, then anything related to attributes, followed by the instance methods.

So did that, and the # in descriptions, but then spotted we were testing a method that actually came from a concern and was not directly on the `TransientRegistration` class.

This should really be in a shared example to make it clearer its not directly tied to the transient registration class, so also made that tweak.