### PR TITLE
Fixes error handling redirect to internal error app

### DIFF
--- a/app/controllers/waste_carriers_engine/errors_controller.rb
+++ b/app/controllers/waste_carriers_engine/errors_controller.rb
@@ -5,14 +5,15 @@ module WasteCarriersEngine
     def show
       render(
         template: file_for(template),
-        locals: { message: exception.try(:message) }
+        locals: { message: exception.try(:message) },
+        status: (template_exists(error_code) ? error_code : "500")
       )
     end
 
     protected
 
     def error_code
-      @error_code ||= params[:id]
+      @error_code ||= params[:status]
     end
 
     def template_exists(name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -420,7 +420,10 @@ WasteCarriersEngine::Engine.routes.draw do
             end
 
   # See http://patrickperey.com/railscast-053-handling-exceptions/
-  get "errors/:id", to: "errors#show", as: "error"
+  get "(errors)/:status",
+      to: "errors#show",
+      constraints: { status: /\d{3}/ },
+      as: "error"
 
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"

--- a/spec/requests/waste_carriers_engine/errors_spec.rb
+++ b/spec/requests/waste_carriers_engine/errors_spec.rb
@@ -5,14 +5,34 @@ require "rails_helper"
 module WasteCarriersEngine
   RSpec.describe "Errors", type: :request do
     describe "#show" do
-      it "renders matching error template when one exists" do
-        get error_path("401")
-        expect(response).to render_template(:error_401)
+      %w[401 403 404 422].each do |code|
+        it "renders the error_#{code} template" do
+          get error_path(code)
+
+          expect(response).to render_template("error_#{code}")
+        end
+
+        it "responds with a status of #{code}" do
+          get error_path(code)
+
+          expect(response.code).to eq(code)
+        end
       end
 
-      it "renders generic error template when no matching error template exists" do
-        get error_path("unknown")
+      it "renders the generic error template when no matching error template exists" do
+        get error_path("601")
+
+        expect(response.code).to eq("500")
         expect(response).to render_template(:error_generic)
+      end
+
+      it "correctly redirects page not found errors to the correct internal view" do
+        rails_respond_without_detailed_exceptions do
+          get "/this-page-does-not-exist"
+
+          expect(response.code).to eq("404")
+          expect(response.body).to include(I18n.t("waste_carriers_engine.errors.error_404.clarification"))
+        end
       end
     end
   end

--- a/spec/support/error_response_helper.rb
+++ b/spec/support/error_response_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ErrorResponses
+  def rails_respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config["action_dispatch.show_exceptions"]
+    original_show_detailed_exceptions = env_config["action_dispatch.show_detailed_exceptions"]
+    env_config["action_dispatch.show_exceptions"] = true
+    env_config["action_dispatch.show_detailed_exceptions"] = false
+    yield
+  ensure
+    env_config["action_dispatch.show_exceptions"] = original_show_exceptions
+    env_config["action_dispatch.show_detailed_exceptions"] = original_show_detailed_exceptions
+  end
+end
+
+RSpec.configure do |config|
+  config.include ErrorResponses
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-317

Added test coverage on content of the view and correct redirect from real error in requests error spec.
Fixed the return of the correct status code on the error controller.
The mounted error app initializer was already present.
Added spec helper to activate the correct error configs for testing purposes.
As agreed with Andrew, rendering the views is the main part. Missing paths, restyling and re-wording of the messages in the view will be tackled separately.