### PR TITLE
Unlock Rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       mongoid (~> 5.2.0)
       nokogiri
       phonelib
-      rails (= 4.2.11)
+      rails (~> 4.2.11)
       rest-client (~> 2.0)
       turbolinks
       uk_postcode

--- a/waste_carriers_engine.gemspec
+++ b/waste_carriers_engine.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "4.2.11"
+  s.add_dependency "rails", "~> 4.2.11"
   # Use MongoDB as the database
   s.add_dependency "mongoid", "~> 5.2.0"
   # Use jquery as the JavaScript library


### PR DESCRIPTION
Previously our Gemfiles locked Rails to a specific version (4.2.11). This meant that Dependabot would not prompt us with upgrades. As there is now a critical security patch we'd like to apply, we've decided it's better to accept 4.2.11 and above (within the 4.2 range). This should allow Dependabot to submit PRs for patch-level changes to Rails.