### PR TITLE
Fix broken test and refactor expiry check service

### DIFF
--- a/app/services/waste_carriers_engine/expiry_check_service.rb
+++ b/app/services/waste_carriers_engine/expiry_check_service.rb
@@ -28,17 +28,13 @@ module WasteCarriersEngine
       # Registrations are expired on the date recorded for their expiry date e.g.
       # an expiry date of Mar 25 2018 means the registration was active up till
       # 24:00 on Mar 24 2018.
-      return false if @expiry_date.to_date > current_day
-
-      true
+      @expiry_date.to_date <= current_day
     end
 
     def in_renewal_window?
       # If the registration expires in more than x months from now, its outside
       # the renewal window
-      return true if @expiry_date.to_date < Rails.configuration.renewal_window.months.from_now
-
-      false
+      @expiry_date.to_date < Rails.configuration.renewal_window.months.from_now
     end
 
     # Its important to note that a registration is expired on its expires_on date.
@@ -77,15 +73,11 @@ module WasteCarriersEngine
     end
 
     def registered_in_daylight_savings?
-      return true if @registration_date.in_time_zone("London").dst?
-
-      false
+      @registration_date.in_time_zone("London").dst?
     end
 
     def expires_on_in_daylight_savings?
-      return true if @expires_on.in_time_zone("London").dst?
-
-      false
+      @expires_on.in_time_zone("London").dst?
     end
 
     # We store dates and times in UTC, but want to use the current date in the

--- a/spec/services/waste_carriers_engine/expiry_check_service_spec.rb
+++ b/spec/services/waste_carriers_engine/expiry_check_service_spec.rb
@@ -34,8 +34,8 @@ module WasteCarriersEngine
         let(:registration) { build(:registration, :has_required_data, :expires_later) }
         subject { ExpiryCheckService.new(registration) }
 
-        it ":expiry_date matches the registration's" do
-          expect(subject.expiry_date).to eq(registration.expires_on)
+        it ":expiry_date is within 1 hour of the registration's" do
+          expect(subject.expiry_date).to be_within(1.hour).of(registration.expires_on)
         end
 
         it ":registration_date matches the registration's" do


### PR DESCRIPTION
Dependabot raised [PR 397](https://github.com/DEFRA/waste-carriers-renewals/pull/397) to update phonelib. However a test failed that broke the build.

```
1) WasteCarriersEngine::ExpiryCheckService#attributes when initialized with an upper tier registration :expiry_date matches the registration's
     Failure/Error: expect(subject.expiry_date).to eq(registration.expires_on)
       expected: Sun, 28 Mar 2021 09:49:03.121213803 +0000
            got: Sun, 28 Mar 2021 08:49:03.121213803 +0000
       (compared using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Sun, 28 Mar 2021 09:49:03 +0000
       +Sun, 28 Mar 2021 08:49:03 +0000
     # ./spec/services/waste_carriers_engine/expiry_check_service_spec.rb:38:in `block (4 levels) in <module:WasteCarriersEngine>'
```

After some local testing we were able to confirm that the issue was pre-existing and not because of phonelib.

It turns out that today (March 28 2019) is GMT, but in 3 years March 28 2021 will be in DST. This means what `ExpiryCheckService` stores as the `expiry_date` attribute is a corrected version and as such will not equal what is against the registration.

The very fact we know the `ExpiryCheckService` service corrects the date means the test is invalid; there must be times when `expiry_date` does not match `my_registration.expires_on` else what is the point of `ExpiryCheckService.corrected_expires_on`!?

So the ideal solution is that test determines whether the `expiry_date` should be back an hour, forward an hour or the same but we believe that would make it unnecessarily complex. It is sufficient to say that `expiry_date` is expected to be within  1 hour of the registration `expires_on` value hence the change in the test.

Whilst we were looking at the code we also spotted some housekeeping improvements hence some refactoring changes in the `ExpiryCheckService` as well.