### PR TITLE
Move methods from TransientRegistration to concern

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -85,6 +85,10 @@ module WasteCarriersEngine
         addresses.where(address_type: "REGISTERED").first
       end
 
+      def charity?
+        business_type == "charity"
+      end
+
       def overseas?
         location == "overseas"
       end

--- a/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_carriers_engine/can_have_registration_attributes.rb
@@ -93,6 +93,13 @@ module WasteCarriersEngine
         location == "overseas"
       end
 
+      # Some business types should not have a company_no
+      def company_no_required?
+        return false if overseas?
+
+        %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
+      end
+
       def main_people
         return [] unless key_people.present?
 

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -77,17 +77,6 @@ module WasteCarriersEngine
       temp_cards * Rails.configuration.card_charge
     end
 
-    def charity?
-      business_type == "charity"
-    end
-
-    # Some business types should not have a company_no
-    def company_no_required?
-      return false if overseas?
-
-      %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
-    end
-
     def company_no_changed?
       return false unless company_no_required?
 

--- a/spec/support/shared_examples/can_have_registration_attributes.rb
+++ b/spec/support/shared_examples/can_have_registration_attributes.rb
@@ -1,6 +1,43 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "Can have registration attributes" do
+  describe "#charity?" do
+    let(:transient_registration) { build(:transient_registration) }
+
+    test_values = {
+      charity: true,
+      limitedCompany: false
+    }
+
+    test_values.each do |business_type, result|
+      context "when the 'business_type' is '#{business_type}'" do
+        it "returns #{result}" do
+          transient_registration.business_type = business_type.to_s
+          expect(transient_registration.charity?).to eq(result)
+        end
+      end
+    end
+  end
+
+  describe "#company_no_required?" do
+    let(:transient_registration) { build(:transient_registration) }
+
+    test_values = {
+      limitedCompany: true,
+      limitedLiabilityPartnership: true,
+      overseas: false
+    }
+
+    test_values.each do |business_type, result|
+      context "when the 'business_type' is '#{business_type}'" do
+        it "returns #{result}" do
+          transient_registration.business_type = business_type.to_s
+          expect(transient_registration.company_no_required?).to eq(result)
+        end
+      end
+    end
+  end
+
   describe "#conviction_check_approved?" do
     context "when there are no conviction_sign_offs" do
       before do


### PR DESCRIPTION
Whilst working with the `TransientRegistration` spotted that there are a couple of methods that could just as easily sit in the shared concern between it and `Registration`.

- `charity?()`
- `company_no_required?()`

So this change covers moving them over to the concern.