### PR TITLE
Add missing # frozen_string_literal: true to spec

### DIFF
--- a/spec/controllers/waste_carriers_engine/registrations_spec.rb
+++ b/spec/controllers/waste_carriers_engine/registrations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :address, class: WasteCarriersEngine::Address do
     trait :has_required_data do

--- a/spec/factories/conviction_search_result.rb
+++ b/spec/factories/conviction_search_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :conviction_search_result, class: WasteCarriersEngine::ConvictionSearchResult do
     trait :match_result_yes do

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :finance_details, class: WasteCarriersEngine::FinanceDetails do
     trait :has_required_data do
       balance { 10_000 }
-      orders {[]}
-      payments {[]}
+      orders { [] }
+      payments { [] }
     end
 
     trait :has_order do

--- a/spec/factories/forms/bank_transfer_form.rb
+++ b/spec/factories/forms/bank_transfer_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :bank_transfer_form, class: WasteCarriersEngine::BankTransferForm do
     trait :has_required_data do

--- a/spec/factories/forms/base_form.rb
+++ b/spec/factories/forms/base_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :base_form, class: WasteCarriersEngine::BaseForm do
     trait :has_required_data do

--- a/spec/factories/forms/business_type_form.rb
+++ b/spec/factories/forms/business_type_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :business_type_form, class: WasteCarriersEngine::BusinessTypeForm do
     trait :has_required_data do

--- a/spec/factories/forms/cannot_renew_company_no_change_form.rb
+++ b/spec/factories/forms/cannot_renew_company_no_change_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :cannot_renew_company_no_change_form, class: WasteCarriersEngine::CannotRenewCompanyNoChangeForm do
     trait :has_required_data do

--- a/spec/factories/forms/cannot_renew_lower_tier_form.rb
+++ b/spec/factories/forms/cannot_renew_lower_tier_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :cannot_renew_lower_tier_form, class: WasteCarriersEngine::CannotRenewLowerTierForm do
     trait :has_required_data do

--- a/spec/factories/forms/cannot_renew_type_change_form.rb
+++ b/spec/factories/forms/cannot_renew_type_change_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :cannot_renew_type_change_form, class: WasteCarriersEngine::CannotRenewTypeChangeForm do
     trait :has_required_data do

--- a/spec/factories/forms/cards_form.rb
+++ b/spec/factories/forms/cards_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :cards_form, class: WasteCarriersEngine::CardsForm do
     trait :has_required_data do

--- a/spec/factories/forms/cbd_type_form.rb
+++ b/spec/factories/forms/cbd_type_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :cbd_type_form, class: WasteCarriersEngine::CbdTypeForm do
     trait :has_required_data do

--- a/spec/factories/forms/check_your_answers_form.rb
+++ b/spec/factories/forms/check_your_answers_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :check_your_answers_form, class: WasteCarriersEngine::CheckYourAnswersForm do
     trait :has_required_data do

--- a/spec/factories/forms/company_address_form.rb
+++ b/spec/factories/forms/company_address_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :company_address_form, class: WasteCarriersEngine::CompanyAddressForm do
     trait :has_required_data do

--- a/spec/factories/forms/company_address_manual_form.rb
+++ b/spec/factories/forms/company_address_manual_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :company_address_manual_form, class: WasteCarriersEngine::CompanyAddressManualForm do
     trait :has_required_data do

--- a/spec/factories/forms/company_name_form.rb
+++ b/spec/factories/forms/company_name_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :company_name_form, class: WasteCarriersEngine::CompanyNameForm do
     trait :has_required_data do

--- a/spec/factories/forms/company_postcode_form.rb
+++ b/spec/factories/forms/company_postcode_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :company_postcode_form, class: WasteCarriersEngine::CompanyPostcodeForm do
     trait :has_required_data do

--- a/spec/factories/forms/construction_demolition_form.rb
+++ b/spec/factories/forms/construction_demolition_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :construction_demolition_form, class: WasteCarriersEngine::ConstructionDemolitionForm do
     trait :has_required_data do

--- a/spec/factories/forms/contact_address_form.rb
+++ b/spec/factories/forms/contact_address_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact_address_form, class: WasteCarriersEngine::ContactAddressForm do
     trait :has_required_data do

--- a/spec/factories/forms/contact_address_manual_form.rb
+++ b/spec/factories/forms/contact_address_manual_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact_address_manual_form, class: WasteCarriersEngine::ContactAddressManualForm do
     trait :has_required_data do

--- a/spec/factories/forms/contact_email_form.rb
+++ b/spec/factories/forms/contact_email_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact_email_form, class: WasteCarriersEngine::ContactEmailForm do
     trait :has_required_data do

--- a/spec/factories/forms/contact_name_form.rb
+++ b/spec/factories/forms/contact_name_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact_name_form, class: WasteCarriersEngine::ContactNameForm do
     trait :has_required_data do

--- a/spec/factories/forms/contact_phone_form.rb
+++ b/spec/factories/forms/contact_phone_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact_phone_form, class: WasteCarriersEngine::ContactPhoneForm do
     trait :has_required_data do

--- a/spec/factories/forms/contact_postcode_form.rb
+++ b/spec/factories/forms/contact_postcode_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact_postcode_form, class: WasteCarriersEngine::ContactPostcodeForm do
     trait :has_required_data do

--- a/spec/factories/forms/conviction_details_form.rb
+++ b/spec/factories/forms/conviction_details_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :conviction_details_form, class: WasteCarriersEngine::ConvictionDetailsForm do
     trait :has_required_data do

--- a/spec/factories/forms/declaration_form.rb
+++ b/spec/factories/forms/declaration_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :declaration_form, class: WasteCarriersEngine::DeclarationForm do
     trait :has_required_data do

--- a/spec/factories/forms/declare_convictions_form.rb
+++ b/spec/factories/forms/declare_convictions_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :declare_convictions_form, class: WasteCarriersEngine::DeclareConvictionsForm do
     trait :has_required_data do

--- a/spec/factories/forms/location_form.rb
+++ b/spec/factories/forms/location_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :location_form, class: WasteCarriersEngine::LocationForm do
     trait :has_required_data do

--- a/spec/factories/forms/main_people_form.rb
+++ b/spec/factories/forms/main_people_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :main_people_form, class: WasteCarriersEngine::MainPeopleForm do
     trait :has_required_data do

--- a/spec/factories/forms/other_businesses_form.rb
+++ b/spec/factories/forms/other_businesses_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :other_businesses_form, class: WasteCarriersEngine::OtherBusinessesForm do
     trait :has_required_data do

--- a/spec/factories/forms/payment_summary_form.rb
+++ b/spec/factories/forms/payment_summary_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :payment_summary_form, class: WasteCarriersEngine::PaymentSummaryForm do
     trait :has_required_data do

--- a/spec/factories/forms/register_in_northern_ireland_form.rb
+++ b/spec/factories/forms/register_in_northern_ireland_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :register_in_northern_ireland_form, class: WasteCarriersEngine::RegisterInNorthernIrelandForm do
     trait :has_required_data do

--- a/spec/factories/forms/register_in_scotland_form.rb
+++ b/spec/factories/forms/register_in_scotland_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :register_in_scotland_form, class: WasteCarriersEngine::RegisterInScotlandForm do
     trait :has_required_data do

--- a/spec/factories/forms/register_in_wales_form.rb
+++ b/spec/factories/forms/register_in_wales_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :register_in_wales_form, class: WasteCarriersEngine::RegisterInWalesForm do
     trait :has_required_data do

--- a/spec/factories/forms/registration_number_form.rb
+++ b/spec/factories/forms/registration_number_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :registration_number_form, class: WasteCarriersEngine::RegistrationNumberForm do
     trait :has_required_data do

--- a/spec/factories/forms/renewal_complete_form.rb
+++ b/spec/factories/forms/renewal_complete_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :renewal_complete_form, class: WasteCarriersEngine::RenewalCompleteForm do
     trait :has_required_data do

--- a/spec/factories/forms/renewal_information_form.rb
+++ b/spec/factories/forms/renewal_information_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :renewal_information_form, class: WasteCarriersEngine::RenewalInformationForm do
     trait :has_required_data do

--- a/spec/factories/forms/renewal_received_form.rb
+++ b/spec/factories/forms/renewal_received_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :renewal_received_form, class: WasteCarriersEngine::RenewalReceivedForm do
     trait :has_required_data do

--- a/spec/factories/forms/renewal_start_form.rb
+++ b/spec/factories/forms/renewal_start_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :renewal_start_form, class: WasteCarriersEngine::RenewalStartForm do
     trait :has_required_data do

--- a/spec/factories/forms/service_provided_form.rb
+++ b/spec/factories/forms/service_provided_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :service_provided_form, class: WasteCarriersEngine::ServiceProvidedForm do
     trait :has_required_data do

--- a/spec/factories/forms/tier_check_form.rb
+++ b/spec/factories/forms/tier_check_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :tier_check_form, class: WasteCarriersEngine::TierCheckForm do
     trait :has_required_data do

--- a/spec/factories/forms/waste_types_form.rb
+++ b/spec/factories/forms/waste_types_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :waste_types_form, class: WasteCarriersEngine::WasteTypesForm do
     trait :has_required_data do

--- a/spec/factories/forms/worldpay_form.rb
+++ b/spec/factories/forms/worldpay_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :worldpay_form, class: WasteCarriersEngine::WorldpayForm do
     trait :has_required_data do

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :key_person, class: WasteCarriersEngine::KeyPerson do
     trait :has_required_data do

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :location, class: WasteCarriersEngine::Location do
   end

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :metaData, class: WasteCarriersEngine::MetaData do
     trait :has_required_data do

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :order, class: WasteCarriersEngine::Order do
     trait :has_required_data do

--- a/spec/factories/order_item.rb
+++ b/spec/factories/order_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :order_item, class: WasteCarriersEngine::OrderItem do
   end

--- a/spec/factories/past_registration.rb
+++ b/spec/factories/past_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :past_registration, class: WasteCarriersEngine::PastRegistration do
   end

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :payment, class: WasteCarriersEngine::Payment do
     trait :worldpay do

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :registration, class: WasteCarriersEngine::Registration do
     trait :has_required_data do

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :transient_registration, class: WasteCarriersEngine::TransientRegistration do
     trait :has_required_data do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
     sequence :email do |n|

--- a/spec/forms/waste_carriers_engine/bank_transfer_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/bank_transfer_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/base_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/base_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/business_type_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/business_type_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/cannot_renew_company_no_change_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cannot_renew_company_no_change_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cards_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/cbd_type_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/cbd_type_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_address_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/company_address_manual_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_address_manual_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_name_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/company_postcode_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/company_postcode_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/construction_demolition_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/construction_demolition_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/contact_address_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_address_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/contact_address_manual_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_address_manual_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/contact_email_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_email_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/contact_name_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_name_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/contact_phone_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_phone_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/contact_postcode_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/contact_postcode_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/declaration_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/location_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/location_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/main_people_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/other_businesses_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/other_businesses_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/register_in_scotland_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/register_in_scotland_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/register_in_wales_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/register_in_wales_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/registration_number_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/registration_number_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/renewal_complete_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_complete_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/renewal_information_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_information_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/renewal_received_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_received_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/renewal_start_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/renewal_start_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/service_provided_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/service_provided_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/tier_check_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/tier_check_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/waste_types_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/waste_types_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/forms/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/forms/waste_carriers_engine/worldpay_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/helpers/waste_carriers_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/mailers/waste_carriers_engine/renewal_mailer_spec.rb
+++ b/spec/mailers/waste_carriers_engine/renewal_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/conviction_search_result.rb
+++ b/spec/models/waste_carriers_engine/conviction_search_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/finance_details_spec.rb
+++ b/spec/models/waste_carriers_engine/finance_details_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/key_person_spec.rb
+++ b/spec/models/waste_carriers_engine/key_person_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/order_item_spec.rb
+++ b/spec/models/waste_carriers_engine/order_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/order_spec.rb
+++ b/spec/models/waste_carriers_engine/order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/past_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/past_registration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/payment_spec.rb
+++ b/spec/models/waste_carriers_engine/payment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_bank_transfer_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_bank_transfer_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_business_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_business_type_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_cannot_renew_lower_tier_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_cannot_renew_lower_tier_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_cannot_renew_type_change_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_cannot_renew_type_change_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_cards_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_cards_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_cbd_type_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_cbd_type_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_check_your_answers_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_check_your_answers_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_address_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_address_manual_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_name_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_company_postcode_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_construction_demolition_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_construction_demolition_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_address_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_address_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_address_manual_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_address_manual_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_email_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_email_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_name_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_name_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_phone_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_phone_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_postcode_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_contact_postcode_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_conviction_details_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_conviction_details_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_declaration_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_declaration_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_declare_convictions_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_declare_convictions_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_location_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_location_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_main_people_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_main_people_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_other_businesses_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_other_businesses_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_payment_summary_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_payment_summary_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_register_in_northern_ireland_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_register_in_northern_ireland_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_register_in_scotland_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_register_in_scotland_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_register_in_wales_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_register_in_wales_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_registration_number_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_registration_number_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_complete_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_complete_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_information_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_information_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_received_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_received_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_start_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_renewal_start_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_service_provided_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_service_provided_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_tier_check_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_tier_check_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_waste_types_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_waste_types_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
+++ b/spec/models/waste_carriers_engine/workflow_states/transient_registration_worldpay_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
+++ b/spec/presenters/waste_carriers_engine/certificate_presenter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"

--- a/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/bank_transfer_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/business_type_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/cannot_renew_company_no_change_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_company_no_change_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_lower_tier_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cannot_renew_type_change_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/cards_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cards_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/cbd_type_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/check_your_answers_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/check_your_answers_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_address_manual_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_name_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/company_postcode_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/construction_demolition_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/contact_address_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_address_manual_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/contact_email_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_email_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_name_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_phone_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/contact_postcode_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/contact_postcode_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/conviction_details_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declaration_forms_spec.rb
@@ -1,3 +1,5 @@
+
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/declare_convictions_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/errors_spec.rb
+++ b/spec/requests/waste_carriers_engine/errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/location_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/location_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/main_people_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/other_businesses_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/payment_summary_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/register_in_northern_ireland_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/register_in_scotland_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/register_in_scotland_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/register_in_wales_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/register_in_wales_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/registration_number_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/registration_number_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/registrations_spec.rb
+++ b/spec/requests/waste_carriers_engine/registrations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_complete_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/renewal_information_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_information_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/renewal_received_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_received_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/renewal_start_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/renewal_start_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/service_provided_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/tier_check_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/tier_check_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/waste_types_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
+++ b/spec/requests/waste_carriers_engine/worldpay_forms_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/address_finder_service_spec.rb
+++ b/spec/services/waste_carriers_engine/address_finder_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/companies_house_service_spec.rb
+++ b/spec/services/waste_carriers_engine/companies_house_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/conviction_data_service_spec.rb
+++ b/spec/services/waste_carriers_engine/conviction_data_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
+++ b/spec/services/waste_carriers_engine/entity_matching_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/generate_pdf_spec.rb
+++ b/spec/services/waste_carriers_engine/generate_pdf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
+++ b/spec/services/waste_carriers_engine/renewal_completion_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/worldpay_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/worldpay_url_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_url_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_validator_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/services/waste_carriers_engine/worldpay_xml_service_spec.rb
+++ b/spec/services/waste_carriers_engine/worldpay_xml_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 module WasteCarriersEngine

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Test coverage report
 require "simplecov"
 SimpleCov.start

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end

--- a/spec/support/presenters.rb
+++ b/spec/support/presenters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
 
   # Adding this resolves getting the following error when you attemp to run the

--- a/spec/support/shared_examples/request_get_flexible_form.rb
+++ b/spec/support/shared_examples/request_get_flexible_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A 'flexible' form is a form that we don't mind users getting to via the back button.
 # Getting to this form too early by URL-hacking might cause problems for the user,
 # but we know that we will be validating the entire transient_registration later in the

--- a/spec/support/shared_examples/request_get_locked_in_form.rb
+++ b/spec/support/shared_examples/request_get_locked_in_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A 'locked-in' form is a form we definitely don't want users to access out-of-order,
 # for example, by clicking the back button or URL-hacking.
 # Users shouldn't be able to get into locked-in forms this way.

--- a/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
+++ b/spec/support/shared_examples/request_get_unsuccessful_worldpay_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples "GET unsuccessful Worldpay response" do |action|
   context "when a valid user is signed in" do
     let(:user) { create(:user) }

--- a/spec/support/shared_examples/request_post_form.rb
+++ b/spec/support/shared_examples/request_post_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # When a user submits a form, that form must match the expected workflow_state.
 # We don't adjust the state to match what the user is doing like we do for viewing forms.
 

--- a/spec/support/shared_examples/request_post_no_params_form.rb
+++ b/spec/support/shared_examples/request_post_no_params_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # When a user submits a form, that form must match the expected workflow_state.
 # We don't adjust the state to match what the user is doing like we do for viewing forms.
 

--- a/spec/support/shared_examples/validate_business_type.rb
+++ b/spec/support/shared_examples/validate_business_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the BusinessTypeValidator
 RSpec.shared_examples "validate business_type" do |form_factory|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_company_name.rb
+++ b/spec/support/shared_examples/validate_company_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the CompanyNameValidator
 RSpec.shared_examples "validate company_name" do |form_factory|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_company_no.rb
+++ b/spec/support/shared_examples/validate_company_no.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the CompanyNoValidator
 RSpec.shared_examples "validate company_no" do |form_factory|
   before do

--- a/spec/support/shared_examples/validate_email.rb
+++ b/spec/support/shared_examples/validate_email.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the EmailValidator
 RSpec.shared_examples "validate email" do |form_factory, field|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_location.rb
+++ b/spec/support/shared_examples/validate_location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the LocationValidator
 RSpec.shared_examples "validate location" do |form_factory|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_person_name.rb
+++ b/spec/support/shared_examples/validate_person_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the PersonNameValidator
 RSpec.shared_examples "validate person name" do |form_factory, field|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_phone_number.rb
+++ b/spec/support/shared_examples/validate_phone_number.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the PhoneNumberValidator
 RSpec.shared_examples "validate phone_number" do |form_factory|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_postcode.rb
+++ b/spec/support/shared_examples/validate_postcode.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the PostcodeValidator
 RSpec.shared_examples "validate postcode" do |form_factory, field|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_registration_type.rb
+++ b/spec/support/shared_examples/validate_registration_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the RegistrationTypeValidator
 RSpec.shared_examples "validate registration_type" do |form_factory|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/validate_yes_no.rb
+++ b/spec/support/shared_examples/validate_yes_no.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for fields using the YesNoValidator
 RSpec.shared_examples "validate yes no" do |form_factory, field|
   context "when a valid transient registration exists" do

--- a/spec/support/shared_examples/worldpay_service_valid_unsuccessful_action.rb
+++ b/spec/support/shared_examples/worldpay_service_valid_unsuccessful_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples "WorldpayService valid unsuccessful action" do |valid_action, status|
   let(:transient_registration) do
     create(:transient_registration,

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 VCR.configure do |c|
   c.cassette_library_dir = "spec/cassettes"
   c.hook_into :webmock


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-535

As one off task this change ensures all files within the spec folder have the missing `# frozen_string_literal: true` added.

This automatically means a large number of the files in this folder no longer fall foul of rubocop.