### PR TITLE
Remove reference from worldpay airbrake message

### DIFF
--- a/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
+++ b/app/controllers/waste_carriers_engine/worldpay_forms_controller.rb
@@ -110,7 +110,7 @@ module WasteCarriersEngine
                    else
                      "Invalid"
                    end
-      title = "#{valid_text} WorldPay response for #{params[:reg_identifier]}: #{action}"
+      title = "#{valid_text} WorldPay response: #{action}"
 
       log_worldpay_response(title)
       send_worldpay_response_to_airbrake(title) unless is_valid && action == :success


### PR DESCRIPTION
We intended to use Airbrake to track our worldpay responses so we could get a better understanding of why they sometimes fail.

When we first did this we included the registration reference in the message we were sending to Errbit not realising this would break Errbit's collation logic.

If Errbit receives the same error as previous, rather than create a new entry it instead records it against the initial record. In this way you can distinguish that your app has 'x' errors, and they have each occurred 'y' number of times.

By breaking the collation logic, it now appears we have hundreds of errors, each only occurring once.

This changes removes the reference from the message we send to fix this. We still get the reference number as its included in the params that get attached.