### PR TITLE
Add new revoked trait to trans reg factory

### DIFF
--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -84,5 +84,11 @@ FactoryBot.define do
         [build(:key_person, :has_matching_conviction, :main)]
       end
     end
+
+    trait :has_been_revoked do
+      # Create a new registration when initializing so we can copy its data
+      initialize_with { new(reg_identifier: create(:registration, :has_required_data,
+      metaData: build(:metaData, revoked_reason: "foo")).reg_identifier) }
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -44,15 +44,10 @@ module WasteCarriersEngine
       end
 
       context "when the source registration has a revoked_reason" do
-        let(:registration) do
-          create(:registration,
-                 :has_required_data,
-                 metaData: build(:metaData, revoked_reason: "foo"))
-        end
+        let(:revoked_transient_registration) { build(:transient_registration, :has_been_revoked) }
 
         it "does not import it" do
-          transient_registration = TransientRegistration.new(reg_identifier: registration.reg_identifier)
-          expect(transient_registration.metaData.revoked_reason).to eq(nil)
+          expect(revoked_transient_registration.metaData.revoked_reason).to eq(nil)
         end
       end
     end
@@ -245,10 +240,7 @@ module WasteCarriersEngine
           end
 
           context "when the registration is not active" do
-            let(:revoked_transient_registration) do
-              registration = create(:registration, :has_required_data, :is_revoked)
-              TransientRegistration.new(reg_identifier: registration.reg_identifier)
-            end
+            let(:revoked_transient_registration) { build(:transient_registration, :has_been_revoked) }
 
             it "returns false" do
               expect(revoked_transient_registration.pending_manual_conviction_check?).to eq(false)


### PR DESCRIPTION
Add a new revoked trait to the Transient Registration factory and then refactor existing tests in transient registration spec to use it.