### PR TITLE
Add missing relationship between metaData & trans reg

### DIFF
--- a/app/models/waste_carriers_engine/meta_data.rb
+++ b/app/models/waste_carriers_engine/meta_data.rb
@@ -3,8 +3,9 @@ module WasteCarriersEngine
     include Mongoid::Document
     include CanChangeRegistrationStatus
 
-    embedded_in :registration,      class_name: "WasteCarriersEngine::Registration"
-    embedded_in :past_registration, class_name: "WasteCarriersEngine::PastRegistration"
+    embedded_in :registration,           class_name: "WasteCarriersEngine::Registration"
+    embedded_in :past_registration,      class_name: "WasteCarriersEngine::PastRegistration"
+    embedded_in :transient_registration, class_name: "WasteCarriersEngine::TransientRegistration"
 
     field :route,                                 type: String
     field :dateRegistered, as: :date_registered,  type: DateTime


### PR DESCRIPTION
Taking the finance details for example, we define the relationship both in the `CanHaveRegistrationAttributes` concern and in `FinanceDetails` between `FinanceDetails` and `TransientRegistration`.

However we don't have this declaration on `MetaData` class for `TransientRegistration` even though we need it, so this change adds the missing declaration.

Obviously we have been fine up to now without it. However this is inconsistent with how we have done it elsewhere so we feel its important to make this change.