### PR TITLE
Refactor tier decision for smart answers

### DIFF
--- a/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_carriers_engine/can_change_workflow_status.rb
@@ -489,10 +489,7 @@ module WasteCarriersEngine
     end
 
     def switch_to_lower_tier_based_on_smart_answers?
-      return true if other_businesses == "no" && construction_waste == "no"
-      return true if other_businesses == "yes" && is_main_service == "no" && construction_waste == "no"
-      return true if other_businesses == "yes" && is_main_service == "yes" && only_amf == "yes"
-      false
+      SmartAnswersCheckerService.new(self).lower_tier?
     end
 
     def require_new_registration_based_on_company_no?

--- a/app/services/waste_carriers_engine/smart_answers_checker_service.rb
+++ b/app/services/waste_carriers_engine/smart_answers_checker_service.rb
@@ -10,11 +10,25 @@ module WasteCarriersEngine
     end
 
     def lower_tier?
-      return true if @other_businesses == "no" && @construction_waste == "no"
-      return true if @other_businesses == "yes" && @is_main_service == "no" && @construction_waste == "no"
-      return true if @other_businesses == "yes" && @is_main_service == "yes" && @only_amf == "yes"
+      return true if no_other_businesses_and_no_construction_waste?
+      return true if other_businesses_but_not_main_service_or_construction_waste?
+      return true if other_businesses_and_main_service_but_only_amf?
 
       false
+    end
+
+    private
+
+    def no_other_businesses_and_no_construction_waste?
+      @other_businesses == "no" && @construction_waste == "no"
+    end
+
+    def other_businesses_but_not_main_service_or_construction_waste?
+      @other_businesses == "yes" && @is_main_service == "no" && @construction_waste == "no"
+    end
+
+    def other_businesses_and_main_service_but_only_amf?
+      @other_businesses == "yes" && @is_main_service == "yes" && @only_amf == "yes"
     end
   end
 end

--- a/app/services/waste_carriers_engine/smart_answers_checker_service.rb
+++ b/app/services/waste_carriers_engine/smart_answers_checker_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class SmartAnswersCheckerService
+    def initialize(transient_registration)
+      @construction_waste = transient_registration.construction_waste
+      @is_main_service = transient_registration.is_main_service
+      @only_amf = transient_registration.only_amf
+      @other_businesses = transient_registration.other_businesses
+    end
+
+    def lower_tier?
+      return true if @other_businesses == "no" && @construction_waste == "no"
+      return true if @other_businesses == "yes" && @is_main_service == "no" && @construction_waste == "no"
+      return true if @other_businesses == "yes" && @is_main_service == "yes" && @only_amf == "yes"
+
+      false
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/smart_answers_checker_service_spec.rb
+++ b/spec/services/waste_carriers_engine/smart_answers_checker_service_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe SmartAnswersCheckerService do
+    let(:transient_registration) { build(:transient_registration) }
+    let(:service) { SmartAnswersCheckerService.new(transient_registration) }
+
+    describe "#lower_tier?" do
+      context "when other_businesses is no" do
+        before { transient_registration.other_businesses = "no" }
+
+        context "when construction_waste is no" do
+          before { transient_registration.construction_waste = "no" }
+
+          it "returns true" do
+            expect(service.lower_tier?).to eq(true)
+          end
+        end
+
+        context "when construction_waste is yes" do
+          before { transient_registration.construction_waste = "yes" }
+
+          it "returns false" do
+            expect(service.lower_tier?).to eq(false)
+          end
+        end
+      end
+
+      context "when other_businesses is yes" do
+        before { transient_registration.other_businesses = "yes" }
+
+        context "when is_main_service is no" do
+          before { transient_registration.is_main_service = "no" }
+
+          context "when construction_waste is no" do
+            before { transient_registration.construction_waste = "no" }
+
+            it "returns true" do
+              expect(service.lower_tier?).to eq(true)
+            end
+          end
+
+          context "when construction_waste is yes" do
+            before { transient_registration.construction_waste = "yes" }
+
+            it "returns false" do
+              expect(service.lower_tier?).to eq(false)
+            end
+          end
+        end
+
+        context "when is_main_service is yes" do
+          before { transient_registration.is_main_service = "yes" }
+
+          context "when only_amf is no" do
+            before { transient_registration.only_amf = "no" }
+
+            it "returns false" do
+              expect(service.lower_tier?).to eq(false)
+            end
+          end
+
+          context "when only_amf is yes" do
+            before { transient_registration.only_amf = "yes" }
+
+            it "returns true" do
+              expect(service.lower_tier?).to eq(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change is part of our ongoing housekeeping to enable Rubocop as part of our CI.

Rubocop flagged that the complexity of the method we used to check if a registration should be upper or lower tier based on the smart answers was high. So this PR attempts to solve this issue and make the code more readable.