### PR TITLE
Remove unnecessary whitespace stripping from manual addresses

### DIFF
--- a/app/forms/waste_carriers_engine/manual_address_form.rb
+++ b/app/forms/waste_carriers_engine/manual_address_form.rb
@@ -24,8 +24,6 @@ module WasteCarriersEngine
     end
 
     def submit(params)
-      # Strip out whitespace from start and end
-      params.each { |_key, value| value.strip! }
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.house_number = params[:house_number]
       self.address_line_1 = params[:address_line_1]


### PR DESCRIPTION
Manual address forms had an additional `strip!` in their submit method to remove whitespace, which caused an error once strings were frozen. However, the CanStripWhitespace concern is called after this in the base form, making this pointless.