### PR TITLE
Format postcode without modifying frozen strings

### DIFF
--- a/app/forms/waste_carriers_engine/company_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/company_postcode_form.rb
@@ -13,8 +13,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.temp_company_postcode = params[:temp_company_postcode]
-      format_postcode(temp_company_postcode)
+      self.temp_company_postcode = format_postcode(params[:temp_company_postcode])
       attributes = { temp_company_postcode: temp_company_postcode }
 
       # While we won't proceed if the postcode isn't valid, we should always save it in case it's needed for manual entry

--- a/app/forms/waste_carriers_engine/contact_postcode_form.rb
+++ b/app/forms/waste_carriers_engine/contact_postcode_form.rb
@@ -11,8 +11,7 @@ module WasteCarriersEngine
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.temp_contact_postcode = params[:temp_contact_postcode]
-      format_postcode(temp_contact_postcode)
+      self.temp_contact_postcode = format_postcode(params[:temp_contact_postcode])
       attributes = { temp_contact_postcode: temp_contact_postcode }
 
       # While we won't proceed if the postcode isn't valid, we should always save it in case it's needed for manual entry

--- a/app/forms/waste_carriers_engine/postcode_form.rb
+++ b/app/forms/waste_carriers_engine/postcode_form.rb
@@ -4,8 +4,8 @@ module WasteCarriersEngine
 
     def format_postcode(postcode)
       return unless postcode.present?
-      postcode.upcase!
-      postcode.strip!
+
+      postcode.upcase.strip
     end
   end
 end


### PR DESCRIPTION
In Ruby 3, all string literals are immutable. This isn't true in Ruby 2, but to prepare for an eventual upgrade, we are adding the comment # frozen_string_literal: true to the start of all our files. Rubocop enforces this.

However, while adding this comment, we discovered that the `strip!` and `upcase!` commands in PostcodeForm violate this, as they attempt to modify a frozen string.

This PR refactors our postcode forms to work with frozen strings.