### PR TITLE
Get defra-ruby-style from Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,8 @@ gem "turbolinks"
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"
-  gem "defra_ruby_style",
-      git: "https://github.com/DEFRA/defra-ruby-style",
-      branch: "master"
+  # Apply our style guide to ensure consistency in how the code is written
+  gem "defra_ruby_style"
   gem "dotenv-rails"
   gem "rspec-rails", "~> 3.6"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/DEFRA/defra-ruby-style
-  revision: 53a29901cbade724ccf7112518db3ec93875aba6
-  branch: master
-  specs:
-    defra_ruby_style (0.0.1)
-      rubocop
-
 PATH
   remote: .
   specs:
@@ -88,6 +80,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
+    defra_ruby_style (0.0.2)
+      rubocop
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -317,7 +311,7 @@ DEPENDENCIES
   byebug
   cancancan (~> 1.10)
   database_cleaner
-  defra_ruby_style!
+  defra_ruby_style
   devise (>= 4.4.3)
   dotenv-rails
   factory_bot_rails


### PR DESCRIPTION
Now that this is available on Rubygems, we no longer need to specify the repo and branch.