### PR TITLE
Add stuck? method to the transient registration

### DIFF
--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -141,6 +141,13 @@ module WasteCarriersEngine
       true
     end
 
+    def stuck?
+      return false unless renewal_application_submitted?
+      return false if pending_payment? || pending_manual_conviction_check?
+
+      true
+    end
+
     private
 
     def copy_data_from_registration

--- a/app/models/waste_carriers_engine/transient_registration.rb
+++ b/app/models/waste_carriers_engine/transient_registration.rb
@@ -143,6 +143,7 @@ module WasteCarriersEngine
 
     def stuck?
       return false unless renewal_application_submitted?
+      return true if conviction_sign_offs&.first&.rejected?
       return false if pending_payment? || pending_manual_conviction_check?
 
       true

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
       declared_convictions { "yes" }
     end
 
+    trait :is_submitted do
+      workflow_state { "renewal_received_form" }
+    end
+
     trait :has_finance_details do
       after(:build, :create) do |transient_registration|
         WasteCarriersEngine::FinanceDetails.new_finance_details(transient_registration, :worldpay, build(:user))
@@ -46,7 +50,7 @@ FactoryBot.define do
     end
 
     trait :requires_conviction_check do
-      workflow_state { "renewal_received_form" }
+      is_submitted
       key_people { [build(:key_person, :matched_conviction_search_result)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off)] }
@@ -111,7 +115,7 @@ FactoryBot.define do
     trait :is_ready_to_complete do
       has_required_data
       has_paid_order
-      workflow_state { "renewal_received_form" }
+      is_submitted
     end
   end
 end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -56,7 +56,13 @@ FactoryBot.define do
       conviction_sign_offs { [build(:conviction_sign_off)] }
     end
 
+    trait :has_rejected_conviction_sign_off do
+      declared_convictions
+      conviction_search_result { build(:conviction_sign_off, :rejected) }
+    end
+
     trait :has_unpaid_balance do
+      is_submitted
       finance_details { build(:finance_details, balance: 1000) }
     end
 

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -460,5 +460,41 @@ module WasteCarriersEngine
         end
       end
     end
+
+    describe "#stuck?" do
+      context "when the registration is not submitted" do
+        let(:transient_registration) { build(:transient_registration) }
+
+        it "returns false" do
+          expect(transient_registration.stuck?).to eq(false)
+        end
+      end
+
+      context "when the registration is submitted" do
+        context "and has an outstanding payment" do
+          let(:transient_registration) { build(:transient_registration, :has_unpaid_balance) }
+
+          it "returns false" do
+            expect(transient_registration.stuck?).to eq(false)
+          end
+        end
+
+        context "and has an outstanding conviction check" do
+          let(:transient_registration) { build(:transient_registration, :is_submitted, :requires_conviction_check) }
+
+          it "returns false" do
+            expect(transient_registration.stuck?).to eq(false)
+          end
+        end
+
+        context "and has no outstanding checks" do
+          let(:transient_registration) { build(:transient_registration, :is_submitted, :has_paid_balance) }
+
+          it "returns true" do
+            expect(transient_registration.stuck?).to eq(true)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/waste_carriers_engine/transient_registration_spec.rb
+++ b/spec/models/waste_carriers_engine/transient_registration_spec.rb
@@ -487,6 +487,14 @@ module WasteCarriersEngine
           end
         end
 
+        context "and has been refused" do
+          let(:transient_registration) { build(:transient_registration, :is_submitted, :has_rejected_conviction_sign_off) }
+
+          it "returns true" do
+            expect(transient_registration.stuck?).to eq(true)
+          end
+        end
+
         context "and has no outstanding checks" do
           let(:transient_registration) { build(:transient_registration, :is_submitted, :has_paid_balance) }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-533

As part of helping NCCC manage renewals that get stuck we are adding a new status to the dashboard in [Waste carriers back office PR 217](https://github.com/DEFRA/waste-carriers-back-office/pull/217).

To display the status we need to know if a transient registration is stuck. Initial designs rely on too much logic in the view, or falling back on helpers that would try and make the determination based on existing properties and methods.

So instead we are adding a method to the transient registration so we can simply ask it directly; are you stuck?
